### PR TITLE
fix(ssh): the sign-in dialog works under Android's keyboard

### DIFF
--- a/e2e/agent-device/README.md
+++ b/e2e/agent-device/README.md
@@ -126,3 +126,27 @@ need them again:
 observed=other/SSH`) while the selector itself matched exactly one element.
   Without the comments the steps resolve by selector, which is what the labels
   are for.
+
+## Android
+
+`ssh-demo.ad` is an iOS script: agent-device gates suite selection on the
+`context platform=…` line, `${VAR}` interpolation is not applied to it, and
+removing the line makes `--platform android` match nothing. So Android gets its
+own copy, `ssh-demo.android.ad`, which differs in exactly three places and is
+otherwise the same script:
+
+- the `context` line names `platform=android`, an emulator, and the AVD;
+- the `open` line passes `--platform android` and the Android Metro port;
+- the first `wait` is given 120 s, because a cold `--relaunch` on an emulator
+  spends most of a minute starting the app and pulling the bundle.
+
+Every other step -- the selectors, `Send Enter`, `id="ssh-composer-input"`,
+`type "hello"`, `Run command` and the destination guard -- runs unchanged on
+Android. When you edit one script, edit both: they are deliberately line-for-line
+the same so a diff shows only those three lines.
+
+Run it with the device name your AVD reports to `agent-device devices`:
+
+```sh
+agent-device test e2e/agent-device/ssh-demo.android.ad --platform android --device "<your avd>"
+```

--- a/e2e/agent-device/ssh-demo.android.ad
+++ b/e2e/agent-device/ssh-demo.android.ad
@@ -1,0 +1,22 @@
+context platform=android device="muqun_main_android" kind=emulator theme=unknown
+open "dev.osuki.muqun" --relaunch --platform android --metro-host 127.0.0.1 --metro-port 8102
+wait "text" "Try the demo" 120000
+press "role=\"button\" label=\"SSH\" || label=\"SSH\""
+wait "stable" 800 10000
+wait "role=button label=\"Open SSH host Demo shell\""
+press "role=\"button\" label=\"Open SSH host Demo shell\" || label=\"Open SSH host Demo shell\""
+wait "stable" 800 10000
+wait "role=button label=\"Disconnect from Demo shell\""
+wait "text" "Connected to demo@demo.invalid"
+press "role=\"button\" label=\"Send Enter\" || label=\"Send Enter\""
+wait "stable" 800 10000
+wait "role=button label=\"Disconnect from Demo shell\""
+press "id=\"ssh-composer-input\""
+wait "stable" 800 10000
+type "hello"
+press "role=\"button\" label=\"Run command\" || label=\"Run command\""
+wait "stable" 800 10000
+wait "role=button label=\"Disconnect from Demo shell\""
+press "role=\"button\" label=\"Go back\" || label=\"Go back\""
+wait "stable" 800 10000
+wait "role=button label=\"Open SSH host Demo shell\""

--- a/src/components/ssh-terminal-workspace.tsx
+++ b/src/components/ssh-terminal-workspace.tsx
@@ -1038,6 +1038,15 @@ function KeyboardInteractiveDialog({
 }) {
   const { t } = useLingui();
   const [answers, setAnswers] = useState<string[]>([]);
+  const [keyboardUp, setKeyboardUp] = useState(false);
+  useEffect(() => {
+    const shown = Keyboard.addListener('keyboardDidShow', () => setKeyboardUp(true));
+    const hidden = Keyboard.addListener('keyboardDidHide', () => setKeyboardUp(false));
+    return () => {
+      shown.remove();
+      hidden.remove();
+    };
+  }, []);
   const { challenge } = prompt;
   const name = sanitizeServerText(challenge.name, 80);
   const instruction = sanitizeServerText(challenge.instruction);
@@ -1045,10 +1054,24 @@ function KeyboardInteractiveDialog({
     label: sanitizeServerText(item.prompt, SERVER_LINE_LIMIT),
     echo: item.echo === true,
   }));
+  // Android draws this dialog behind the soft keyboard, so Continue can end up
+  // out of reach, and the system back gesture -- the obvious way to get the
+  // keyboard out of the way -- closes the dialog instead, which cancels the
+  // sign-in. Two answers: the keyboard's own return key submits, and a close
+  // request while the keyboard is up puts the keyboard away rather than
+  // abandoning the connection.
+  const submit = () => prompt.resolve(prompts.map((_item, index) => answers[index] ?? ''));
+
   return (
     <Dialog
       visible
-      onClose={() => prompt.resolve(undefined)}
+      onClose={() => {
+        if (keyboardUp) {
+          Keyboard.dismiss();
+          return;
+        }
+        prompt.resolve(undefined);
+      }}
       title={name || t`Sign in`}
       message={instruction || t`The server is asking for more before it lets you in.`}
       actionLayout="row"
@@ -1058,7 +1081,7 @@ function KeyboardInteractiveDialog({
           id: 'submit',
           label: t`Continue`,
           tone: 'primary',
-          onPress: () => prompt.resolve(prompts.map((_item, index) => answers[index] ?? '')),
+          onPress: submit,
         },
       ]}>
       <View style={styles.prompts}>
@@ -1079,6 +1102,8 @@ function KeyboardInteractiveDialog({
             autoCorrect={false}
             variant="outline"
             size="compact"
+            returnKeyType={index === prompts.length - 1 ? 'go' : 'next'}
+            onSubmitEditing={index === prompts.length - 1 ? submit : undefined}
           />
         ))}
       </View>


### PR DESCRIPTION
Two small things the Android verification of #2 turned up.

## The keyboard-interactive dialog was reachable only by luck on Android

Android draws the dialog behind the soft keyboard, so **Continue** ends up under it — and the system back gesture, which is what anyone would reach for to move the keyboard out of the way, closes the *dialog* instead, which cancels the sign-in (`session ended: early eof`). The verification hit exactly that.

- The last field's return key submits (`returnKeyType="go"`, `onSubmitEditing`), so the answer can be sent without touching a buried button. Earlier fields get `"next"`.
- A close request while the keyboard is up dismisses the keyboard and leaves the dialog standing. Only a close with the keyboard already down cancels.

iOS is unaffected either way: it lifts the dialog, and its return key now submits too, which is what a one-field password prompt should always have done.

## The demo e2e script now has an Android twin

`agent-device` gates suite selection on the `context platform=…` line, does not apply `${VAR}` interpolation to it, and matches nothing if the line is removed — so one `.ad` cannot serve both platforms. `ssh-demo.android.ad` differs from `ssh-demo.ad` in exactly three lines (the context gate, the `open` line's platform and Metro port, and a 120 s first wait for a cold emulator start); everything else — selectors, `Send Enter`, `id="ssh-composer-input"`, `type "hello"`, `Run command`, the destination guard — is identical and was confirmed to run unchanged on Android. The README says which three lines differ and that both files are edited together.

## Checks

```
npx tsc --noEmit     → clean
bun run lint         → 0 findings
bun run format:check → clean
bun test src         → 2514 pass, 0 fail
```

Not re-verified on a device: the dialog change is small and its two behaviours were observed failing on Android during #2's verification. Worth a look in the next Android pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)