### PR TITLE
test(terminal): give the heavy history invariant a budget of its own

### DIFF
--- a/src/terminal/__tests__/bun-test.d.ts
+++ b/src/terminal/__tests__/bun-test.d.ts
@@ -46,7 +46,12 @@ declare module 'bun:test' {
   }
 
   interface TestFn {
-    (name: string, fn: () => void | Promise<void>): void;
+    /**
+     * `timeoutMs` overrides bun's 5s default for one test. Declared because a
+     * couple of the invariant suites do seconds of real work and would
+     * otherwise fail on a machine that is merely busy.
+     */
+    (name: string, fn: () => void | Promise<void>, timeoutMs?: number): void;
     each: EachFn;
     skip(name: string, fn: () => void | Promise<void>): void;
     only(name: string, fn: () => void | Promise<void>): void;

--- a/src/terminal/__tests__/history-invariants.test.ts
+++ b/src/terminal/__tests__/history-invariants.test.ts
@@ -16,6 +16,16 @@ import { foldPaneRead, mergeTerminalWindow, sanitizePaneRead } from '../history'
 
 const MAXIMUM = 2_000;
 
+/**
+ * The budget for the one test here that does seconds of real work.
+ *
+ * Bun's default is 5s and that test lands a few hundred milliseconds under it,
+ * so a build sharing the machine tips it over and the suite reports the
+ * terminal contract as broken when nothing about it is. Well clear of the work,
+ * well short of a hang.
+ */
+const HEAVY_INVARIANT_TIMEOUT_MS = 30_000;
+
 function rows(output: string): string[] {
   return output ? output.split('\n') : [];
 }
@@ -377,23 +387,33 @@ describe('(d) identical adjacent blocks never accumulate', () => {
   // milliseconds. It blew bun's 5s default once, on a machine sharing the box
   // with a release build, which reads as the terminal contract failing when it
   // is only the laptop being busy -- hence the cheap assertion below.
-  test('no run of the simulated session ever accumulates one', () => {
-    for (const seed of [3, 13, 97, 2_026]) {
-      const random = randomizer(seed);
-      const pane = new Pane();
-      let window = '';
-      for (let poll = 0; poll < 150; poll += 1) {
-        pane.emit(Math.floor(random() * 90));
-        window = foldPaneRead(window, pane.screen(), 'frame', MAXIMUM);
-        // Asserted only when there is something to say. Six hundred passing
-        // deep-equality checks were most of this test's runtime, and the run
-        // that mattered -- the one where a repeat appears -- still reports the
-        // seed and the poll it appeared on.
-        const repeat = adjacentRepeat(rows(window));
-        if (repeat) expect({ seed, poll, repeat }).toEqual({ seed, poll, repeat: null as never });
+  //
+  // The cheap assertion was not enough: it still lands within a few hundred
+  // milliseconds of the 5s default, so any machine running a build alongside
+  // the suite fails it. A budget of its own is the honest fix. Thirty seconds
+  // is far above what the work costs even on a loaded laptop and far below a
+  // hang, so a failure here still means the fold is stuck rather than slow.
+  test(
+    'no run of the simulated session ever accumulates one',
+    () => {
+      for (const seed of [3, 13, 97, 2_026]) {
+        const random = randomizer(seed);
+        const pane = new Pane();
+        let window = '';
+        for (let poll = 0; poll < 150; poll += 1) {
+          pane.emit(Math.floor(random() * 90));
+          window = foldPaneRead(window, pane.screen(), 'frame', MAXIMUM);
+          // Asserted only when there is something to say. Six hundred passing
+          // deep-equality checks were most of this test's runtime, and the run
+          // that mattered -- the one where a repeat appears -- still reports the
+          // seed and the poll it appeared on.
+          const repeat = adjacentRepeat(rows(window));
+          if (repeat) expect({ seed, poll, repeat }).toEqual({ seed, poll, repeat: null as never });
+        }
       }
-    }
-  });
+    },
+    HEAVY_INVARIANT_TIMEOUT_MS
+  );
 
   test('a seam hidden under the composer is found, not appended over', () => {
     // Caught by `scripts/terminal-soak.ts` against a live pane, eleven folds


### PR DESCRIPTION
### What

`(d) identical adjacent blocks never accumulate > no run of the simulated session ever accumulates one` runs four seeds x 150 polls with an O(window^2) repeat scan after every poll. It lands a few hundred milliseconds under bun's 5s default, so a machine running a build alongside the suite fails it — and the failure reads as the terminal contract breaking when it is only the laptop being busy.

This is not hypothetical. It failed on **unmodified `main`** during today's work, while three builds shared the box:

```
(fail) (d) identical adjacent blocks never accumulate > no run of the simulated session ever accumulates one [5232.93ms]
  ^ this test timed out after 5000ms.
```

The test's own comment already recorded this happening once, and bought headroom by dropping six hundred passing deep-equality checks. That bought milliseconds where the problem needed seconds.

### The change

A 30s budget for that one test. Far above what the work costs even under load, far below a hang — so a failure here still means the fold is stuck rather than slow. Nothing about what the test asserts changes.

`src/terminal/__tests__/bun-test.d.ts` did not declare the optional timeout parameter, so it gains the third argument bun has always accepted at runtime. The reindentation in the test file is oxfmt's, from the call gaining that argument.

### Gates

```
npx tsc --noEmit      exit 0
bun run lint          exit 0, no findings
bun run format:check  All matched files use the correct format (406 files)
bun test src          2514 pass, 2 skip, 0 fail, 13581 expect() calls
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)