### PR TITLE
fix(ssh): the first tap on the shell composer opens the keyboard again

### DIFF
--- a/docs/deps-upgrade-2026-09.md
+++ b/docs/deps-upgrade-2026-09.md
@@ -531,9 +531,21 @@ only be used in web implementation.`); the list is ignored and the hook re-regis
   from this repo — a scan of every `useAnimatedStyle` / `useAnimatedReaction` / `useHandler` / `useDerivedValue` /
   `useAnimatedProps` / `useAnimatedScrollHandler` / `useFrameCallback` call in `src/` finds no dependency list
   left (the only two-argument call remaining is `useFrameCallback(cb, false)`, whose second argument is
-  `autostart`). Runtime attribution of the library warnings was attempted by patching the reanimated logger in
+  `autostart`). **That scan was wrong.** It was done by hand, and it missed
+  `useAnimatedStyle(..., [bottomInset])` in `src/components/ssh-terminal-workspace.tsx` — a file that arrived in
+  this same PR, from `feature/ssh-client`, after the terminal's own arrays had already been removed. It is gone
+  now, and `src/components/__tests__/reanimated-dependencies.test.ts` walks the TypeScript AST for the rule so
+  the next hand scan is not what stands behind it. Runtime attribution of the library warnings was attempted by patching the reanimated logger in
   `node_modules` to print a stack; Metro did not pick the patched module up even after `--clear`, so the
   attribution above rests on the source scan of the two libraries, which do forward a `deps` argument.
+- The warning is not only noise, which is why `src/app/_layout.tsx` now mutes it by its exact text. LogBox
+  answers a warning with a notification pinned across the bottom of the screen, and the bottom of the screen is
+  where a terminal dock is: on the SSH shell it covered `ssh-composer-input` outright, so the first tap on the
+  composer went to the notification and dismissed it and only the second reached the field — which is also what
+  failed `e2e/agent-device/ssh-demo.ad` at its `type "hello"` step. The gateway workspace escaped it by height
+  alone: its dock carries a pane strip and an actions row above the input, so only its send button sits in the
+  notification's band. Muting one library warning is a smaller thing than it looks — the app's own call sites
+  are covered by the AST test above, and every other warning still raises the notification.
 - The reactions the arrays were dropped from still fire: scrolling the demo terminal up shows scrollback and
   raises the "Latest" pill, pressing it returns to the tail and hides the pill, opening the composer keyboard
   (workspace and SSH demo shell) lifts the terminal by the keyboard offset, and a text-size change re-lays the

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -12,7 +12,7 @@ import {
 import * as NavigationBar from 'expo-navigation-bar';
 import * as SecureStore from 'expo-secure-store';
 import { useEffect, useMemo } from 'react';
-import { Platform } from 'react-native';
+import { LogBox, Platform } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
 
@@ -27,6 +27,29 @@ import { useThemePack } from '@/hooks/use-theme-pack';
 import { AppI18nProvider } from '@/i18n/provider';
 import { useGatewayPushRegistration, useNotificationObserver } from '@/lib/notifications';
 import { useAppSettings } from '@/stores/app-settings';
+
+/**
+ * One library warning, silenced, because LogBox answers it by covering the
+ * composer.
+ *
+ * reanimated 4.6 warns on native -- per render, `__DEV__` only -- whenever a
+ * dependency list is passed to one of its hooks, and it arrives several hundred
+ * times in a session. Every remaining source is a library:
+ * react-native-keyboard-controller's `useHandler` and its scroll views,
+ * gesture-handler's `ReanimatedSwipeable` and `ReanimatedDrawerLayout`. This
+ * app's own call sites have none left, and
+ * `src/components/__tests__/reanimated-dependencies.test.ts` is what keeps it
+ * that way, so nothing of ours is being hidden here.
+ *
+ * Silenced rather than tolerated because LogBox does not merely log it. The
+ * warning notification is pinned across the bottom of the screen, which is
+ * where a terminal dock is: on the SSH shell it landed exactly on
+ * `ssh-composer-input`, so the first tap on the field went to the notification
+ * and dismissed it and only the second reached the field. Ignored by its exact
+ * text and nothing else, so every other warning still raises the notification
+ * the way it always did.
+ */
+LogBox.ignoreLogs(['[Reanimated] dependencies should only be used in web implementation.']);
 
 SplashScreen.preventAutoHideAsync();
 

--- a/src/components/__tests__/reanimated-dependencies.test.ts
+++ b/src/components/__tests__/reanimated-dependencies.test.ts
@@ -1,0 +1,112 @@
+// The rule this file exists to keep: no reanimated hook in `src/` is handed a
+// dependency list.
+//
+// reanimated 4.6 ignores the list -- the hook re-registers from the closures of
+// its worklets plus their hashes, which is a superset of anything the list could
+// say -- and warns, on native, per render, that it did. That warning is not
+// quiet: it arrives several hundred times in a session, and LogBox answers it
+// with a notification pinned across the bottom of the screen. On the SSH shell
+// the notification lands exactly on `ssh-composer-input`, so the first tap on
+// the composer goes to the notification and dismisses it and only the second
+// reaches the field.
+//
+// `src/app/_layout.tsx` silences the warning by its exact text, because the
+// remaining sources are libraries (keyboard-controller, gesture-handler) and
+// there is nothing this repo can do about those until they release. That mute
+// is why this test is here: it would hide a call site of *ours* just as
+// happily, and a hand scan is what missed the one in
+// `ssh-terminal-workspace.tsx` when the arrays were removed from the terminal
+// during the September 2026 upgrade.
+//
+// The scan walks the real TypeScript AST rather than the text, so a dependency
+// list written in a comment or inside a string is not a finding and one written
+// across four lines is.
+/// <reference types="node" />
+import { describe, expect, test } from 'bun:test';
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import ts from 'typescript';
+
+const SRC = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/**
+ * The reanimated hooks whose last argument is a dependency list.
+ *
+ * `useFrameCallback` is deliberately absent: its second argument is
+ * `autostart`, a boolean, and it is the one two-argument reanimated call in the
+ * tree that is written correctly.
+ */
+const HOOKS_WITH_DEPENDENCIES = new Set([
+  'useAnimatedGestureHandler',
+  'useAnimatedKeyboardHandler',
+  'useAnimatedProps',
+  'useAnimatedReaction',
+  'useAnimatedScrollHandler',
+  'useAnimatedStyle',
+  'useDerivedValue',
+  'useHandler',
+]);
+
+interface Finding {
+  file: string;
+  line: number;
+  hook: string;
+}
+
+function sourceFiles(directory: string): string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === '__tests__') continue;
+      found.push(...sourceFiles(path));
+      continue;
+    }
+    if (entry.name.endsWith('.ts') || entry.name.endsWith('.tsx')) found.push(path);
+  }
+  return found;
+}
+
+function findDependencyLists(): { findings: Finding[]; fileCount: number } {
+  const files = sourceFiles(SRC);
+  const findings: Finding[] = [];
+  for (const file of files) {
+    const text = readFileSync(file, 'utf8');
+    // Cheap first pass: most of the tree never mentions one of these names, and
+    // parsing every file to learn that costs seconds.
+    if (![...HOOKS_WITH_DEPENDENCIES].some((hook) => text.includes(hook))) continue;
+    const source = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true);
+    const visit = (node: ts.Node) => {
+      if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
+        const hook = node.expression.text;
+        const last = node.arguments.at(-1);
+        if (HOOKS_WITH_DEPENDENCIES.has(hook) && last && ts.isArrayLiteralExpression(last)) {
+          findings.push({
+            file: relative(SRC, file),
+            line: source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1,
+            hook,
+          });
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(source);
+  }
+  return { findings, fileCount: files.length };
+}
+
+describe('no reanimated hook is passed a dependency list', () => {
+  const { findings, fileCount } = findDependencyLists();
+
+  test('the scan reaches the whole tree, or it is not proving anything', () => {
+    // A walk that silently stopped finding files would report zero findings and
+    // look like success. This is what tells the two apart.
+    expect(fileCount).toBeGreaterThan(150);
+  });
+
+  test('every call site re-registers from its closures instead', () => {
+    expect(findings.map(({ file, line, hook }) => `${file}:${line} ${hook}`)).toEqual([]);
+  });
+});

--- a/src/components/ssh-terminal-workspace.tsx
+++ b/src/components/ssh-terminal-workspace.tsx
@@ -251,10 +251,11 @@ export function SshTerminalWorkspace({ hostId }: { hostId: string }) {
   // safe-area inset, which the keyboard covers, so that much is not doubled.
   const { height: keyboardHeight } = useReanimatedKeyboardAnimation();
   const bottomInset = insets.bottom;
-  const keyboardSpacerStyle = useAnimatedStyle(
-    () => ({ height: Math.max(0, -keyboardHeight.value - bottomInset) }),
-    [bottomInset]
-  );
+  // No dependency list: reanimated 4.6 ignores one and warns per render that it
+  // did, and the inset is read straight out of the worklet's closure anyway.
+  const keyboardSpacerStyle = useAnimatedStyle(() => ({
+    height: Math.max(0, -keyboardHeight.value - bottomInset),
+  }));
 
   useEffect(
     () => () => {


### PR DESCRIPTION
## What was reported

On the SSH demo shell, the composer took two taps to focus: the first did
nothing, the second raised the keyboard. `bun agent-device test
e2e/agent-device/ssh-demo.ad` failed at step 15, `type "hello"`, with `expected
"hello", observed ""`. The gateway workspace's composer focused on the first
tap, which made it look like an SSH-side layout bug.

## What it actually was

Nothing is wrong with the composer.

reanimated 4.6 — new in #3 — warns on native, per render and `__DEV__` only,
whenever a dependency list is passed to one of its hooks. On this screen it
arrives **798 times** in a session, and LogBox answers a warning with a
notification pinned across the bottom of the screen. The bottom of the screen
is where a terminal dock is. The notification landed squarely on
`ssh-composer-input`:

The first tap dismissed the notification. Only the second reached the field.

Confirmed at the touch level rather than inferred — with `onTouchStart` /
`onFocus` logged on the field:

| | first tap | second tap |
|---|---|---|
| notification up | *no events at all* | `onTouchStart` → `onFocus` |
| notification dismissed first | `onTouchStart` → `onFocus` | — |

Same coordinate `(177, 815)` in every case, so it is not a stale hit frame or
an automation artifact. With `agent-device react-native dismiss-overlay` run
first, the first tap focuses, twice out of two.

The gateway workspace escaped it by height alone: its dock carries a pane strip
and an actions row above the input, so only its send button sits in the
notification's band.

**So this is dev-only.** Release builds have no LogBox and a user never saw
it. But a developer on a dev build lost the first tap too, and the e2e script
had no way past it, so it is worth stopping rather than working around.

## The change

- **`src/app/_layout.tsx`** mutes that one warning by its exact text. Every
  remaining source is a library — keyboard-controller's `useHandler` and its
  scroll views, gesture-handler's `ReanimatedSwipeable` and
  `ReanimatedDrawerLayout` — pending upstream releases. Every other warning
  still raises the notification.
- **`src/components/ssh-terminal-workspace.tsx`** still passed `[bottomInset]`
  to `useAnimatedStyle` — the last dependency list in `src/`. #3's own scan for
  these was done by hand and missed it, because the SSH files landed in that
  same PR *after* the terminal's arrays had been removed. Dropped; reanimated
  ignores the list anyway and reads the inset from the worklet's closure.
- **`src/components/__tests__/reanimated-dependencies.test.ts`** walks the
  TypeScript AST for the rule. This is the other half of the mute: it would
  hide a call site of ours just as happily, so a hand scan should not be what
  stands behind it. Checked against the regression — restoring `[bottomInset]`
  fails the test.
- **`docs/deps-upgrade-2026-09.md`** corrects the claim that no dependency list
  was left in `src/`, and records what LogBox does with the warning.

## Verification

Both platforms, demo shell, after the change: first tap focuses, `echo hello`
types and sends, the shell echoes it, and the dock still rides up with the
system keyboard while the terminal shrinks and re-lays out — the hook whose
dependency list was dropped is the one driving that spacer.

- iOS — iPhone 17 simulator (`muqun-composer`), dev build on Metro. No LogBox
  notification on launch. `ssh-demo.ad` **passes in 22.1s** (it failed at step
  15 before).
- Android — Pixel emulator, `assembleDebug`. Checked with the real soft
  keyboard (`--no-test-ime`), not just the headless test IME, so the dock lift
  is real.

Gates, on the rebased tree:

```
npx tsc --noEmit      exit 0, no output
bun run lint          oxlint --deny-warnings, no findings
bun run format:check  All matched files use the correct format. (407 files)
bun test src          2516 pass, 2 skip, 0 fail, across 92 files
```

`e2e/agent-device/ssh-demo.ad` is unchanged — the point of fixing the app side
rather than the script is that the script did not need fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
