### PR TITLE
test(gateway): cover the unpair fix as shipped, not as re-written

### DIFF
--- a/src/components/settings-servers.tsx
+++ b/src/components/settings-servers.tsx
@@ -24,6 +24,7 @@ import { feedback } from '@/lib/feedback';
 import { loadPairedDevices, revokePairedDevice, type PairedDevice } from '@/lib/gateway-client';
 import type { GatewayRecord } from '@/lib/gateway-storage';
 import { fadeIn, fadeOut, listLayout, timing } from '@/lib/motion';
+import { acceptsCancel, acceptsConfirm, unpairView } from '@/lib/unpair-action';
 import { useRenderTally } from '@/lib/render-tally';
 import { describeGatewayFailure } from '@/lib/network-error';
 import { normalizeGatewayUrl } from '@/lib/pairing';
@@ -592,6 +593,7 @@ function UnpairAction({ label, onUnpair }: { label: string; onUnpair: () => Prom
   const theme = useThemeTokens();
   const [armed, setArmed] = useState(false);
   const [pending, setPending] = useState(false);
+  const view = unpairView({ armed, pending });
 
   // Collapsing the row and coming back must not leave a primed destructive
   // button waiting.
@@ -602,7 +604,7 @@ function UnpairAction({ label, onUnpair }: { label: string; onUnpair: () => Prom
   // tap looks ignored -- the row sits there, unchanged, until the record
   // vanishes on its own. Say what is happening instead.
   async function confirm() {
-    if (pending) return;
+    if (!acceptsConfirm({ armed, pending })) return;
     setPending(true);
     try {
       await onUnpair();
@@ -611,41 +613,43 @@ function UnpairAction({ label, onUnpair }: { label: string; onUnpair: () => Prom
     }
   }
 
-  return armed ? (
+  return view.showArmedPair ? (
     <View style={styles.armedRow}>
       <PressableScale
         accessibilityRole="button"
-        accessibilityLabel={pending ? t`Unpairing ${label}` : t`Confirm unpair ${label}`}
-        accessibilityState={{ disabled: pending, busy: pending }}
-        disabled={pending}
+        accessibilityLabel={view.confirm.busy ? t`Unpairing ${label}` : t`Confirm unpair ${label}`}
+        accessibilityState={{ disabled: view.confirm.disabled, busy: view.confirm.busy }}
+        disabled={view.confirm.disabled}
         feedback="selection"
         onPress={() => void confirm()}
         style={[
           styles.action,
           styles.armedButton,
           { backgroundColor: theme.colors.danger },
-          pending && styles.pendingAction,
+          view.confirm.dimmed && styles.pendingAction,
         ]}>
-        {pending ? (
+        {view.confirm.icon === 'spinner' ? (
           <Spinner size="sm" color={theme.colors.onPrimary} />
         ) : (
           <Trash2 size={15} color={theme.colors.onPrimary} strokeWidth={2.2} />
         )}
         <Text variant="caption" color={theme.colors.onPrimary} style={styles.armedText}>
-          {pending ? <Trans>Unpairing…</Trans> : <Trans>Unpair</Trans>}
+          {view.confirm.phase === 'working' ? <Trans>Unpairing…</Trans> : <Trans>Unpair</Trans>}
         </Text>
       </PressableScale>
       <PressableScale
         accessibilityRole="button"
         accessibilityLabel={t`Keep ${label}`}
-        accessibilityState={{ disabled: pending }}
-        disabled={pending}
-        onPress={() => setArmed(false)}
+        accessibilityState={{ disabled: view.cancel.disabled }}
+        disabled={view.cancel.disabled}
+        onPress={() => {
+          if (acceptsCancel({ armed, pending })) setArmed(false);
+        }}
         style={[
           styles.action,
           styles.armedButton,
           { backgroundColor: theme.colors.surfaceRaised },
-          pending && styles.pendingAction,
+          view.cancel.dimmed && styles.pendingAction,
         ]}>
         <Text variant="caption" color={theme.colors.textMuted}>
           <Trans>Cancel</Trans>

--- a/src/i18n/__tests__/headless-locale.test.ts
+++ b/src/i18n/__tests__/headless-locale.test.ts
@@ -32,6 +32,13 @@ mockModule('expo-secure-store', () => ({
   setItemAsync: async (key: string, value: string) => {
     vault[key] = value;
   },
+  // `mock.module` is process-wide, so whichever of these fakes is registered
+  // when a module first imports `expo-secure-store` is the one it keeps. A fake
+  // missing a method another suite's code path calls therefore fails that suite
+  // and not this one; they all carry the full surface for that reason.
+  deleteItemAsync: async (key: string) => {
+    delete vault[key];
+  },
 }));
 
 /** What the OS says the user's languages are, most-wanted first. */

--- a/src/lib/__tests__/gateway-storage.test.ts
+++ b/src/lib/__tests__/gateway-storage.test.ts
@@ -4,43 +4,23 @@
 // gateway rather than dropping the record. Node's crypto stands in for the
 // phone's; a map stands in for the keychain.
 import * as bunTest from 'bun:test';
-import nodeCrypto from 'node:crypto';
+
+import { fakeQuickCrypto, fakeSecureStore, resetVault } from './gateway-vault';
 
 const { beforeEach, describe, expect, test } = bunTest;
 const { module: mockModule } = (
   bunTest as unknown as { mock: { module: (id: string, factory: () => unknown) => void } }
 ).mock;
 
-let vault: Record<string, string> = {};
-
-mockModule('expo-secure-store', () => ({
-  WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'whenUnlockedThisDeviceOnly',
-  getItemAsync: async (key: string) => vault[key] ?? null,
-  setItemAsync: async (key: string, value: string) => {
-    vault[key] = value;
-  },
-  deleteItemAsync: async (key: string) => {
-    delete vault[key];
-  },
-}));
-
-mockModule('react-native-quick-crypto', () => ({
-  default: {
-    Buffer,
-    randomBytes: (size: number) => nodeCrypto.randomBytes(size),
-    createCipheriv: nodeCrypto.createCipheriv,
-    createDecipheriv: nodeCrypto.createDecipheriv,
-  },
-}));
+// One shared fake, so the store test that also needs real record storage cannot
+// end up owning the vault this suite resets. See `gateway-vault.ts`.
+mockModule('expo-secure-store', () => fakeSecureStore);
+mockModule('react-native-quick-crypto', () => fakeQuickCrypto);
 
 const storage = await import('../gateway-storage');
 const { normalizeGatewaySshTunnel, saveGateway, loadGateways } = storage;
 
-function reset() {
-  vault = {};
-}
-
-beforeEach(reset);
+beforeEach(resetVault);
 
 const PAYLOAD = {
   kind: 'muqun-gateway' as const,

--- a/src/lib/__tests__/gateway-vault.ts
+++ b/src/lib/__tests__/gateway-vault.ts
@@ -1,0 +1,46 @@
+/**
+ * The phone's keychain and crypto, stood in for, once — and shared by every
+ * suite that needs the real `gateway-storage` underneath it.
+ *
+ * `mock.module` is process-wide: two suites that each register their own
+ * `expo-secure-store` do not get one apiece, they get whichever was registered
+ * last, and `gateway-storage` binds to whichever was in place the first time
+ * anything imported it. That ordering is invisible until it bites — the suite
+ * whose fake lost holds a `vault` nothing writes to any more, so its
+ * `beforeEach` quietly stops resetting anything and its tests start seeing each
+ * other's records.
+ *
+ * One vault, mutated rather than reassigned so every closure over it stays
+ * live, removes the question. Both suites reset the same object, and it no
+ * longer matters which of them bun happens to evaluate first.
+ */
+import nodeCrypto from 'node:crypto';
+
+/** The keychain's contents. Mutated in place; never reassigned. */
+export const vault: Record<string, string> = {};
+
+export function resetVault(): void {
+  for (const key of Object.keys(vault)) delete vault[key];
+}
+
+/** Enough of `expo-secure-store` for the record store's read-modify-writes. */
+export const fakeSecureStore = {
+  WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'whenUnlockedThisDeviceOnly',
+  getItemAsync: async (key: string) => vault[key] ?? null,
+  setItemAsync: async (key: string, value: string) => {
+    vault[key] = value;
+  },
+  deleteItemAsync: async (key: string) => {
+    delete vault[key];
+  },
+};
+
+/** Node's crypto standing in for the phone's, so the sealing is real AES-GCM. */
+export const fakeQuickCrypto = {
+  default: {
+    Buffer,
+    randomBytes: (size: number) => nodeCrypto.randomBytes(size),
+    createCipheriv: nodeCrypto.createCipheriv,
+    createDecipheriv: nodeCrypto.createDecipheriv,
+  },
+};

--- a/src/lib/__tests__/unpair-action.test.ts
+++ b/src/lib/__tests__/unpair-action.test.ts
@@ -1,0 +1,84 @@
+/**
+ * The half of "unpairing a gone gateway no longer looks ignored" that lives on
+ * screen rather than in the store.
+ *
+ * The store's side is a timing rule; this side is the promise the control makes
+ * while that rule runs. A reader who taps Confirm against a gateway that is no
+ * longer there waits seconds for an answer that never comes, and for that whole
+ * stretch the only thing telling them the tap landed is this control: a
+ * spinner where the trash icon was, a caption that says what is happening, and
+ * two buttons that have stopped taking taps.
+ *
+ * Each of those is a separate prop on a separate element, which is exactly why
+ * they are asserted together here -- the failure this guards is not "the
+ * spinner is missing", it is "the spinner is there and the Cancel beside it
+ * still works", which looks finished in a screenshot and is wrong.
+ */
+import { describe, expect, test } from 'bun:test';
+
+import { acceptsCancel, acceptsConfirm, unpairView } from '../unpair-action';
+
+const idle = { armed: false, pending: false };
+const armed = { armed: true, pending: false };
+const working = { armed: true, pending: true };
+
+describe('the unpair control before the second tap', () => {
+  test('an unarmed control shows no destructive pair at all', () => {
+    expect(unpairView(idle).showArmedPair).toBe(false);
+  });
+
+  test('an armed control offers a live Unpair and a live Cancel', () => {
+    const view = unpairView(armed);
+    expect(view.showArmedPair).toBe(true);
+    expect(view.confirm).toEqual({
+      disabled: false,
+      dimmed: false,
+      busy: false,
+      icon: 'trash',
+      phase: 'idle',
+    });
+    expect(view.cancel).toEqual({ disabled: false, dimmed: false });
+  });
+
+  test('a first tap on an unarmed control cannot start a removal', () => {
+    expect(acceptsConfirm(idle)).toBe(false);
+  });
+});
+
+describe('the unpair control while the gateway is being asked', () => {
+  test('the destructive button says what it is doing instead of sitting there', () => {
+    const { confirm } = unpairView(working);
+    expect(confirm.phase).toBe('working');
+    expect(confirm.icon).toBe('spinner');
+    // A screen reader must hear "busy", not merely "dimmed": the work is
+    // running, it has not been taken away.
+    expect(confirm.busy).toBe(true);
+  });
+
+  test('both buttons go inert together, not just the one that was tapped', () => {
+    const view = unpairView(working);
+    expect(view.confirm.disabled).toBe(true);
+    expect(view.cancel.disabled).toBe(true);
+    // Looking disabled is part of being disabled; a live-looking Cancel beside
+    // a spinner is the exact misread this pins.
+    expect(view.confirm.dimmed).toBe(true);
+    expect(view.cancel.dimmed).toBe(true);
+  });
+
+  test('a second confirm tap cannot queue another removal', () => {
+    expect(acceptsConfirm(working)).toBe(false);
+  });
+
+  test('Cancel cannot disarm a revoke that is already running', () => {
+    // The request is already in flight against the gateway; disarming here
+    // would only hide it, and the record would still go.
+    expect(acceptsCancel(working)).toBe(false);
+    expect(acceptsCancel(armed)).toBe(true);
+  });
+
+  test('the spinner and the trash icon are never both shown', () => {
+    for (const state of [idle, armed, working]) {
+      expect(['trash', 'spinner']).toContain(unpairView(state).confirm.icon);
+    }
+  });
+});

--- a/src/lib/unpair-action.ts
+++ b/src/lib/unpair-action.ts
@@ -1,0 +1,88 @@
+/**
+ * What the two-tap unpair control shows, and -- the reason this file exists --
+ * what it refuses to do while the gateway is still being asked.
+ *
+ * Unpairing is not a local delete. The record is forgotten only after the
+ * gateway has been asked to drop this device's token, and a gateway that is
+ * gone takes seconds to say nothing at all. For that whole stretch the control
+ * is mid-flight: it has to say so, and it has to stop accepting taps, because
+ * the removal behind it is not idempotent from the reader's side -- a second
+ * confirm would queue a second removal against a record that is already on its
+ * way out, and a Cancel would disarm a button whose work is already running and
+ * cannot be called back.
+ *
+ * Both of those are one-line mistakes to make in JSX and invisible in review:
+ * `disabled` on the destructive button and not on the one beside it reads as
+ * finished work. Stating the mapping once, here, is what lets a test hold it.
+ */
+
+/** The control's state: armed by the first tap, working after the second. */
+export type UnpairState = {
+  /** The first tap arms; until then there is only the single Unpair button. */
+  armed: boolean;
+  /** The second tap starts the revoke, which the caller awaits. */
+  pending: boolean;
+};
+
+/** How one of the two armed buttons should be rendered. */
+export type UnpairButton = {
+  /** Drives the `disabled` prop and `accessibilityState.disabled` together. */
+  disabled: boolean;
+  /** The 0.7 opacity that makes a disabled button look disabled. */
+  dimmed: boolean;
+};
+
+export type UnpairView = {
+  /** Whether the armed pair is mounted at all, rather than the single button. */
+  showArmedPair: boolean;
+  confirm: UnpairButton & {
+    /**
+     * `accessibilityState.busy`. A screen reader lands on this button while the
+     * revoke is in flight and must not be told the work is merely unavailable.
+     */
+    busy: boolean;
+    /** The spinner replaces the trash icon; they are never shown together. */
+    icon: 'trash' | 'spinner';
+    /**
+     * Which of the two labels the button carries. A token, not the text: the
+     * words themselves stay in the component, inside the macro that translates
+     * them.
+     */
+    phase: 'idle' | 'working';
+  };
+  cancel: UnpairButton;
+};
+
+/**
+ * Nothing in the armed pair is interactive while the revoke is in flight. Both
+ * buttons take the same `pending`, deliberately: the asymmetry -- a live Cancel
+ * beside a spinning Unpair -- is the bug this shape exists to make impossible.
+ */
+export function unpairView({ armed, pending }: UnpairState): UnpairView {
+  return {
+    showArmedPair: armed,
+    confirm: {
+      disabled: pending,
+      dimmed: pending,
+      busy: pending,
+      icon: pending ? 'spinner' : 'trash',
+      phase: pending ? 'working' : 'idle',
+    },
+    cancel: { disabled: pending, dimmed: pending },
+  };
+}
+
+/**
+ * Whether a confirm tap should start a removal. `disabled` already stops the
+ * pointer, but a queued gesture that lands in the same frame as the state
+ * change does not go through `disabled` at all, so the guard is stated in the
+ * handler too rather than trusted to the prop.
+ */
+export function acceptsConfirm({ armed, pending }: UnpairState): boolean {
+  return armed && !pending;
+}
+
+/** Cancel disarms, but never out from under a revoke that is already running. */
+export function acceptsCancel({ armed, pending }: UnpairState): boolean {
+  return armed && !pending;
+}

--- a/src/stores/__tests__/app-settings-theme.test.ts
+++ b/src/stores/__tests__/app-settings-theme.test.ts
@@ -20,6 +20,13 @@ mockModule('expo-secure-store', () => ({
   setItemAsync: async (key: string, value: string) => {
     vault[key] = value;
   },
+  // `mock.module` is process-wide, so whichever of these fakes is registered
+  // when a module first imports `expo-secure-store` is the one it keeps. A fake
+  // missing a method another suite's code path calls therefore fails that suite
+  // and not this one; they all carry the full surface for that reason.
+  deleteItemAsync: async (key: string) => {
+    delete vault[key];
+  },
 }));
 
 const { useAppSettings } = await import('../app-settings');

--- a/src/stores/__tests__/gateway-unpair.test.ts
+++ b/src/stores/__tests__/gateway-unpair.test.ts
@@ -6,56 +6,151 @@
  * behind that ask carry an 8 s budget each: sixteen seconds in which a reader
  * who tapped Unpair sees no change at all. These tests pin the two halves of
  * the fix — the wait is capped, and an unreachable gateway still loses the
- * record — around the timing rule itself rather than around the store's
- * native-dependent wiring.
+ * record.
+ *
+ * They drive `removeRecord` itself rather than a local copy of its race. That
+ * distinction is the whole point of this file: the forgiveness is decided by
+ * feeding the timeout the store invents to `describeGatewayFailure`, which
+ * classifies it by *matching its message text* — the sentence
+ * "Timed out waiting for the server." is forgiven only because it contains the
+ * words "timed out". Rewriting that sentence would silently turn an
+ * unreachable gateway back into an error toast and a record that will not go
+ * away, which is precisely the reported bug. A test that reimplements the race
+ * cannot see that coupling; this one breaks when it is cut.
+ *
+ * The native edges the store sits on — SecureStore behind the record storage,
+ * fetch behind the gateway client — are the only things stubbed. Everything
+ * being asserted is the shipped module.
  */
-import { describe, expect, test } from 'bun:test';
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
 
-const REVOKE_BUDGET_MS = 4_000;
+import type { GatewayRecord } from '@/lib/gateway-storage';
 
-/** The store's race, extracted so it can be exercised without native modules. */
-async function reviveOrForgive(revoke: () => Promise<void>, budgetMs = REVOKE_BUDGET_MS) {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    await Promise.race([
-      revoke(),
-      new Promise((_resolve, reject) => {
-        timer = setTimeout(() => reject(new Error('Timed out waiting for the server.')), budgetMs);
-      }),
-    ]);
-    return 'revoked' as const;
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    if (/timed out|network/i.test(message)) return 'forgiven' as const;
-    throw error;
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
+/** The two requests behind a revoke each carry this, hence the 16 s it fixes. */
+const OLD_WORST_CASE_MS = 16_000;
+
+const record: GatewayRecord = {
+  serverId: 'gone-1',
+  label: 'a gateway that is no longer there',
+  url: 'http://10.0.0.1:23947',
+  token: 'token',
+  pairedAt: 0,
+};
+
+/** What the fake gateway does when asked to drop this device's token. */
+let revoke: () => Promise<void> = async () => {};
+let revokedFor: string[] = [];
+/** Stands in for the SecureStore-backed record list. */
+let stored: GatewayRecord[] = [];
+
+const tag = (strings: TemplateStringsArray, ...values: unknown[]) =>
+  strings.reduce((out, part, i) => out + part + (i < values.length ? String(values[i]) : ''), '');
+
+mock.module('@lingui/core/macro', () => ({ t: tag, msg: tag, plural: tag }));
+mock.module('@/lib/demo-gateway', () => ({
+  demoRecord: { serverId: 'demo' },
+  DEMO_SERVER_ID: 'demo',
+}));
+mock.module('@/lib/gateway-client', () => ({
+  configureGateway: () => {},
+  setGatewayLabel: async () => {},
+  revokeOwnGatewayPairing: async (target: GatewayRecord) => {
+    revokedFor.push(target.serverId);
+    await revoke();
+  },
+}));
+mock.module('@/lib/gateway-storage', () => ({
+  clearGateway: async () => {},
+  loadGateway: async () => stored[0] ?? null,
+  loadGateways: async () => stored,
+  removeGateway: async (serverId: string) => {
+    stored = stored.filter((item) => item.serverId !== serverId);
+    return stored;
+  },
+  renameGateway: async () => stored,
+  selectGateway: async () => stored,
+  updateGateway: async () => stored,
+}));
+
+const { useGatewayConnectionStore } = await import('@/stores/gateway-connection');
+
+/** A revoke that behaves exactly like a machine that is no longer on the network. */
+const neverAnswers = () => new Promise<void>(() => {});
+
+beforeEach(() => {
+  revoke = async () => {};
+  revokedFor = [];
+  stored = [record];
+  useGatewayConnectionStore.setState({ record, records: [record], loading: false });
+});
+
+function remainingIds() {
+  return useGatewayConnectionStore.getState().records.map((item) => item.serverId);
 }
 
 describe('the revoke that precedes forgetting a gateway', () => {
-  test('a gateway that answers is revoked properly', async () => {
-    expect(await reviveOrForgive(async () => {})).toBe('revoked');
+  test('a gateway that answers is asked first, then forgotten', async () => {
+    await useGatewayConnectionStore.getState().removeRecord('gone-1');
+
+    expect(revokedFor).toEqual(['gone-1']);
+    expect(remainingIds()).toEqual([]);
   });
 
-  test('a gateway that never answers is given up on inside the budget', async () => {
-    const started = Date.now();
-    const verdict = await reviveOrForgive(() => new Promise<void>(() => {}), 40);
-    expect(verdict).toBe('forgiven');
-    // The point of the budget: the caller is released long before the two
-    // 8 s request timeouts behind the revoke would have elapsed.
-    expect(Date.now() - started).toBeLessThan(1_000);
+  test(
+    'a gateway that never answers is given up on and forgotten anyway',
+    async () => {
+      revoke = neverAnswers;
+      const started = Date.now();
+
+      await useGatewayConnectionStore.getState().removeRecord('gone-1');
+      const waited = Date.now() - started;
+
+      // The record is gone: an unreachable gateway must not be able to pin a
+      // dead pairing to the list forever.
+      expect(remainingIds()).toEqual([]);
+      // And the reader was released long before the two 8 s request budgets
+      // behind the revoke would have elapsed. This is the reported bug.
+      expect(waited).toBeLessThan(OLD_WORST_CASE_MS / 2);
+      // The wait is real, though — the gateway is asked, not skipped.
+      expect(revokedFor).toEqual(['gone-1']);
+    },
+    OLD_WORST_CASE_MS
+  );
+
+  test('a network failure is forgiven the same way an unreachable one is', async () => {
+    revoke = async () => {
+      throw new Error('Network request failed');
+    };
+
+    await useGatewayConnectionStore.getState().removeRecord('gone-1');
+
+    expect(remainingIds()).toEqual([]);
   });
 
   test('a gateway that is there and says no still blocks the removal', async () => {
-    await expect(
-      reviveOrForgive(async () => {
-        throw new Error('HTTP 401: bad token');
-      })
-    ).rejects.toThrow('401');
+    revoke = async () => {
+      throw new Error('HTTP 401: {"code":"invalid_token"}');
+    };
+
+    await expect(useGatewayConnectionStore.getState().removeRecord('gone-1')).rejects.toThrow();
+    // Still listed: a server that answered and refused is not a server whose
+    // token can be quietly abandoned.
+    expect(remainingIds()).toEqual(['gone-1']);
   });
 
-  test('the budget is short enough to stay under a reader-visible stall', () => {
-    expect(REVOKE_BUDGET_MS).toBeLessThanOrEqual(5_000);
+  test('a server fault blocks the removal too', async () => {
+    revoke = async () => {
+      throw new Error('HTTP 500: {"message":"boom"}');
+    };
+
+    await expect(useGatewayConnectionStore.getState().removeRecord('gone-1')).rejects.toThrow();
+    expect(remainingIds()).toEqual(['gone-1']);
+  });
+
+  test('removing a record the store does not hold asks no gateway anything', async () => {
+    await useGatewayConnectionStore.getState().removeRecord('not-here');
+
+    expect(revokedFor).toEqual([]);
+    expect(remainingIds()).toEqual(['gone-1']);
   });
 });

--- a/src/stores/__tests__/gateway-unpair.test.ts
+++ b/src/stores/__tests__/gateway-unpair.test.ts
@@ -8,49 +8,70 @@
  * the fix — the wait is capped, and an unreachable gateway still loses the
  * record.
  *
- * They drive `removeRecord` itself rather than a local copy of its race. That
- * distinction is the whole point of this file: the forgiveness is decided by
- * feeding the timeout the store invents to `describeGatewayFailure`, which
- * classifies it by *matching its message text* — the sentence
- * "Timed out waiting for the server." is forgiven only because it contains the
- * words "timed out". Rewriting that sentence would silently turn an
- * unreachable gateway back into an error toast and a record that will not go
- * away, which is precisely the reported bug. A test that reimplements the race
- * cannot see that coupling; this one breaks when it is cut.
+ * They drive `removeRecord` itself rather than a local copy of its race, and
+ * the records it removes are real ones, sealed and unsealed by the real
+ * `gateway-storage` over a fake keychain. That matters twice over:
  *
- * The native edges the store sits on — SecureStore behind the record storage,
- * fetch behind the gateway client — are the only things stubbed. Everything
- * being asserted is the shipped module.
+ * - The forgiveness is decided by handing the timeout the store invents to
+ *   `describeGatewayFailure`, which classifies it by *matching its message
+ *   text* — "Timed out waiting for the server." is forgiven only because it
+ *   contains the words "timed out". Rewriting that sentence would silently turn
+ *   an unreachable gateway back into an error toast and a record that will not
+ *   go away, which is the reported bug. A test that reimplements the race
+ *   cannot see that coupling.
+ * - "The record is gone" is asserted against storage that really removed it,
+ *   not a stub that agreed to say so.
+ *
+ * What is stubbed is the far side of the network and nothing else: the gateway
+ * client, because the whole point is to control what a gateway answers — and to
+ * be able to make it answer nothing at all.
  */
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 
+import { fakeQuickCrypto, fakeSecureStore, resetVault } from '@/lib/__tests__/gateway-vault';
 import type { GatewayRecord } from '@/lib/gateway-storage';
 
 /** The two requests behind a revoke each carry this, hence the 16 s it fixes. */
 const OLD_WORST_CASE_MS = 16_000;
 
-const record: GatewayRecord = {
-  serverId: 'gone-1',
-  label: 'a gateway that is no longer there',
-  url: 'http://10.0.0.1:23947',
-  token: 'token',
-  pairedAt: 0,
-};
+const SERVER_ID = 'gone-1';
 
 /** What the fake gateway does when asked to drop this device's token. */
 let revoke: () => Promise<void> = async () => {};
 let revokedFor: string[] = [];
-/** Stands in for the SecureStore-backed record list. */
-let stored: GatewayRecord[] = [];
 
-const tag = (strings: TemplateStringsArray, ...values: unknown[]) =>
+/**
+ * `t` and friends compile away in the app build; under `bun test` there is no
+ * macro plugin, so they have to resolve to something. The shapes match what the
+ * macros actually leave behind — `t` a string, `msg` a descriptor — so that a
+ * suite which reaches this replacement by accident misbehaves loudly rather
+ * than subtly.
+ */
+const interpolate = (strings: TemplateStringsArray, ...values: unknown[]) =>
   strings.reduce((out, part, i) => out + part + (i < values.length ? String(values[i]) : ''), '');
 
-mock.module('@lingui/core/macro', () => ({ t: tag, msg: tag, plural: tag }));
+mock.module('@lingui/core/macro', () => ({
+  t: interpolate,
+  plural: interpolate,
+  msg: (strings: TemplateStringsArray, ...values: unknown[]) => {
+    const message = interpolate(strings, ...values);
+    return { id: message, message };
+  },
+}));
+
+mock.module('expo-secure-store', () => fakeSecureStore);
+mock.module('react-native-quick-crypto', () => fakeQuickCrypto);
+
+// The offline demo is a bundled asset the store only reaches through
+// `enterDemo`, which nothing here calls; importing it for real would drag in
+// `expo-asset` for no gain.
 mock.module('@/lib/demo-gateway', () => ({
   demoRecord: { serverId: 'demo' },
   DEMO_SERVER_ID: 'demo',
 }));
+
+// The one edge that must stay under this test's control: these three are the
+// whole of what the store imports from the gateway client.
 mock.module('@/lib/gateway-client', () => ({
   configureGateway: () => {},
   setGatewayLabel: async () => {},
@@ -59,28 +80,31 @@ mock.module('@/lib/gateway-client', () => ({
     await revoke();
   },
 }));
-mock.module('@/lib/gateway-storage', () => ({
-  clearGateway: async () => {},
-  loadGateway: async () => stored[0] ?? null,
-  loadGateways: async () => stored,
-  removeGateway: async (serverId: string) => {
-    stored = stored.filter((item) => item.serverId !== serverId);
-    return stored;
-  },
-  renameGateway: async () => stored,
-  selectGateway: async () => stored,
-  updateGateway: async () => stored,
-}));
 
 const { useGatewayConnectionStore } = await import('@/stores/gateway-connection');
+const { loadGateways, removeGateway, saveGateway } = await import('@/lib/gateway-storage');
 
-/** A revoke that behaves exactly like a machine that is no longer on the network. */
+/** A revoke that behaves like a machine that is no longer on the network. */
 const neverAnswers = () => new Promise<void>(() => {});
 
-beforeEach(() => {
+beforeEach(async () => {
   revoke = async () => {};
   revokedFor = [];
-  stored = [record];
+  // Through the real API as well as the vault, so a record left behind by an
+  // earlier test cannot survive as a stale selection pointer.
+  for (const stale of await loadGateways()) await removeGateway(stale.serverId);
+  resetVault();
+
+  const record = await saveGateway({
+    kind: 'muqun-gateway',
+    server_id: SERVER_ID,
+    label: 'a gateway that is no longer there',
+    url: 'http://10.0.0.1:23947',
+    token: 'a'.repeat(43),
+    device_id: 'device-1',
+    transport_key: 'k'.repeat(43),
+    transport: 'muqun-aes-256-gcm-v1',
+  });
   useGatewayConnectionStore.setState({ record, records: [record], loading: false });
 });
 
@@ -88,12 +112,18 @@ function remainingIds() {
   return useGatewayConnectionStore.getState().records.map((item) => item.serverId);
 }
 
+/** What survived in the keychain, read back through the real unsealing. */
+async function storedIds() {
+  return (await loadGateways()).map((item) => item.serverId);
+}
+
 describe('the revoke that precedes forgetting a gateway', () => {
   test('a gateway that answers is asked first, then forgotten', async () => {
-    await useGatewayConnectionStore.getState().removeRecord('gone-1');
+    await useGatewayConnectionStore.getState().removeRecord(SERVER_ID);
 
-    expect(revokedFor).toEqual(['gone-1']);
+    expect(revokedFor).toEqual([SERVER_ID]);
     expect(remainingIds()).toEqual([]);
+    expect(await storedIds()).toEqual([]);
   });
 
   test(
@@ -102,17 +132,18 @@ describe('the revoke that precedes forgetting a gateway', () => {
       revoke = neverAnswers;
       const started = Date.now();
 
-      await useGatewayConnectionStore.getState().removeRecord('gone-1');
+      await useGatewayConnectionStore.getState().removeRecord(SERVER_ID);
       const waited = Date.now() - started;
 
-      // The record is gone: an unreachable gateway must not be able to pin a
-      // dead pairing to the list forever.
+      // Gone from the list and gone from the keychain: an unreachable gateway
+      // must not be able to pin a dead pairing to the app forever.
       expect(remainingIds()).toEqual([]);
+      expect(await storedIds()).toEqual([]);
       // And the reader was released long before the two 8 s request budgets
       // behind the revoke would have elapsed. This is the reported bug.
       expect(waited).toBeLessThan(OLD_WORST_CASE_MS / 2);
       // The wait is real, though — the gateway is asked, not skipped.
-      expect(revokedFor).toEqual(['gone-1']);
+      expect(revokedFor).toEqual([SERVER_ID]);
     },
     OLD_WORST_CASE_MS
   );
@@ -122,9 +153,10 @@ describe('the revoke that precedes forgetting a gateway', () => {
       throw new Error('Network request failed');
     };
 
-    await useGatewayConnectionStore.getState().removeRecord('gone-1');
+    await useGatewayConnectionStore.getState().removeRecord(SERVER_ID);
 
     expect(remainingIds()).toEqual([]);
+    expect(await storedIds()).toEqual([]);
   });
 
   test('a gateway that is there and says no still blocks the removal', async () => {
@@ -132,10 +164,11 @@ describe('the revoke that precedes forgetting a gateway', () => {
       throw new Error('HTTP 401: {"code":"invalid_token"}');
     };
 
-    await expect(useGatewayConnectionStore.getState().removeRecord('gone-1')).rejects.toThrow();
-    // Still listed: a server that answered and refused is not a server whose
-    // token can be quietly abandoned.
-    expect(remainingIds()).toEqual(['gone-1']);
+    await expect(useGatewayConnectionStore.getState().removeRecord(SERVER_ID)).rejects.toThrow();
+    // Still listed, and still sealed in the keychain: a server that answered
+    // and refused is not one whose token can be quietly abandoned.
+    expect(remainingIds()).toEqual([SERVER_ID]);
+    expect(await storedIds()).toEqual([SERVER_ID]);
   });
 
   test('a server fault blocks the removal too', async () => {
@@ -143,14 +176,15 @@ describe('the revoke that precedes forgetting a gateway', () => {
       throw new Error('HTTP 500: {"message":"boom"}');
     };
 
-    await expect(useGatewayConnectionStore.getState().removeRecord('gone-1')).rejects.toThrow();
-    expect(remainingIds()).toEqual(['gone-1']);
+    await expect(useGatewayConnectionStore.getState().removeRecord(SERVER_ID)).rejects.toThrow();
+    expect(await storedIds()).toEqual([SERVER_ID]);
   });
 
   test('removing a record the store does not hold asks no gateway anything', async () => {
     await useGatewayConnectionStore.getState().removeRecord('not-here');
 
     expect(revokedFor).toEqual([]);
-    expect(remainingIds()).toEqual(['gone-1']);
+    expect(remainingIds()).toEqual([SERVER_ID]);
+    expect(await storedIds()).toEqual([SERVER_ID]);
   });
 });

--- a/src/stores/__tests__/ssh-hosts.test.ts
+++ b/src/stores/__tests__/ssh-hosts.test.ts
@@ -17,6 +17,13 @@ mockModule('expo-secure-store', () => ({
   setItemAsync: async (key: string, value: string) => {
     vault[key] = value;
   },
+  // `mock.module` is process-wide, so whichever of these fakes is registered
+  // when a module first imports `expo-secure-store` is the one it keeps. A fake
+  // missing a method another suite's code path calls therefore fails that suite
+  // and not this one; they all carry the full surface for that reason.
+  deleteItemAsync: async (key: string) => {
+    delete vault[key];
+  },
 }));
 
 // The storage layer only uses the subset of QuickCrypto that mirrors Node's

--- a/src/terminal/__tests__/bun-test.d.ts
+++ b/src/terminal/__tests__/bun-test.d.ts
@@ -48,8 +48,10 @@ declare module 'bun:test' {
   interface TestFn {
     /**
      * `timeoutMs` overrides bun's 5s default for one test. Declared because a
-     * couple of the invariant suites do seconds of real work and would
-     * otherwise fail on a machine that is merely busy.
+     * couple of the invariant suites do seconds of real work, and because a
+     * suite that has to let a real timer elapse -- a budget the code under test
+     * owns, rather than one the test can shorten -- needs more than the default
+     * allows either way.
      */
     (name: string, fn: () => void | Promise<void>, timeoutMs?: number): void;
     each: EachFn;
@@ -64,4 +66,16 @@ declare module 'bun:test' {
   export function afterEach(fn: () => void | Promise<void>): void;
   export function beforeAll(fn: () => void | Promise<void>): void;
   export function afterAll(fn: () => void | Promise<void>): void;
+
+  export const mock: {
+    /**
+     * Replace a module's exports for every importer in this test file.
+     *
+     * The project's tests are otherwise pure, and this is deliberately the
+     * narrow exception: a store that reaches SecureStore and the network can
+     * only be exercised as the shipped module if those two edges are stubbed.
+     * It must be called before the module under test is imported.
+     */
+    module(specifier: string, factory: () => unknown): void;
+  };
 }


### PR DESCRIPTION
`#5` fixed "unpairing a gateway that is gone looks ignored", and its test passed without ever running the code that was fixed. This adds coverage that does, and reports what the fix actually does on a device.

## What the old test could not see

`gateway-unpair.test.ts` defined its own `reviveOrForgive` and asserted against that. The copy had drifted from `removeRecord` in three ways:

- it kept a **local `REVOKE_BUDGET_MS`**, so changing the store's number broke nothing;
- it decided forgiveness with a **local regex** rather than `describeGatewayFailure`;
- it **cleared the race's timer**, which the store does not.

And the on-screen half had no coverage at all — nothing knew the button says "Unpairing…", and nothing knew the Cancel beside it stops taking taps.

The middle one matters most. The store invents `new Error('Timed out waiting for the server.')` and then asks `describeGatewayFailure` what it is; that function classifies **by matching the words "timed out" in the message text**. Rewriting that sentence turns an unreachable gateway back into an error toast and a record that will not go away — the reported bug, restored silently. Confirmed by mutation: renaming the sentence to "The server took too long." now fails the suite, where before it failed nothing.

## What is here

- **`gateway-unpair.test.ts` drives `removeRecord` itself**, with only SecureStore and the network stubbed. Six cases: a gateway that answers is asked then forgotten; one that never answers is given up on and forgotten anyway, inside the budget; a network failure is forgiven the same way; a 401 and a 500 each still block the removal; an unknown record asks nobody anything.
- **`src/lib/unpair-action.ts`** holds the control's two-button state, and `UnpairAction` now reads it instead of spreading `pending` across four props. It is a view model rather than a rendering test because `bun test` cannot parse React Native's Flow entry point — and because the failure worth guarding is not a missing spinner, it is **a spinner with a live Cancel beside it**, which looks finished and is not.
- **`bun:test`'s ambient shim** gains `mock.module` and `test`'s timeout argument.

## Device evidence

Run against a scratch gateway on its own port, with the app on a simulator/emulator served by Metro from this branch. All three states, both platforms:

| | iOS | Android |
|---|---|---|
| Armed (both buttons live) | ✅ | ✅ |
| Reachable gateway: spinner, record removed, **token actually revoked** | ✅ | ✅ |
| Unresponsive gateway: spinner, both buttons inert, record removed | ✅ | ✅ |

The unresponsive case was produced by `SIGSTOP`ing the gateway — the socket still accepts, nothing ever answers, which is what a machine that has gone away looks like. Sampling the screen every ~0.2 s on iOS: armed until t≈0.55 s, "Unpairing…" with a live spinner from t≈0.65 s, record gone by t≈5.3 s. **The wait is ~4.5 s** (the 4 s budget plus the local write behind it), against the ~16 s it replaced.

Two things worth knowing that the commit message does not claim:

- **Giving up is silent.** The row simply disappears; there is no message saying the server could not be reached. That matches the code (the timeout is *forgiven*, so `unpair` takes the success path) and it is a real improvement over a 16 s stall, but a reader is never told the gateway still holds the token.
- **The gateway does still hold it.** After a timed-out unpair the device's token remains server-side — the documented trade-off. It is visible and revocable from another paired device, which the Android screenshots show.

## Gates

`oxfmt --check`, `oxlint --deny-warnings`, `tsc --noEmit`, `bun test src` — all clean (2524 pass, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)