### PR TITLE
fix(ssh): the sign-in dialog appears on the first connection to a 2FA host

### DIFF
--- a/e2e/agent-device/README.md
+++ b/e2e/agent-device/README.md
@@ -58,6 +58,11 @@ is authored and replayed as native `.ad` scripts here.
    install. A system alert hides the app's accessibility tree, and the script
    deliberately does not tap system UI.
 
+The first-run what's-new card is _not_ a precondition: the flow dismisses it
+when it is there and steps past it when it is not, so the run is the same from
+a clean install as from a warm one. See the first bullet under
+[Re-recording](#re-recording).
+
 ## Run it
 
 ```sh
@@ -139,9 +144,22 @@ what `session save-script` uses as the destination guard, and a duration wait
 or a `wait @ref` is not accepted as one. Never record a real password without
 `--record-as` (see `agent-device help scripting`).
 
-Four edits were made to the published script by hand, and a re-recording will
+Five edits were made to the published script by hand, and a re-recording will
 need them again:
 
+- A `press` that dismisses the what's-new card, right after the first `wait`.
+  On a genuinely fresh install the card is drawn over the top of the home
+  screen and it swallows the tap meant for the header's `SSH` button: the run
+  then timed out at the host-list guard having never left home, and it only
+  ever passed on a device that had dismissed the card on some earlier run --
+  which made this gate green for the wrong reason. `.ad` has no conditional
+  step and the card shows once per changelog per install, so the step is
+  written to be right in both states: the `||` chain presses
+  `Dismiss what's new` when the card is up, and otherwise falls through to the
+  home screen's own tagline, which is a static text and answers a tap with
+  nothing. `Your agents, anywhere.` is a safe fallback precisely here, because
+  the flow already waits for `Try the demo` and both belong to the same empty
+  home state.
 - A `wait "text" "Try the demo"` right after `open`. Without it the first
   `press` fires while the splash screen is still up (the bundle is still
   loading from Metro), and the recorded selector `wait` that used to sit
@@ -182,10 +200,11 @@ otherwise the same script:
 - the first `wait` is given 120 s, because a cold `--relaunch` on an emulator
   spends most of a minute starting the app and pulling the bundle.
 
-Every other step -- the selectors, `Send Enter`, `id="ssh-composer-input"`,
-`type "hello"`, `Run command` and the destination guard -- runs unchanged on
-Android. When you edit one script, edit both: they are deliberately line-for-line
-the same so a diff shows only those three lines.
+Every other step -- the selectors, the what's-new dismissal, `Send Enter`,
+`id="ssh-composer-input"`, `type "hello"`, `Run command` and the destination
+guard -- runs unchanged on Android. When you edit one script, edit both: they
+are deliberately line-for-line the same so a diff shows only those three
+lines.
 
 Run it with the device name your AVD reports to `agent-device devices`:
 

--- a/e2e/agent-device/ssh-demo.ad
+++ b/e2e/agent-device/ssh-demo.ad
@@ -1,6 +1,8 @@
 context platform=ios device="muqun-home" kind=simulator theme=unknown
 open "dev.osuki.muqun" --relaunch --platform ios --metro-host 127.0.0.1 --metro-port 8098
 wait "text" "Try the demo"
+press "role=\"button\" label=\"Dismiss what's new\" || label=\"Your agents, anywhere.\""
+wait "stable" 800 10000
 press "role=\"button\" label=\"SSH\" || label=\"SSH\""
 wait "stable" 800 10000
 wait "role=button label=\"Open SSH host Demo shell\""

--- a/e2e/agent-device/ssh-demo.android.ad
+++ b/e2e/agent-device/ssh-demo.android.ad
@@ -1,6 +1,8 @@
 context platform=android device="muqun_main_android" kind=emulator theme=unknown
 open "dev.osuki.muqun" --relaunch --platform android --metro-host 127.0.0.1 --metro-port 8102
 wait "text" "Try the demo" 120000
+press "role=\"button\" label=\"Dismiss what's new\" || label=\"Your agents, anywhere.\""
+wait "stable" 800 10000
 press "role=\"button\" label=\"SSH\" || label=\"SSH\""
 wait "stable" 800 10000
 wait "role=button label=\"Open SSH host Demo shell\""

--- a/src/components/__tests__/ssh-connect-dialogs.test.ts
+++ b/src/components/__tests__/ssh-connect-dialogs.test.ts
@@ -1,0 +1,90 @@
+// The two rules this file exists to keep, both of them about behaviour that is
+// invisible to every other gate in the repo and was very nearly lost to a
+// rebase once already.
+//
+// 1. The server's sign-in dialog stays usable under Android's soft keyboard.
+//    The keyboard covers Cancel and Continue outright -- verified on a Pixel
+//    emulator, the buttons sit entirely below the IME -- so the keyboard's own
+//    return key has to submit, and a close request while the keyboard is up has
+//    to put the keyboard away instead of abandoning the connection, which is
+//    what the system back gesture would otherwise do. That is #7. It was
+//    written against the copy of the dialog that lived in
+//    `ssh-terminal-workspace.tsx`, and #4 moved the dialog to
+//    `ssh-host-key-dialog.tsx` from a branch that predated it: the rebase
+//    dropped all three parts silently and they were put back by hand.
+//
+// 2. The two connect dialogs hand over through `useModalHandoff`. iOS presents
+//    one modal at a time and refuses one asked for while the previous is still
+//    going away -- trusting a host key and then being asked for a one-time code
+//    is exactly that pair, and against a server on the same machine both land
+//    in one frame. The dialog then renders, invisibly, and the connection waits
+//    forever on a question nobody can see.
+//
+// Neither rule can be checked by types, lint or a render test (this repo has no
+// renderer). So the scan reads the real TypeScript AST, scopes itself to each
+// exported dialog by name, and fails loudly if a dialog it expects is gone --
+// a rename is a finding here, not a silent pass.
+/// <reference types="node" />
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import ts from 'typescript';
+
+const DIALOGS = join(dirname(fileURLToPath(import.meta.url)), '..', 'ssh-host-key-dialog.tsx');
+
+/** The source of one exported function, by name. */
+function dialogSource(name: string): string {
+  const text = readFileSync(DIALOGS, 'utf8');
+  const source = ts.createSourceFile(DIALOGS, text, ts.ScriptTarget.Latest, true);
+  let found: string | undefined;
+  const visit = (node: ts.Node) => {
+    if (ts.isFunctionDeclaration(node) && node.name?.text === name) {
+      found = node.getText(source);
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  if (found === undefined) {
+    throw new Error(`${name} is not an exported function of ssh-host-key-dialog.tsx any more`);
+  }
+  return found;
+}
+
+describe('the server sign-in dialog survives the Android soft keyboard', () => {
+  const dialog = dialogSource('SshKeyboardInteractiveDialog');
+
+  test('it knows whether the keyboard is up', () => {
+    expect(dialog).toContain("Keyboard.addListener('keyboardDidShow'");
+    expect(dialog).toContain("Keyboard.addListener('keyboardDidHide'");
+  });
+
+  test('a close request with the keyboard up dismisses the keyboard, not the connection', () => {
+    // The order matters: `Keyboard.dismiss()` has to come first and return, so
+    // the `onResolve(undefined)` below it is only ever reached with the
+    // keyboard already down.
+    const dismiss = dialog.indexOf('Keyboard.dismiss()');
+    const cancel = dialog.indexOf('onResolve(undefined)');
+    expect(dismiss).toBeGreaterThan(-1);
+    expect(cancel).toBeGreaterThan(dismiss);
+    expect(dialog).toContain('if (keyboardUp)');
+  });
+
+  test('the last field submits from the keyboard, since Continue is under it', () => {
+    expect(dialog).toContain('returnKeyType');
+    expect(dialog).toContain('onSubmitEditing');
+    expect(dialog).toContain("index === prompts.length - 1 ? 'go' : 'next'");
+  });
+});
+
+describe('the connect dialogs hand over one at a time', () => {
+  test('both of them wait out the beat before asking to be presented', () => {
+    for (const name of ['SshHostKeyDialog', 'SshKeyboardInteractiveDialog']) {
+      const dialog = dialogSource(name);
+      expect(dialog).toContain('useModalHandoff()');
+      expect(dialog).toContain('if (!ready) return null;');
+    }
+  });
+});

--- a/src/components/ssh-host-key-dialog.tsx
+++ b/src/components/ssh-host-key-dialog.tsx
@@ -8,6 +8,51 @@ import { sanitizeServerText, SERVER_LINE_LIMIT } from '@/lib/ssh-server-text';
 import type { SshTrustedHostKey } from '@/lib/ssh-hosts';
 
 /**
+ * How long a connect dialog waits for the one before it to be gone.
+ *
+ * iOS presents one modal at a time and it is unforgiving about the handover: a
+ * modal asked to appear while the previous one is still going away never
+ * appears at all, and nothing says so. Trusting a host key and then being asked
+ * for a one-time code is exactly that sequence -- and against a server on the
+ * same machine both happen inside a single frame -- so the sign-in dialog was
+ * mounted, rendered, and invisible, and the connection waited forever on a
+ * question nobody could see.
+ *
+ * So the two dialogs hand over through one beat: each records when it left the
+ * screen, and the next waits out whatever is left of the beat before it asks to
+ * be presented. It is only ever spent between two dialogs of one connection --
+ * the reader has just tapped Trust and the handshake is still in flight -- so
+ * it costs nothing anyone can perceive. Android stacks dialogs happily and
+ * never waits.
+ */
+const MODAL_HANDOFF_MS = Platform.OS === 'ios' ? 350 : 0;
+
+/** When the last connect dialog left the screen, module-wide. */
+let lastDialogClosedAt = 0;
+
+function handoffRemainingMs(): number {
+  if (MODAL_HANDOFF_MS === 0 || lastDialogClosedAt === 0) return 0;
+  return Math.max(0, MODAL_HANDOFF_MS - (Date.now() - lastDialogClosedAt));
+}
+
+/**
+ * `false` until the previous connect dialog has had its beat. Render nothing
+ * while it is false; see {@link MODAL_HANDOFF_MS}.
+ */
+function useModalHandoff(): boolean {
+  const [ready, setReady] = useState(() => handoffRemainingMs() === 0);
+  useEffect(() => {
+    const remaining = handoffRemainingMs();
+    const timer = remaining > 0 ? setTimeout(() => setReady(true), remaining) : undefined;
+    return () => {
+      if (timer !== undefined) clearTimeout(timer);
+      lastDialogClosedAt = Date.now();
+    };
+  }, []);
+  return ready;
+}
+
+/**
  * Trust-on-first-use and its refusal, in one dialog, shared by every screen
  * that opens an SSH connection -- the terminal and the gateway tunnel both.
  *
@@ -33,7 +78,9 @@ export function SshHostKeyDialog({
 }) {
   const { t } = useLingui();
   const theme = useThemeTokens();
+  const ready = useModalHandoff();
   const mismatch = verdict === 'mismatch';
+  if (!ready) return null;
   return (
     <Dialog
       visible
@@ -96,6 +143,7 @@ export function SshKeyboardInteractiveDialog({
   const { t } = useLingui();
   const [answers, setAnswers] = useState<string[]>([]);
   const [keyboardUp, setKeyboardUp] = useState(false);
+  const ready = useModalHandoff();
   useEffect(() => {
     const shown = Keyboard.addListener('keyboardDidShow', () => setKeyboardUp(true));
     const hidden = Keyboard.addListener('keyboardDidHide', () => setKeyboardUp(false));
@@ -117,6 +165,7 @@ export function SshKeyboardInteractiveDialog({
   // request while the keyboard is up puts the keyboard away rather than
   // abandoning the connection.
   const submit = () => onResolve(prompts.map((_item, index) => answers[index] ?? ''));
+  if (!ready) return null;
   return (
     <Dialog
       visible


### PR DESCRIPTION
The keyboard-interactive (2FA) sign-in dialog had never been exercised against
a server that actually raises it — the bundled demo shell only echoes, so
typing `2fa` into it proves nothing. This drives it on a real one, on both
platforms, and fixes the two things that turned up.

## The server

A throwaway russh server on this machine, not `sshd`: macOS routes
`KbdInteractiveAuthentication` through PAM and a non-root `sshd` cannot
authenticate through it, so a PAM-free server was the honest route.
`rust/rnssh-testserver` in `react-native-ssh` already is one — its `kbi` user
is keyboard-interactive-only — and it ran unmodified except for a second
prompt, so both branches of `returnKeyType` are covered:

```
name:        Muqun 2FA check
instruction: Employee ID is muqun, secret word is test.
prompts:     "Employee ID: " (echo)   "Secret word: " (no echo)
```

Bound to `0.0.0.0:2230`, reached as `127.0.0.1:2230` from the iOS simulator
and through `adb reverse tcp:2230` from the emulator, killed afterwards.
Nothing on the machine was enabled or left running; Remote Login was never
touched.

## What the verification found

**The dialog never appeared on the first connection to such a host, on iOS.**
The connection sat on `Connecting to kbi@127.0.0.1:2230` forever while the
server waited on answers. The React component was mounted and rendering — its
render logged the challenge — but iOS presents one modal at a time and refuses
one asked for while the previous is still going away. Trusting a new host key
and then being asked for a one-time code is exactly that pair, and against a
server on the same machine both land inside a single frame. Reproduced 3/3 on
an erased simulator; the same host reconnected, its key already trusted and no
dialog before it, asked and connected fine every time.

The fix is a handover beat in `ssh-host-key-dialog.tsx`: each connect dialog
records when it left the screen, and the next waits out what is left of the
beat before it asks to be presented. It lives in the file both dialogs share,
which is also the one place both prompt owners — the terminal screen's own
prompt state and the app-wide `SshConnectPromptGate` — go through. Android has
no such rule and never waits (`MODAL_HANDOFF_MS` is 0 there). The beat is only
ever spent between two dialogs of one connection, with the handshake still in
flight, so nothing perceivable is added.

**#7's port survives the #4 refactor, all three parts.** With the real Android
IME up (`--no-test-ime`; the emulator's default headless test IME would have
hidden this), CANCEL and CONTINUE sit entirely below the keyboard — the
screenshot is unambiguous — so the two answers matter and both work:
`returnKeyType` is `next` on the first field and `go` on the last, the last
one submits, and a close request while the keyboard is up puts the keyboard
away and leaves the connection alive. The last was checked directly, not just
via the back gesture: pressing the dialog's own Close with the keyboard up
dismissed only the keyboard, and pressing it again with the keyboard down
cancelled — which is `if (keyboardUp) Keyboard.dismiss()` doing its job in
both directions.

## The four checks

|                                          | iOS | Android |
| ---------------------------------------- | --- | ------- |
| 1. Dialog appears with the server's text  | yes, after the fix; before it, never | yes |
| 2. Answering connects                     | yes, real shell banner | yes, real shell banner |
| 3. Return key submits / back hides keyboard | return key submits (`go`) | both |
| 4. Cancel cancels cleanly                 | `Cancelled` + Reconnect, server sees a clean EOF | same, by button and by back |

The dialog carries the server's own words throughout: `Muqun 2FA check`,
`Employee ID is muqun, secret word is test.`, `EMPLOYEE ID:`, `SECRET WORD:`.
The host-key dialog's fingerprint matched the one the server printed on start.

`ssh-connect-dialogs.test.ts` pins all of it to the source — the keyboard
listeners, the dismiss-before-cancel order, the `go`/`next` split, and the
handoff on both dialogs. A rebase is what nearly took #7 once already, and
this repo has no renderer to catch it any other way.

## `ssh-demo.ad` on a fresh device

It could not pass on one. The first-run what's-new card is drawn over the top
of the home screen and swallows the tap meant for the header's `SSH` button
(pressing it with the card up returns `+0 -0`), so the flow timed out at the
host-list guard having never left home. It only passed on a device that had
dismissed the card on some earlier run, which made the repo's own SSH gate
green for the wrong reason.

`.ad` has no conditional step and the card shows once per changelog per
install, so the dismissal is written to be right in both states: the `||`
chain presses `Dismiss what's new` when the card is up and otherwise falls
through to the home screen's tagline, which is a static text and answers a tap
with nothing. Both branches were exercised for real — iOS took the card
branch, Android (where the card does not show on a debug build) took the
fallback.

Proof, on a simulator erased with `simctl erase` and a freshly installed app:

```
# the committed flow before this change
Error (REPLAY_DIVERGENCE): Replay failed at step 5
  (wait "role=button label=\"Open SSH host Demo shell\""): wait timed out.
  Current surface: Dismiss what's new, SSH, Scan a gateway QR, Settings.
    @e5 [button] "Dismiss what's new"
    @e6 [text] "WHAT'S NEW"

# after
e2e-agent-device: replay ssh-demo.ad on ios/muqun-kbi
Replayed 23 steps in 113.8s
```

and on the emulator after `adb shell pm clear dev.osuki.muqun`:

```
e2e-agent-device: replay ssh-demo.android.ad on android/muqun kbi
Replayed 23 steps in 63.5s
```

The two scripts stay line-for-line identical apart from the three lines the
README already documents.

## Gates

```
$ npx tsc --noEmit
(no output, exit 0)

$ bun run lint
$ oxlint --deny-warnings
(no findings, exit 0)

$ bun run format:check
$ oxfmt --check
All matched files use the correct format.
Finished in 214ms on 420 files using 12 threads.

$ bun test src
 2562 pass
 2 skip
 0 fail
 13688 expect() calls
Ran 2564 tests across 97 files. [4.16s]
```

`scripts/e2e.sh` (the Maestro suite) was not run: this work was scoped to
agent-device, and the SSH e2e it owns was run on both platforms from clean
state, as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
