### PR TITLE
fix(android): the sign-in segmented control fits its track again

### DIFF
--- a/patches/@osuki-dev%2Fui@1.0.0.patch
+++ b/patches/@osuki-dev%2Fui@1.0.0.patch
@@ -92,3 +92,36 @@ diff --git a/src/components/toast.tsx b/src/components/toast.tsx
  				flexDirection: "row",
  				alignItems: "flex-start",
  				gap: theme.spacing.sm,
+diff --git a/src/components/segmented-control.tsx b/src/components/segmented-control.tsx
+--- a/src/components/segmented-control.tsx
++++ b/src/components/segmented-control.tsx
+@@ -1,5 +1,5 @@
+ import React from "react";
+-import { TouchableOpacity, View, type ViewProps, type ViewStyle } from "react-native";
++import { Platform, TouchableOpacity, View, type ViewProps, type ViewStyle } from "react-native";
+ import ExpoSegmentedControl from "@expo/ui/community/segmented-control";
+ import Animated, { useSharedValue, useAnimatedStyle, withSpring } from "react-native-reanimated";
+ import { useThemeTokens } from "../theme";
+@@ -86,7 +86,21 @@
+ 		...(mode === "light" ? shadow.soft : {}),
+ 	};
+ 
+-	if (!hasDisabledOptions) {
++	// The native control only fits this container on iOS.
++	//
++	// `@expo/ui/community/segmented-control` renders the platform's own widget.
++	// On iOS that is `UISegmentedControl`, which is compact and chromeless enough
++	// to sit inside the decorative track above. On Android it is Material's
++	// `SegmentedButtonRow`, which draws a full outlined track of its own: its own
++	// border, its own dividers between segments and its own selected fill. Nested
++	// in this one you get two tracks, and Material's row wants more height than
++	// the 36pt this container leaves it, so the selected segment overflows top and
++	// bottom while the labels overflow the parent's rounded clip on the right.
++	//
++	// The branch below is not a fallback -- it is this design system's own
++	// rendering of the control, and it is what the rules in the doc comment
++	// describe. Android takes it.
++	if (Platform.OS === "ios" && !hasDisabledOptions) {
+ 		return (
+ 			<View accessibilityRole="tablist" testID={testID} style={[containerStyles, style]} {...rest}>
+ 				<ExpoSegmentedControl


### PR DESCRIPTION
On the SSH host form, Android drew the selected segment **taller than the control containing it** — overflowing top and bottom — with the third option's rounded edge pushed past the track's right corner, and a divider line between every segment so it read as three outlined boxes rather than one control. iOS was unaffected.

### Cause

`@osuki-dev/ui`'s `SegmentedControl` wraps `@expo/ui/community/segmented-control`, which renders the **platform's own widget**, inside a decorative track of the library's own: `height: 44`, `padding: 4`, `borderRadius: 14`, `backgroundColor: surfaceRaised`, soft shadow.

- **iOS** gets `UISegmentedControl` — compact and chromeless enough to sit inside that track.
- **Android** gets Material's `SegmentedButtonRow`, which draws a full outlined track of its own: its own border, its own dividers, its own selected fill. The two nest, and Material's row wants more height than the 36pt the padding leaves it.

### Fix

The library already has its own rendering of this control — flex segments, a `colors.surface` pill behind the active one, uppercase label text — and it is what the design rules in its own doc comment describe. It was reachable only when an option is `disabled`. Android takes it now; iOS keeps the native widget.

### Why a patch and not an upstream fix

`patches/@osuki-dev%2Fui@1.0.0.patch` already carried the toast `maxWidth` gap. This is a store-submission week, and moving `@osuki-dev/ui` means muqun follows it through a version bump and another regression pass. Both hunks belong upstream once this ships.

The patch was verified to apply from a clean `bun install --force` (735 packages) — both hunks land.

### Verified on device

Pixel emulator, real debug build, before and after. The three segments sit inside the track, the active pill is bounded by it, and tapping "Ask each time" moves the selection and swaps the field below for its explanation.

```
npx tsc --noEmit      exit 0
bun run lint          exit 0
bun run format:check  All matched files use the correct format (428 files)
bun test src          2593 pass, 2 skip, 0 fail
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)