### PR TITLE
fix(android): the composer stops tearing the terminal down while it opens

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:android:production": "eas build --platform android --profile production",
     "build:android:production:local": "EAS_LOCAL_BUILD_ARTIFACTS_DIR=\"$PWD/dist/eas-builds\" eas build --platform android --profile production --local",
     "build:android:production-apk:local": "EAS_LOCAL_BUILD_WORKINGDIR=$(mktemp -d \"${TMPDIR:-/tmp}/muqun-eas-production.XXXXXX\") EAS_LOCAL_BUILD_ARTIFACTS_DIR=\"$PWD/dist/eas-builds\" eas build --platform android --profile production-apk --local",
-    "release:android:local": "EAS_LOCAL_BUILD_WORKINGDIR=$(mktemp -d \"${TMPDIR:-/tmp}/muqun-eas-android.XXXXXX\") EAS_LOCAL_BUILD_ARTIFACTS_DIR=\"$PWD/dist/eas-builds\" eas build --platform android --profile production --local && p=$(ls -t dist/eas-builds/*.aab | head -1) && echo \"Submitting $p\" && eas submit --platform android --profile production --path \"$p\"",
+    "release:android:local": "_JAVA_OPTIONS='-Xmx6g -XX:MaxMetaspaceSize=2g' EAS_LOCAL_BUILD_WORKINGDIR=$(mktemp -d \"${TMPDIR:-/tmp}/muqun-eas-android.XXXXXX\") EAS_LOCAL_BUILD_ARTIFACTS_DIR=\"$PWD/dist/eas-builds\" eas build --platform android --profile production --local && p=$(ls -t dist/eas-builds/*.aab | head -1) && echo \"Submitting $p\" && eas submit --platform android --profile production --path \"$p\"",
     "submit:android": "npx eas-cli@latest build --platform android --profile production --auto-submit",
     "submit:android:latest": "npx eas-cli@latest submit --platform android --profile production --latest",
     "build:ios": "eas build --platform ios --profile testflight --auto-submit",

--- a/src/components/server-terminal-workspace.tsx
+++ b/src/components/server-terminal-workspace.tsx
@@ -339,6 +339,16 @@ const PAD_PANE_STRIP_MAX_WIDTH = 614;
 const CONNECTION_RECOVERED_MS = 1_400;
 
 /**
+ * How long the dock's measurement is given to settle before it becomes state.
+ *
+ * Long enough to swallow a run of alternating measurements -- see
+ * `measureComposerHeight` -- and short enough to land well inside the dock's
+ * own reflow, so a height that really did change still moves the terminal's
+ * inset within the same animation.
+ */
+const COMPOSER_MEASURE_WINDOW_MS = 50;
+
+/**
  * The composer dock, as something whose height can be animated.
  *
  * `SafeAreaView` is an ordinary view under the inset provider, so wrapping it
@@ -497,6 +507,53 @@ export function ServerTerminalWorkspace({
   const [sendingKey, setSendingKey] = useState<string | null>(null);
   const [composerHeight, setComposerHeight] = useState(96);
   const [shortcuts, setShortcuts] = useState<PaneShortcuts | null>(null);
+  /*
+    The dock's measured height, handed to React on the leading and trailing
+    edge of a window rather than on every measurement.
+
+    `onLayout` is a native callback delivered inside the commit that laid the
+    dock out, so the state it writes is a nested update in React's accounting.
+    One nested update is nothing. A run of them is the defect this exists for:
+    the bottom inset the dock is padded by can flip between its keyboard-up and
+    its keyboard-down value repeatedly while the keyboard animates, and each
+    flip re-measures the dock at the other of two heights. Written straight
+    through, that alternation is a chain of nested updates, and a gateway
+    streaming pane output commits the screen on top of it until the chain
+    passes React's limit of fifty: "Maximum update depth exceeded", thrown from
+    whichever setter the frame lands on, which drops the terminal to its
+    boundary and back -- the flicker. It needs both halves, which is why only a
+    live server ever showed it and the demo workspace never could.
+
+    The throttle is the whole of the fix. The first measurement still lands at
+    once, so nothing waits on a height that really did change; an alternation
+    collapses to a single write on the trailing edge; and a write made from a
+    timer is not nested at all, so the chain cannot form.
+  */
+  const measuredComposerHeightRef = useRef(96);
+  const composerMeasureTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const composerMeasuredAtRef = useRef(0);
+  const measureComposerHeight = useCallback((height: number) => {
+    measuredComposerHeightRef.current = height;
+    if (composerMeasureTimerRef.current) return;
+    const elapsed = Date.now() - composerMeasuredAtRef.current;
+    if (elapsed >= COMPOSER_MEASURE_WINDOW_MS) {
+      composerMeasuredAtRef.current = Date.now();
+      setComposerHeight((current) => (current === height ? current : height));
+      return;
+    }
+    composerMeasureTimerRef.current = setTimeout(() => {
+      composerMeasureTimerRef.current = undefined;
+      composerMeasuredAtRef.current = Date.now();
+      const settled = measuredComposerHeightRef.current;
+      setComposerHeight((current) => (current === settled ? current : settled));
+    }, COMPOSER_MEASURE_WINDOW_MS - elapsed);
+  }, []);
+  useEffect(
+    () => () => {
+      if (composerMeasureTimerRef.current) clearTimeout(composerMeasureTimerRef.current);
+    },
+    []
+  );
   // The keyboard button swaps the compact key row for a full on-screen QWERTY
   // that types straight into the pane -- the way to drive a TUI like nvim from
   // a phone. Off by default so the output stays visible.
@@ -3107,8 +3164,7 @@ export function ServerTerminalWorkspace({
                   edges={['bottom']}
                   layout={dockRowLayout}
                   onLayout={(event: LayoutChangeEvent) => {
-                    const nextHeight = Math.ceil(event.nativeEvent.layout.height);
-                    setComposerHeight((current) => (current === nextHeight ? current : nextHeight));
+                    measureComposerHeight(Math.ceil(event.nativeEvent.layout.height));
                   }}
                   style={[styles.composerSafeArea, isPadLayout && styles.padComposerSafeArea]}>
                   {/* Inside the dock rather than floating over the pane: the dock is

--- a/src/components/skia-terminal.tsx
+++ b/src/components/skia-terminal.tsx
@@ -213,6 +213,27 @@ function openPaneScaleStore(): PaneScaleStore {
 
 const PANE_SCALE_STORAGE_KEY = 'muqun.terminal-pane-scale.v1';
 
+/**
+ * How long the terminal's measured box must hold still before the grid follows
+ * it.
+ *
+ * Everything downstream of `viewport` is expensive: the content width, the
+ * unobstructed height, the clamps that re-run on it, and -- through them -- the
+ * recorded picture the canvas draws. That is the right price to pay once, for
+ * a size the reader is going to keep. It is the wrong price to pay fifteen
+ * times for the fifteen sizes a keyboard passes through on its way up, and a
+ * caller that resizes this terminal to animate is not doing anything unusual:
+ * an animated height reaches the layout system frame by frame by design.
+ *
+ * So a resize is committed at the size it settles on rather than at each size
+ * on the way there. A quarter-second keyboard becomes one resize, and the grid
+ * still ends up exactly where the layout put it. `ssh-terminal-workspace.tsx`
+ * settles its own viewport for the same reason and by the same clock -- there
+ * it is the PTY on the far side that must not hear about fifteen sizes; here
+ * it is the picture.
+ */
+const VIEWPORT_SETTLE_MS = 100;
+
 let paneScaleStoreInstance: PaneScaleStore | null = null;
 function paneScaleStore(): PaneScaleStore {
   if (!paneScaleStoreInstance) paneScaleStoreInstance = openPaneScaleStore();
@@ -434,6 +455,15 @@ export function SkiaTerminal({
   }, [nerdFont]);
   const lineHeight = terminalLineHeight(fontSize);
   const [viewport, setViewport] = useState({ width: 0, height: 0 });
+  /** The settle timer behind `handleLayout`, and whether a first size has landed. */
+  const viewportSettleRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const viewportMeasuredRef = useRef(false);
+  useEffect(
+    () => () => {
+      if (viewportSettleRef.current) clearTimeout(viewportSettleRef.current);
+    },
+    []
+  );
   // Parsing + re-recording the picture is the expensive part of an output
   // burst, so it runs off a coalesced snapshot (leading + trailing, ~100ms) --
   // keyed on terminalId so a pane switch flushes at once. The raw `output` prop
@@ -1895,12 +1925,31 @@ export function SkiaTerminal({
     longPressGesture
   );
 
+  /**
+   * The measured box, committed once it has held still -- see
+   * `VIEWPORT_SETTLE_MS` for why it is not committed as it moves.
+   *
+   * The first measurement is the exception and lands at once: there is nothing
+   * for it to be in flight from, and the grid has to have a size before it can
+   * draw anything at all.
+   */
   function handleLayout(event: LayoutChangeEvent) {
     const { width, height } = event.nativeEvent.layout;
-    setViewport((current) => {
-      const next = { width: Math.round(width), height: Math.round(height) };
-      return current.width === next.width && current.height === next.height ? current : next;
-    });
+    const next = { width: Math.round(width), height: Math.round(height) };
+    const commit = () =>
+      setViewport((current) =>
+        current.width === next.width && current.height === next.height ? current : next
+      );
+    if (viewportSettleRef.current) clearTimeout(viewportSettleRef.current);
+    if (!viewportMeasuredRef.current) {
+      viewportMeasuredRef.current = true;
+      commit();
+      return;
+    }
+    viewportSettleRef.current = setTimeout(() => {
+      viewportSettleRef.current = null;
+      commit();
+    }, VIEWPORT_SETTLE_MS);
   }
 
   // One snap per send, not one per frame. The layout values in the dependency


### PR DESCRIPTION
Focusing the composer over a **live gateway** pane made the terminal flash to black, repeatedly. I could not reproduce it in the demo workspace, and that turned out to be the clue rather than a dead end.

## What it was

The dock measures itself into `composerHeight` from `onLayout`. That is a native callback delivered inside the commit that laid the dock out, so the state it writes is a *nested* update in React's accounting. One is nothing. A run of them is the defect.

While the keyboard animates, `insets.bottom` flips between its keyboard-up value (0) and its keyboard-down value (24), and each flip re-measures the dock at the other of two heights. Written straight through, that alternation is a chain of nested updates — and a gateway streaming pane output commits the screen on top of it until the chain passes React's limit of fifty:

```
ERROR  Maximum update depth exceeded.
  applyPaneOutput   server-terminal-workspace.tsx:1643   (setPaneRevision)
  onPaneOutput      server-terminal-workspace.tsx:2033
  handleHerdrEvent  use-pane-events.ts:149
```

React then drops the subtree to its boundary and puts it back. That is the black flash.

It needs both halves, which is exactly why demo mode could never show it: a static transcript never commits a frame.

Measured on an emulator against a real gateway (v0.8.0, tmux backend, nvim running in the pane, real Gboard as the input method): **41 alternations between 109 and 133**, in lockstep with `insets.bottom` flipping 24/0, then the throw.

## The fix

The measurement is throttled instead of written straight through. The first one still lands at once, so nothing waits on a height that really did change; an alternation collapses to a single write on the trailing edge; and a write made from a timer is not nested at all, so the chain cannot form.

**Evidence:** roughly one focus in twenty reproduced it before. Eighty-two consecutive focus/dismiss cycles after, none.

The terminal's own viewport gets the same treatment, for the reason `ssh-terminal-workspace.tsx` already settles its own: everything downstream of `viewport` is expensive, an animated height reaches the layout system frame by frame by design, and a caller that resizes the terminal to animate should pay for the size it settles on, not for the fifteen on the way there. Nothing resizes it that way today — the keyboard moves the content, not the box — but the next thing that does will not have to learn this again.

## Also in here

`2bb31a6` from `fix/android-local-build-memory`, cherry-picked: one line in `package.json` giving `release:android:local` the JVM memory it needs. Unrelated to the rest, folded in at the maintainer's request.

## Gates

`npx tsc --noEmit`, `bun run lint`, `bun run format:check`, `bun test src` (2593 pass, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
