### PR TITLE
chore: tidy comment wording

### DIFF
--- a/scripts/i18n-audit.ts
+++ b/scripts/i18n-audit.ts
@@ -1,7 +1,7 @@
 /**
  * The sweep that finds copy the macros never saw.
  *
- * Three separate mistakes put English on a 繁體中文 screen, and only the first
+ * Three separate mistakes put English on a Traditional Chinese screen, and only the first
  * of them is visible when you read a diff:
  *
  *  1. A literal written straight into a user-facing prop -- `title="Retry"`,

--- a/src/app/commands.tsx
+++ b/src/app/commands.tsx
@@ -863,7 +863,7 @@ export default function QuickCommandsScreen() {
  * A group's instrument label, and whatever control belongs to the group itself.
  *
  * `variant="label"` rather than a caption with `toUpperCase()` applied in
- * JavaScript: case is a language's business, and `toUpperCase()` on 日本語 does
+ * JavaScript: case is a language's business, and `toUpperCase()` on Japanese does
  * nothing while on some scripts it does the wrong thing. `textTransform` is a
  * rendering instruction the platform applies per script.
  */

--- a/src/components/session-artifacts.tsx
+++ b/src/components/session-artifacts.tsx
@@ -227,7 +227,7 @@ export function SessionArtifacts({
   // Each chip carries its spoken label as its own message rather than as
   // ``Show ${label.toLowerCase()}``. Concatenation looks like it translates --
   // the noun is a message, after all -- but the verb around it never was, so
-  // VoiceOver in zh-TW read "Show 圖片": an English sentence with a Chinese word
+  // VoiceOver in zh-TW read "Show <image>" with the noun in Chinese: an English sentence with a Chinese word
   // dropped into it. Half a sentence per language is worse than none, because
   // the reader cannot tell whether they misheard. Nor does `toLowerCase()` mean
   // anything outside a cased script; it is a no-op on Chinese and wrong in the

--- a/src/components/settings-chrome.tsx
+++ b/src/components/settings-chrome.tsx
@@ -70,7 +70,7 @@ const CHIP_SIZE = 36;
  * instrument style, the same one the segmented controls' own labels use. It
  * used to be a `caption` with `title.toUpperCase()` applied in JavaScript,
  * which is the mistake `i18n/labels.ts` is written to prevent: case is a
- * language's business, `toUpperCase()` on 日本語 does nothing and on some
+ * language's business, `toUpperCase()` on Japanese does nothing and on some
  * scripts does something wrong. `textTransform` is a rendering instruction the
  * platform applies per script, and it costs no catalog churn.
  */

--- a/src/components/settings-language-sheet.tsx
+++ b/src/components/settings-language-sheet.tsx
@@ -8,8 +8,8 @@
  *
  * In the sheet it is what a language picker should be: one option per line,
  * scanned rather than compared, in the same card-with-hairlines the rest of the
- * page is built from. Each language is written in itself -- English, 繁體中文,
- * 日本語 -- because a reader looking for Chinese is not scanning for the English
+ * page is built from. Each language is written in itself -- English, Traditional
+ * Chinese, Japanese -- because a reader looking for Chinese is not scanning for the English
  * word for it. Only "System" is translated, since it is a description rather
  * than a name.
  *

--- a/src/i18n/__tests__/catalogs.test.ts
+++ b/src/i18n/__tests__/catalogs.test.ts
@@ -48,7 +48,7 @@ const catalogs: Record<AppLocale, Catalog> = {
 const TRANSLATED_LOCALES = APP_LOCALES.filter((locale) => locale !== 'en');
 
 // Every character here exists only in the Simplified set. Shared characters
-// (端, 面, 会) are deliberately absent -- one of them in the list makes the
+// (three common CJK characters) are deliberately absent -- one of them in the list makes the
 // whole assertion cry wolf. Module-level because two suites hold zh-TW text to
 // it: the compiled catalog, and the native locale files prebuild reads.
 const SIMPLIFIED_ONLY =
@@ -457,7 +457,7 @@ describe('the native locale files', () => {
 
     // Muqun is a brand name, so it is the same word in most locales. That is a
     // decision rather than an oversight, and asserting it is what makes it one.
-    // zh-TW and ja are the exception: the app is called 牧群 there, matching the
+    // zh-TW and ja are the exception: the app carries its native CJK name there, matching the
     // localisation already published on osuki.dev -- the app must not invent
     // its own convention for its own name where one already exists.
     const localName: Partial<Record<AppLocale, string>> = { 'zh-TW': '牧群', ja: '牧群' };

--- a/src/i18n/labels.ts
+++ b/src/i18n/labels.ts
@@ -28,7 +28,7 @@ import type { ServerReachability } from '@/lib/server-reachability';
  * What the card says out loud next to the dot.
  *
  * Upper case is baked into the English rather than applied with a transform,
- * because case is a language's business: `text-transform: uppercase` on 繁體中文
+ * because case is a language's business: `text-transform: uppercase` on Traditional Chinese
  * does nothing, and on some scripts it does something wrong.
  */
 export const reachabilityLabel: Record<ServerReachability, MessageDescriptor> = {
@@ -61,7 +61,7 @@ export const paneViewModeDetail: Record<PaneViewMode, MessageDescriptor> = {
  *
  * It used to be `Switch to the ${label.toLowerCase()} view`, which quietly
  * assumed two things English happens to allow: that a word has a lower-case
- * form, and that a sentence can be built by dropping a noun into a slot. 繁體中文
+ * form, and that a sentence can be built by dropping a noun into a slot. Traditional Chinese
  * has no case at all, so `toLowerCase()` is a no-op there -- and the sentence a
  * translator wants to write is not a template with a hole in it.
  */
@@ -179,7 +179,7 @@ export const editorActionDescription: Record<string, MessageDescriptor> = {
  * agent advertises -- fell through to the English `accessibilityLabel` baked
  * into `@/lib/terminal-keys`. That module is pure and under test, so it cannot
  * hold a macro; the strings had nowhere to be translated and were spoken in
- * English on a 繁體中文 phone.
+ * English on a Traditional Chinese phone.
  *
  * **Keyed by the English label, not by the key name.** The same key means
  * different things in different rows -- `ctrl+r` is reverse search at a shell,

--- a/src/i18n/locale.ts
+++ b/src/i18n/locale.ts
@@ -60,9 +60,9 @@ export const LOCALE_LABELS: Record<AppLocale, string> = {
  * Muqun is a brand name, and most of these files say "Muqun" for exactly that
  * reason -- the same reason the gateway's tables leave "Gateway" in Latin
  * script. `zh-TW` and `ja` are the deliberate exceptions: the site at
- * osuki.dev already gives the product a native name there, 牧群, and
+ * osuki.dev already gives the product a native name there (the CJK form of Muqun), and
  * `native-locales/zh-TW.json` and `native-locales/ja.json` carry it too, so a
- * reader who knows the app as 牧群 does not meet "Muqun" in a permission
+ * reader who knows the app by that native name does not meet "Muqun" in a permission
  * prompt or the App Store's own listing of the app's name. The pipeline is
  * wired up for every locale regardless, because the alternative is
  * discovering it does not work on the day another market needs a local name,

--- a/src/lib/demo-gateway.ts
+++ b/src/lib/demo-gateway.ts
@@ -34,7 +34,7 @@ import {
  * and no gateway, so this file *is* the gateway, and its prose is the only copy
  * in the app that would otherwise be hard-coded English. That is not a small
  * corner: this is what an App Store or Play reviewer sees, and it is where the
- * store screenshots come from, so a 繁體中文 phone showing an English demo is a
+ * store screenshots come from, so a Traditional Chinese phone showing an English demo is a
  * screenshot in the wrong language on every localized store listing.
  *
  * **Why every one of these is `i18n._(msg`...`)` inside a function.** These are

--- a/src/terminal/__tests__/selection.test.ts
+++ b/src/terminal/__tests__/selection.test.ts
@@ -272,11 +272,11 @@ describe('selectionSpans', () => {
 });
 
 describe('selectionSpans with wide glyphs', () => {
-  // 你好 occupies columns 0..3; 'ok' follows at 4 and 5.
+  // The two-character CJK greeting occupies columns 0..3; 'ok' follows at 4 and 5.
   const lines = rows('你好ok');
 
   test('an end landing on a continuation column takes the whole glyph', () => {
-    // Focus on column 1, the second half of 你.
+    // Focus on column 1, the second half of the first wide character.
     expect(selectionSpans(lines, span([0, 0], [0, 1]), 80)).toEqual([
       { row: 0, startColumn: 0, endColumn: 2 },
     ]);

--- a/src/terminal/__tests__/unicode.test.ts
+++ b/src/terminal/__tests__/unicode.test.ts
@@ -156,7 +156,7 @@ describe('CJK stays two columns', () => {
   });
 
   test('a CJK and Latin row measures the same width the gateway laid out', () => {
-    // "条治理、Files 三合一" -- 4 wide + 6 narrow + 1 space + 3 wide.
+    // The mixed fixture above: 4 wide + 6 narrow + 1 space + 3 wide.
     expect(displayWidth('条治理、Files 三合一')).toBe(4 * 2 + 5 + 1 + 3 * 2);
   });
 });


### PR DESCRIPTION
Comment lines that quoted a CJK word as an example are rewritten to describe the example instead. No fixture string, identifier, or catalog entry changes; no behaviour changes. Two lines in files under active edit are left for those pull requests.

Gates: tsc, oxlint, oxfmt clean; bun test src 2593 pass / 0 fail.