### PR TITLE
fix(simfarm): the port row fits the screen again

### DIFF
--- a/src/components/simfarm-preview.tsx
+++ b/src/components/simfarm-preview.tsx
@@ -168,7 +168,12 @@ export function SimfarmPreview({
           placeholder={String(SIMFARM_DEFAULT_PORT)}
           accessibilityLabel={t`simfarm port`}
           testID="simfarm-port"
-          style={styles.port}
+          // `containerStyle`, not `style`: this Input hands `style` to the
+          // TextInput inside its own full-width wrapper, so a width there sized
+          // the text box and left the wrapper as wide as the screen. The row
+          // then overflowed both edges -- the port lost its first digit on the
+          // left and Look again was cut off on the right.
+          containerStyle={styles.port}
           onSubmitEditing={() => {
             const parsed = parsePort(portText);
             if (parsed !== null) setPort(parsed);
@@ -193,6 +198,6 @@ const styles = StyleSheet.create({
   middle: { textAlign: 'center' },
   sheetPad: { paddingHorizontal: 24 },
   embeddedPad: { paddingHorizontal: 12 },
-  row: { flexDirection: 'row', alignItems: 'center', gap: 8, marginTop: 4 },
+  row: { flexDirection: 'row', alignItems: 'center', gap: 8, marginTop: 4, maxWidth: '100%' },
   port: { width: 104 },
 });


### PR DESCRIPTION
Reported by the maintainer on Android (zh-TW): on the *No simulator on port* screen the port field ran off the left edge and **Look again** ran off the right — `8801` read as `801`, and the button showed only its first characters.

### Cause

`styles.port` set `width: 104` through the Input's `style` prop. `@osuki-dev/ui`'s `Input` hands `style` (typed `TextStyle`) to the `TextInput` **inside** its own wrapper and sizes the wrapper from `containerStyle` (`input.tsx:146`/`158`); the wrapper is full width by default. So the width sized the text box, the wrapper stayed as wide as the screen, and a row of wrapper + button was wider than its parent. The parent centres its children, so the overflow was split between both edges — which is why both ends were clipped rather than one.

### Fix

The width moves to `containerStyle`, and the row is capped at `maxWidth: '100%'` so a long translation of *Look again* wraps inside it rather than pushing past it.

### Verification

By API contract from the library source, not on a device: this screen only appears for a paired gateway reachable over Tailscale/HTTPS with simfarm absent on the named port, which the demo workspace cannot produce and the emulators here are not paired for. The maintainer can confirm on the device that showed it.

Gates: `tsc` clean, `oxlint` clean, `oxfmt` clean, `bun test src` 2593 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)