### PR TITLE
perf(terminal): the gesture redraws once a frame, not once a touch

### DIFF
--- a/src/components/skia-terminal.tsx
+++ b/src/components/skia-terminal.tsx
@@ -1806,12 +1806,113 @@ export function SkiaTerminal({
   // steps keep each glyph's rasterization phase constant at any resting scale.
   // Scale is deliberately not snapped: quantizing a pinch reads as stutter.
   const devicePixelRatio = PixelRatio.get();
+  /*
+    The transform the canvas is actually drawn at, which is not always the one
+    the gesture is at.
+
+    Every write to this value costs a redraw, and a redraw is the expensive
+    thing here -- not the drawing. Measured on an emulator against a live
+    gateway pane, interleaved so host load falls on both arms equally: a pan
+    over the full terminal and the same pan with the entire scene replaced by
+    one eight-pixel rectangle cost the same, 92.3ms against 90.9ms a frame, and
+    rendered the same number of frames. The content is not what is being paid
+    for. What is paid for runs once per change of this value whatever it draws:
+    the reanimated property commit, re-recording the scene, and the redraw it
+    asks for -- a full-surface clear, a draw and a blocking buffer swap, on
+    Android on the main thread.
+
+    So during a gesture the value is committed at half rate. The finger still
+    samples at the display's rate and every clamp, decay and hit test still sees
+    every value -- this is the last step before the pixels and nothing upstream
+    of it changes. What it buys is that the redraw is asked for half as often,
+    which is the only quantity that was ever making this slow.
+
+    Outside a gesture nothing is dropped. An eased scroll or a follow-bottom
+    catch-up is short, already smooth, and rare enough that halving it would be
+    a visible cost for no gain.
+  */
+  const committedTranslateX = useSharedValue(0);
+  const committedTranslateY = useSharedValue(0);
+  const committedScale = useSharedValue(1);
+  /** 1 once the frame callback below has taken over pacing for this gesture. */
+  const commitPaced = useSharedValue(0);
+  /**
+   * The gesture's commit, run once per display frame instead of once per touch.
+   *
+   * Touch arrives faster than the display can show it, and every write pays the
+   * whole cost: the property commit, a re-record of the scene, and a redraw
+   * request that ends in a full-surface clear, a draw and a blocking buffer
+   * swap on the main thread. Measured here on a 500ms pan: the transform was
+   * written 40 times and the app presented 4 frames. Thirty-six of those writes
+   * did all of that work for pixels nobody ever saw.
+   *
+   * A frame callback is the display's own clock, so it cannot write more than
+   * once per frame however fast the digitizer samples, and it writes the newest
+   * value rather than an averaged or a delayed one. It also paces itself to
+   * whatever rate the device is actually achieving. On hardware quick enough to
+   * present every frame this changes nothing that reaches the screen.
+   *
+   * What it does NOT do is smooth anything or hold anything back: every clamp,
+   * decay and hit test upstream still sees every touch. This is the last step
+   * before the pixels and nothing above it is aware of it.
+   */
+  const gestureCommitFrame = useFrameCallback(() => {
+    'worklet';
+    commitPaced.value = 1;
+    committedTranslateX.value = translateX.value;
+    committedTranslateY.value = translateY.value + pullDistance.value;
+    committedScale.value = scale.value;
+  }, false);
+  useAnimatedReaction(
+    () => ({
+      x: translateX.value,
+      y: translateY.value + pullDistance.value,
+      s: scale.value,
+      moving: gesturing.value || coasting.value > 0,
+    }),
+    (live) => {
+      // Paced only once the callback is actually running. Registering it is a
+      // hop to the JS thread and back (see the effect below), and the frames in
+      // that gap still have to reach the screen -- a gesture that began with a
+      // hitch would be a poor trade for the frames it saved.
+      if (live.moving && commitPaced.value === 1) return;
+      committedTranslateX.value = live.x;
+      committedTranslateY.value = live.y;
+      committedScale.value = live.s;
+    }
+  );
+  const [gestureMoving, setGestureMoving] = useState(false);
+  useAnimatedReaction(
+    () => gesturing.value || coasting.value > 0,
+    (moving, wasMoving) => {
+      if (moving === wasMoving) return;
+      if (moving) {
+        commitPaced.value = 0;
+      } else {
+        // The callback stops on the frame the gesture ends, and the finger's
+        // last position lands after it. Written straight through so a release
+        // cannot leave the pane a frame short of where it was let go.
+        committedTranslateX.value = translateX.value;
+        committedTranslateY.value = translateY.value + pullDistance.value;
+        committedScale.value = scale.value;
+      }
+      scheduleOnRN(setGestureMoving, moving);
+    }
+  );
+  // Registered and unregistered from the JS thread, which is the only thread
+  // that may: `setActive` mutates reanimated's callback registry, and calling it
+  // from a worklet corrupts it (measured -- it throws inside
+  // `manageStateFrameCallback` and takes the screen down with it).
+  useEffect(() => {
+    gestureCommitFrame.setActive(gestureMoving);
+    return () => gestureCommitFrame.setActive(false);
+  }, [gestureCommitFrame, gestureMoving]);
   const contentTransform = useDerivedValue(() => {
     const snap = (value: number) => Math.round(value * devicePixelRatio) / devicePixelRatio;
     return [
-      { translateX: snap(translateX.value) },
-      { translateY: snap(translateY.value + pullDistance.value) },
-      { scale: scale.value },
+      { translateX: snap(committedTranslateX.value) },
+      { translateY: snap(committedTranslateY.value) },
+      { scale: committedScale.value },
     ];
   });
   /**


### PR DESCRIPTION
A pan or a pinch rendered a handful of frames where it should have rendered thirty. The cause turned out not to be the drawing, and finding that out closed off most of the obvious fixes.

## What the cost is not

**Not the scene.** Interleaved against each other so host load fell on both arms equally, a pan over the full terminal and the same pan with the entire scene replaced by one 8x8 rectangle:

| arm | median frame | frames rendered |
|---|---|---|
| full terminal | 92.3 ms | 27 over 9 pans |
| single 8x8 rect | 90.9 ms | 27 over 9 pans |

Identical. That closes the whole culling / smaller-chunks / snapshot family: none of them can help, because the rows are not what is being paid for.

**Not a snapshot, either.** I built the canvas-snapshot design first: `makeImageSnapshot()` on gesture start, draw the image under the delta transform for every intermediate frame, swap back on release. It worked (verified by a marker drawn only on that branch, visible mid-pan). Interleaved A/B: ON median 118 ms, OFF median 119 ms. No effect, for the same reason as above. Reverted; it is not in this diff.

**Not the terminal re-laying out.** Instrumented: `handleLayout` fires 0 times during a keyboard or dock animation, `SkiaTerminal` re-renders once, the workspace 1-3 times.

## What the cost is

It runs once per change of the content transform and costs the same whatever is underneath: the reanimated property commit, `JsiRecorder::play()` re-recording the scene, and `requestRedraw` leading to a full-surface clear, a draw and a blocking `eglSwapBuffers` on the Android main thread.

So the question became how often that is asked for. Counted:

- **Unpaced (main): 40 transform writes for a 500 ms pan** -- about 80/s, against a 60 Hz display -- while the app presented **4** frames. Touch sampling was setting the rate, and 36 of those 40 did all of that work for pixels nobody saw.

## The change

The commit runs from a frame callback for the length of a gesture, so it cannot happen more than once per displayed frame however fast the digitizer samples, and it always commits the newest value.

| | writes per 500 ms pan |
|---|---|
| before | 40 |
| after, healthy | 28-29 (the display's own rate) |
| after, host loaded to ~8 fps | 4 (paces itself down) |

Nothing upstream changes: every clamp, decay and hit test still sees every touch. Off a gesture nothing is paced. Registration is on the JS thread deliberately -- calling `setActive` from a worklet throws inside `manageStateFrameCallback` and takes the screen down (measured while building this).

**Honest limit:** I could not demonstrate a wall-clock win. This host ran four emulators from other agents at load 16-58 for the whole session, and absolute frame timings swung from 52 ms to 535 ms between identical runs. Every conclusion above rests on interleaved ratios or on counts, which survive that; the timings do not. What is shown is that the change strictly removes work that could never have reached the screen.

Verified by hand after the change: pinch scales and settles correctly, fling decays and repaints, the grid renders correctly at the new scale, no crash.

## Canvas `opaque`

**Recommendation: keep it.** The reasoning, not a measurement of the flash itself, which needs the maintainer's device:

- `opaque` puts Skia on a `SurfaceView`, and `performDraw` clears to transparent, so a frame that clears but never draws shows as solid black where a `TextureView` would show nothing. That is a real candidate for the reported flash.
- But `OpenGLWindowContext::resize()` -- which presents an undrawn back buffer -- **cannot fire during the keyboard animations**. Instrumented `onSize`: **0 emissions** across IME raise/dismiss and virtual-keyboard show/hide. The Canvas is sized once at mount (411.43 x 914.29 dp) and never resizes; the keyboard moves the content, not the box. It does re-emit on a pane switch, which is where to look.
- Dropping `opaque` measured no cost difference, but the non-opaque path leaks one `android.view.Surface` per Canvas (upstream Shopify/react-native-skia#4045, fix unmerged). Trading a cosmetic device-specific flash for a confirmed per-pane leak is the wrong way round.

Worth doing on the device that shows it: flip `opaque` off temporarily. If the black flash becomes invisible, that confirms the mechanism and the fix can be scoped properly.

## Not a dependency regression

Diffed `v2.10.1...v2.11.2`: 30 commits, 99 files, **exactly two Android files**, neither in the render path. `RNSkOpenGLCanvasProvider.cpp`, `OpenGLWindowContext.h`, `SkiaBaseView/SurfaceView/PictureView.java`, `RNSkPictureView.h`, `Container.native.ts` and `Canvas.tsx` are byte-identical across the range. 2.11.x is in fact better for an animated Group transform than 2.10.1 (#4013 CTM balance, #4021 paint stack, #4016 uniform scale, #4024 anti-aliasing default). No downgrade is warranted.

## iOS

Ran on a dedicated iOS 26.5 simulator against the same gateway, on this branch's JS.

- App pairs, opens the nvim pane, renders correctly; the app's own virtual keyboard opens and closes correctly.
- **0 "Maximum update depth exceeded"** across composer focus/dismiss cycles.
- **Not verified, and I want to be plain about it:** the simulator would not raise the *system* software keyboard -- the hardware keyboard stays attached and I could not detach it on a headless `simctl`-booted device. #20's bug depends on `insets.bottom` alternating during a system keyboard animation, so that specific mechanism was never exercised. iOS should be re-checked on a simulator driven through Simulator.app with the hardware keyboard off, or on a device.

## Gates

`npx tsc --noEmit`, `bun run lint`, `bun run format:check`, `bun test src` (2606 pass, 0 fail). One file changed.

Rebased on `7c214aa`. `use-settled-height.ts` from #23 is untouched -- main's version stands.

Generated with [Claude Code](https://claude.com/claude-code)
