### PR TITLE
fix(files): one files sheet, and a listing that is dropped when it closes

### DIFF
--- a/src/components/artifacts-button.tsx
+++ b/src/components/artifacts-button.tsx
@@ -65,7 +65,24 @@ export function ArtifactsButton({
       onPress={() => {
         // The sheet would otherwise open behind the on-screen keyboard.
         Keyboard.dismiss();
-        router.push({
+        // `navigate`, not `push`, and the difference is the whole of this bug.
+        //
+        // A push always adds a route. The sheet takes a moment to arrive -- the
+        // route mounts, the form sheet animates up, and against a real gateway
+        // it then sits on a header with nothing under it while the listing is
+        // asked for -- and for that whole moment this button is still the thing
+        // under the reader's thumb. A second tap in there pushed a second files
+        // sheet, identical to the first and equally empty, so the two were
+        // indistinguishable: the close button dismissed the top one and the
+        // reader was left looking at the same loading sheet they had just
+        // closed. The sheet was never stuck. There were two of them.
+        //
+        // `navigate` goes to the `/artifacts` route already on the stack and
+        // updates its params instead of stacking a twin, so the second tap is
+        // the no-op the reader meant it to be. Nothing here debounces or
+        // disables the button: a control that stops answering is its own bug,
+        // and the rule this needs is about the stack, not about time.
+        router.navigate({
           pathname: '/artifacts',
           params: { sessionId, tabId, label },
         } as unknown as Href);

--- a/src/components/asset-viewer.tsx
+++ b/src/components/asset-viewer.tsx
@@ -71,7 +71,12 @@ function EncryptedImageViewer({ asset, onClose }: { asset: SessionAsset; onClose
   const onCloseRef = useLatestRef(onClose);
   useEffect(() => {
     let active = true;
-    readAssetImageSource(asset)
+    // The same bargain the text read below makes, and for the same reason: a
+    // picture is downloaded whole before the lightbox has anything to show, so
+    // closing the viewer while it is coming has to stop the download rather
+    // than let it finish into a screen that has gone.
+    const controller = new AbortController();
+    readAssetImageSource(asset, { signal: controller.signal })
       .then((next) => {
         if (active) setSource(next);
       })
@@ -80,6 +85,7 @@ function EncryptedImageViewer({ asset, onClose }: { asset: SessionAsset; onClose
       });
     return () => {
       active = false;
+      controller.abort();
     };
   }, [asset, onCloseRef]);
   if (!source) {

--- a/src/components/session-artifacts.tsx
+++ b/src/components/session-artifacts.tsx
@@ -268,11 +268,36 @@ export function SessionArtifacts({
   const [atEnd, setAtEnd] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
 
+  /**
+   * The listing in flight, and the only one whose answer is wanted.
+   *
+   * Exactly one question is on the table at a time: the chip that is lit, the
+   * window that has been asked for, the tab that is selected. Asking a new one
+   * -- or leaving the sheet entirely -- makes the old answer worthless, and an
+   * answer that is worthless must not be allowed to land. Two things follow
+   * from that, and this ref is how both are said:
+   *
+   * The request is *cancelled*, not merely ignored. A gateway that has gone
+   * quiet is answered for by a fifteen-second budget, and until that budget
+   * runs out an abandoned listing holds a socket open for a screen that is no
+   * longer there.
+   *
+   * And its `setState` calls are dropped. Nothing about a request guarantees
+   * the order its answer arrives in, so the slower of two overlapping loads
+   * could land last and repaint the sheet with the question before the one the
+   * reader is looking at -- files for the chip they just left, and `loading`
+   * cleared while the listing they actually asked for is still on the wire.
+   */
+  const inFlightRef = useRef<AbortController | null>(null);
+
   // Keyed on the chip and on the window as well as the session: the filter is
   // the gateway's job now, so changing it is a new question to ask rather than
   // a narrower way of reading the answer already in hand, and so is asking for
   // more of the listing.
   const load = useCallback(async () => {
+    inFlightRef.current?.abort();
+    const controller = new AbortController();
+    inFlightRef.current = controller;
     // No tab to scope to yet -- the first render or two, before the server
     // screen's selection has settled -- so there is no request worth making.
     // An empty id would only ever hit a URL with an empty segment. Showing
@@ -293,7 +318,9 @@ export function SessionArtifacts({
       const page = await listSessionAssets(sessionId, tabId, {
         kind: FILTER_KINDS[filter],
         limit: windowSize,
+        signal: controller.signal,
       });
+      if (controller.signal.aborted) return;
       setAssets(page);
       // A window that came back with room to spare is the whole listing, and a
       // window at the endpoint's ceiling is as much of it as can be asked for.
@@ -306,6 +333,11 @@ export function SessionArtifacts({
       setAvailable(true);
       setError(null);
     } catch (failure) {
+      // A listing this sheet itself gave up on is not a failure to report. It
+      // usually surfaces as the abort, but a request cancelled between the
+      // headers and the body can also come back as the budget's own timeout,
+      // so the controller is what decides -- not the shape of the error.
+      if (controller.signal.aborted) return;
       setAssets([]);
       // A window that failed says nothing about whether a wider one would, but
       // it must not leave the list asking for one on every scroll.
@@ -317,13 +349,23 @@ export function SessionArtifacts({
       }
       setError(describeGatewayFailure(failure, t`Could not load files.`).message);
     } finally {
-      setLoading(false);
-      setLoadingMore(false);
+      // Not the abandoned load's business either. Clearing these would hand the
+      // spinner belonging to the request still on the wire to the one that has
+      // already been given up on.
+      if (!controller.signal.aborted) {
+        setLoading(false);
+        setLoadingMore(false);
+      }
     }
   }, [filter, sessionId, t, windowSize, tabId]);
 
   useEffect(() => {
     void load();
+    // Leaving is a cancellation like any other. The sheet is a route, so the
+    // reader closing it -- by the button, by the swipe, or by the Android back
+    // gesture -- unmounts this component while the listing may still be in
+    // flight, and the request has no reason to finish.
+    return () => inFlightRef.current?.abort();
   }, [load, t]);
 
   /**

--- a/src/lib/__tests__/request-budget.test.ts
+++ b/src/lib/__tests__/request-budget.test.ts
@@ -115,6 +115,33 @@ describe('the body is inside the budget, not outside it', () => {
     expect(budget.signal.aborted).toBe(true);
   });
 
+  // The files sheet, the document viewer and the image viewer all hand their
+  // own signal down and then close on the reader. Closing has to reach the
+  // request even once the headers have landed and the body is on the wire --
+  // which is the half of the request the budget exists to cover, and the half
+  // a caller's cancellation is easiest to lose in.
+  test('a caller that gives up while the body is arriving aborts the request', async () => {
+    const caller = new AbortController();
+    // A budget far longer than this test waits, so what settles the body can
+    // only be the cancellation and never the clock.
+    const budget = startRequestBudget(BUDGET_MS * 40, 'gone', caller.signal);
+    const response = withBodyDeadline(
+      fake(
+        () =>
+          new Promise<string>((_, reject) => {
+            budget.signal.addEventListener('abort', () => reject(new Error('Aborted')));
+          })
+      ),
+      budget
+    );
+
+    const body = response.text();
+    caller.abort();
+
+    await expect(body).rejects.toThrow('Aborted');
+    expect(budget.signal.aborted).toBe(true);
+  });
+
   test('a body that stalls after the headers is still caught by json()', async () => {
     const budget = startRequestBudget(BUDGET_MS, 'The server stopped responding.');
     const response = withBodyDeadline(

--- a/src/lib/gateway-client.ts
+++ b/src/lib/gateway-client.ts
@@ -877,7 +877,18 @@ function gatewayAuthHeaders(): Record<string, string> {
 export async function listSessionAssets(
   sessionId: string,
   tabId: string,
-  options: { since?: number; limit?: number; kind?: readonly AssetKind[] } = {}
+  options: {
+    since?: number;
+    limit?: number;
+    kind?: readonly AssetKind[];
+    /**
+     * The caller's own cancellation. A files sheet that closes, or a chip that
+     * changes the question, abandons the listing it no longer wants: without
+     * this the request ran to completion into a screen that had gone, holding a
+     * socket for nobody, and its answer could still land after a newer one.
+     */
+    signal?: AbortSignal;
+  } = {}
 ): Promise<SessionAsset[]> {
   if (isDemoActive()) {
     const assets = demoSessionAssets();
@@ -902,19 +913,20 @@ export async function listSessionAssets(
   const kind = assetKindQuery(options.kind);
   if (kind) query.push(`kind=${kind}`);
 
-  return requestSessionAssets(sessionId, tabId, query);
+  return requestSessionAssets(sessionId, tabId, query, options.signal);
 }
 
 async function requestSessionAssets(
   sessionId: string,
   tabId: string,
-  query: string[]
+  query: string[],
+  signal?: AbortSignal
 ): Promise<SessionAsset[]> {
   const response = await gatewayFetch(
     gatewayUrl(
       `/api/sessions/${encodeURIComponent(sessionId)}/tabs/${encodeURIComponent(tabId)}/assets?${query.join('&')}`
     ),
-    { headers: gatewayAuthHeaders() }
+    { headers: gatewayAuthHeaders(), signal }
   );
   if (!response.ok) {
     throw new Error(`HTTP ${response.status}: ${await response.text()}`);
@@ -1028,12 +1040,15 @@ export function assetImageSource(asset: SessionAsset): AssetImageSource | null {
 }
 
 /** Download and authenticate image bytes before handing a data URI to the decoder. */
-export async function readAssetImageSource(asset: SessionAsset): Promise<AssetImageSource> {
+export async function readAssetImageSource(
+  asset: SessionAsset,
+  options: { signal?: AbortSignal } = {}
+): Promise<AssetImageSource> {
   const direct = assetImageSource(asset);
   if (direct) return direct;
   const response = await encryptedGatewayFetch(
     assetContentUrl(asset.id),
-    { headers: gatewayAuthHeaders() },
+    { headers: gatewayAuthHeaders(), signal: options.signal },
     ASSET_CONTENT_TIMEOUT_MS
   );
   if (!response.ok) throw new Error(`HTTP ${response.status}: ${await response.text()}`);


### PR DESCRIPTION
The maintainer, on Android against a live gateway: opening Files leaves the sheet on its loading state and the close button does nothing.

The sheet was never stuck. There were two of them.

## What it was

`ArtifactsButton` pushed the `/artifacts` route on every tap, and a push always adds a route. The sheet takes a moment to arrive — the route mounts, the form sheet animates up, and against a real gateway it then sits on a header with nothing under it while the listing is asked for. For that whole moment the button is still the thing under the reader's thumb. A second tap in there pushed a *second* files sheet, identical to the first and equally empty. Closing the top one revealed the same loading sheet the reader had just closed, so the close button read as broken.

That is why demo mode could never show it: the demo listing is in hand before the sheet finishes animating, so the window in which the button is still exposed and the sheet still says nothing is about one frame wide. Against a gateway on the other side of a Tailscale hop it is a second or more, and a human double tap is 150 ms.

## Reproduction

Own gateway instance, not the maintainer's: `muqun-gateway` v0.8.0 built from `main`, its own config and state directories under a scratch path, listening on `:23971`, tmux backend on a private socket, a window whose cwd holds four files, transport encryption on. Paired to an emulator over `adb reverse`. `SIGSTOP` on the gateway is what holds the sheet in its loading state long enough to photograph — the listing has a fifteen-second budget, so a live gateway that is merely slow gives the same state for a shorter time.

**Before** — `adb shell "input tap 208 2206; input tap 208 2206"`, one press of the close button, and the sheet is still there (the second sheet, mid-load; it went on to show the timeout):

<img src="https://raw.githubusercontent.com/osuki-dev/muqun-app/evidence/files-sheet-dismiss/android-before-stuck.png" width="300">

A second press of the same button returned to the terminal. Two presses, two sheets.

**After** — three taps in one `adb shell`, one press of the close button, back on the terminal:

<img src="https://raw.githubusercontent.com/osuki-dev/muqun-app/evidence/files-sheet-dismiss/android-after-dismissed.png" width="300">

iOS, same instance, same frozen gateway. The stuck loading sheet, and one press of the close button after three rapid taps:

<img src="https://raw.githubusercontent.com/osuki-dev/muqun-app/evidence/files-sheet-dismiss/ios-before-stuck.png" width="300"> <img src="https://raw.githubusercontent.com/osuki-dev/muqun-app/evidence/files-sheet-dismiss/ios-after-dismissed.png" width="300">

The iOS simulator's tap cadence under automation is slower than the sheet's presentation, so the duplicate could not be provoked there by script; the code path is the same one, and the fixed behaviour is what the second shot shows.

## The fix

`navigate`, not `push`. It goes to the `/artifacts` route already on the stack and updates its params instead of stacking a twin, so the second tap is the no-op the reader meant it to be. Nothing debounces or disables the button: a control that stops answering is its own bug, and the rule this needs is about the stack, not about time.

## The other half: closing has to end the load

Whatever put the reader in front of a loading sheet, leaving it should end the request. The sheet had no cancellation at all.

Each load now owns an `AbortController`. Asking a new question — a chip, a wider window, another tab — cancels the last one, and unmounting cancels whatever is in flight. An abandoned load's answer is never applied: not its rows, not its error, not its `loading` flag.

Both halves of that matter. Without the cancel, a closed sheet held a socket for up to the fifteen-second budget. Without the drop, two overlapping loads could land out of order — the slower one repainting the sheet with the chip the reader had already left, and clearing `loading` while the listing they actually asked for was still on the wire.

`listSessionAssets` takes a `signal` for this; `request-budget` already chains a caller's signal onto the transport, so it is a real cancellation rather than an ignored result.

The encrypted image viewer gets the same treatment. It already ignored a late result through its `active` flag; now it stops the download too, the way the text read beside it always has.

### Everything else about dismissal, checked

The invariant is that the reader can leave regardless of what the sheet is doing. Against the frozen gateway, on both platforms: the close button dismisses a loading sheet, the Android back gesture dismisses it, the document viewer's own close and back work while its skeleton is up, and the image lightbox's close chip works while its spinner is up. The Android form sheet does not dismiss on a backdrop tap — that is react-native-screens' native behaviour for every sheet in the app, unchanged here.

## Test

`request-budget` is where the cancellation contract actually lives, and the half this fix leans on was unproven: a caller that gives up *after the headers have landed*, while the body is still arriving. The new case holds that down.

## Gates

```
npx tsc --noEmit      clean
bun run lint          clean
bun run format:check  clean
bun test src          2607 pass, 2 skip, 0 fail (2609 across 99 files)
```

`bash scripts/e2e.sh --smoke` did not complete here, and not for a reason in this change: the flow's `clearState` restarts the app cold, and this sandbox's Metro was failing the app's async route-chunk fetches under load, so `demo-tour` timed out on the splash screen before its first assertion. The same build drove both devices by hand for the runs above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
