### PR TITLE
chore: ignore the pulled store config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,7 @@ example
 # Scratch renders the maintainers look at while designing. They were committed
 # by accident; they are working files, not source.
 /design-preview/
+
+# EAS Metadata: pulled from App Store Connect by `eas metadata:pull`, edited
+# locally, pushed with `eas metadata:push`. Store data, not source.
+/store.config.json


### PR DESCRIPTION
`eas metadata:pull` writes `store.config.json` beside the already-ignored `store/` screenshot tree. It is App Store Connect data pulled to be edited and pushed back, not source; it carries release notes and listing URLs that should never be frozen in a commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)