### PR TITLE
feat(terminal): a touch is the program's input when the program asked for one

### DIFF
--- a/src/components/skia-terminal.tsx
+++ b/src/components/skia-terminal.tsx
@@ -83,6 +83,18 @@ import {
   type TerminalHeadRecording,
 } from '@/terminal/chunk-plan';
 import { terminalPaneTheme, type TerminalTheme } from '@/terminal/palette';
+import {
+  packTerminalTouchModes,
+  terminalTouchCellAt,
+  terminalTouchDragBytes,
+  terminalTouchDragTarget,
+  terminalTouchLayer,
+  terminalTouchPressBytes,
+  terminalTouchPressDrags,
+  terminalTouchReleaseBytes,
+  terminalTouchTapBytes,
+  type TerminalTouchModes,
+} from '@/terminal/touch-input';
 import { readTerminalSurface } from '@/terminal/surface';
 import { useTerminalTheme, useThemePack } from '@/hooks/use-theme-pack';
 import {
@@ -305,6 +317,7 @@ export function SkiaTerminal({
   onTwoFingerSwipe,
   screenFocused = true,
   paneColumns,
+  touchInput,
 }: {
   /**
    * The pane's rendered text, parsed here on every change. What the gateway
@@ -409,6 +422,22 @@ export function SkiaTerminal({
    * leaves the parser on that inference exactly as before.
    */
   paneColumns?: number;
+  /**
+   * The far side's input channel, for a pane whose program has asked to hear
+   * about the pointer. Left out by a caller that has no such channel -- the
+   * gateway path, where the output arrives already rendered and the modes a
+   * program set are not in it -- and leaving it out is exactly the behaviour
+   * this component had before: every touch is muqun's own.
+   *
+   * `modes` is the emulator's live answer, re-read on every frame it publishes;
+   * `rows` is the PTY's row count, which is what turns a row of the drawn
+   * frame into a row of the live screen (see `terminalTouchCellAt`).
+   */
+  touchInput?: {
+    modes: TerminalTouchModes;
+    rows: number;
+    send: (bytes: Uint8Array) => void;
+  };
 }) {
   const fontSize = terminalFontSize(textSize);
   const theme = useThemeTokens();
@@ -1333,6 +1362,322 @@ export function SkiaTerminal({
     return () => selectionAutoScrollFrame.setActive(false);
   }, [selectionAutoScrollFrame, selectionDragging]);
 
+  /*
+    Touch as the program's input, when the program has said it wants it.
+
+    Three layers, and `@/terminal/touch-input` has the argument for them: a
+    program reporting the mouse gets clicks and the wheel, a program on the
+    alternate screen that is not gets arrow keys, and everything else keeps the
+    scrollback pan this pane has always had. Two fingers are always the
+    scrollback, in every layer.
+
+    The modes cross to the UI thread as one packed integer rather than as an
+    object, because the pan reads them on every touch sample to decide whether
+    it may move the transform at all -- a decision that cannot wait for a hop
+    to JS without the first frames of every drag scrolling the wrong thing.
+    Zero is "no channel and no modes", which is the gateway path and which
+    resolves to the scrollback layer, so a caller that passes no `touchInput`
+    gets exactly the component that existed before this.
+  */
+  const touchModeBits = useSharedValue(0);
+  const touchScreenRows = useSharedValue(0);
+  const touchInputRef = useLatestRef(touchInput);
+  const touchModes = touchInput?.modes;
+  const touchRows = touchInput?.rows ?? 0;
+  useEffect(() => {
+    touchModeBits.value = touchModes ? packTerminalTouchModes(touchModes) : 0;
+    touchScreenRows.value = touchRows;
+  }, [touchModeBits, touchModes, touchRows, touchScreenRows]);
+
+  /**
+   * The finger's own accumulator, in cells rather than in points.
+   *
+   * `travel` is how far the drag has come from where the program took it over,
+   * truncated to whole cells; `emitted` is how much of that has already gone
+   * out. The frame callback below sends the difference and moves `emitted` up
+   * to `travel`, which is the whole of the coalescing: a flick that crosses
+   * forty rows in one frame is one write of forty wheel events, not forty
+   * writes, and a thumb that wanders inside one cell writes nothing at all.
+   *
+   * The divisor is `lineHeight * scale`, not `lineHeight`: a cell on the glass
+   * is as tall as the current zoom makes it, and a drag over a pinched-in pane
+   * must cross the rows the reader can see crossing.
+   */
+  const programDragActive = useSharedValue(false);
+  const programDragHeld = useSharedValue(false);
+  const programBaseX = useSharedValue(0);
+  const programBaseY = useSharedValue(0);
+  const programTravelRows = useSharedValue(0);
+  const programTravelColumns = useSharedValue(0);
+  const programEmittedRows = useSharedValue(0);
+  const programEmittedColumns = useSharedValue(0);
+  const programCellRow = useSharedValue(1);
+  const programCellColumn = useSharedValue(1);
+  /**
+   * Set when a drag is live but its origin is not, which is the one case a long
+   * press makes: the press arms the button from a recogniser that knows where
+   * the finger is but not how far the pan thinks it has come, and only the pan
+   * can supply that. The next update takes its own translation as the origin.
+   */
+  const programRebase = useSharedValue(false);
+
+  const sendTouchBytes = useCallback(
+    (bytes: Uint8Array | null) => {
+      if (bytes) touchInputRef.current?.send(bytes);
+    },
+    [touchInputRef]
+  );
+
+  const emitProgramDrag = useCallback(
+    (drag: { row: number; column: number; rows: number; columns: number; held: boolean }) => {
+      const input = touchInputRef.current;
+      if (!input) return;
+      sendTouchBytes(
+        terminalTouchDragBytes(
+          {
+            cell: { row: drag.row, column: drag.column },
+            rows: drag.rows,
+            columns: drag.columns,
+            held: drag.held,
+          },
+          packTerminalTouchModes(input.modes)
+        )
+      );
+    },
+    [sendTouchBytes, touchInputRef]
+  );
+
+  const emitProgramPress = useCallback(
+    (cell: { row: number; column: number }) => {
+      const input = touchInputRef.current;
+      if (!input) return;
+      sendTouchBytes(terminalTouchPressBytes(cell, packTerminalTouchModes(input.modes)));
+      void feedback('selection');
+    },
+    [sendTouchBytes, touchInputRef]
+  );
+
+  const emitProgramRelease = useCallback(
+    (cell: { row: number; column: number }) => {
+      const input = touchInputRef.current;
+      if (!input) return;
+      sendTouchBytes(terminalTouchReleaseBytes(cell, packTerminalTouchModes(input.modes)));
+    },
+    [sendTouchBytes, touchInputRef]
+  );
+
+  const emitProgramTap = useCallback(
+    (cell: { row: number; column: number }) => {
+      const input = touchInputRef.current;
+      if (!input) return;
+      sendTouchBytes(terminalTouchTapBytes(cell, packTerminalTouchModes(input.modes)));
+      void feedback('selection');
+    },
+    [sendTouchBytes, touchInputRef]
+  );
+
+  /**
+   * The cell under a viewport point, as the program spells one.
+   *
+   * Two steps: the same hit test the selection uses, which answers in rows of
+   * the *drawing*, and then the conversion to rows of the live screen. On the
+   * main screen those differ by the whole scrollback above, which is why a
+   * click in a mouse-aware pager was landing hundreds of rows off before this
+   * existed.
+   */
+  const programCellAt = useCallback(
+    (x: number, y: number) => {
+      'worklet';
+      const hit = cellAtViewportPoint(
+        x,
+        y,
+        {
+          cellWidth,
+          lineHeight,
+          scale: scale.value,
+          translateX: translateX.value,
+          translateY: translateY.value + pullDistance.value,
+          horizontalPadding,
+          verticalPadding,
+        },
+        gridRows,
+        gridColumns
+      );
+      return terminalTouchCellAt({
+        row: hit.row,
+        column: hit.column,
+        lineCount: gridRows,
+        screenRows: touchScreenRows.value,
+        columns: gridColumns,
+      });
+    },
+    [
+      cellWidth,
+      gridColumns,
+      gridRows,
+      lineHeight,
+      pullDistance,
+      scale,
+      touchScreenRows,
+      translateX,
+      translateY,
+    ]
+  );
+
+  const beginProgramDrag = useCallback(
+    (event: { x: number; y: number; translationX: number; translationY: number }) => {
+      'worklet';
+      const cell = programCellAt(event.x, event.y);
+      programCellRow.value = cell.row;
+      programCellColumn.value = cell.column;
+      programBaseX.value = event.translationX;
+      programBaseY.value = event.translationY;
+      programTravelRows.value = 0;
+      programTravelColumns.value = 0;
+      programEmittedRows.value = 0;
+      programEmittedColumns.value = 0;
+      programRebase.value = false;
+      programDragActive.value = true;
+    },
+    [
+      programBaseX,
+      programBaseY,
+      programCellAt,
+      programCellColumn,
+      programCellRow,
+      programDragActive,
+      programEmittedColumns,
+      programEmittedRows,
+      programRebase,
+      programTravelColumns,
+      programTravelRows,
+    ]
+  );
+
+  const trackProgramDrag = useCallback(
+    (event: { x: number; y: number; translationX: number; translationY: number }) => {
+      'worklet';
+      if (programRebase.value) {
+        programRebase.value = false;
+        programBaseX.value = event.translationX;
+        programBaseY.value = event.translationY;
+        programTravelRows.value = 0;
+        programTravelColumns.value = 0;
+        programEmittedRows.value = 0;
+        programEmittedColumns.value = 0;
+      }
+      const zoom = scale.value > 0 ? scale.value : 1;
+      const rowPitch = lineHeight * zoom;
+      const columnPitch = cellWidth * zoom;
+      programTravelRows.value =
+        rowPitch > 0 ? Math.trunc((event.translationY - programBaseY.value) / rowPitch) : 0;
+      programTravelColumns.value =
+        columnPitch > 0 ? Math.trunc((event.translationX - programBaseX.value) / columnPitch) : 0;
+      const cell = programCellAt(event.x, event.y);
+      programCellRow.value = cell.row;
+      programCellColumn.value = cell.column;
+    },
+    [
+      cellWidth,
+      lineHeight,
+      programBaseX,
+      programBaseY,
+      programCellAt,
+      programCellColumn,
+      programCellRow,
+      programEmittedColumns,
+      programEmittedRows,
+      programRebase,
+      programTravelColumns,
+      programTravelRows,
+      scale,
+    ]
+  );
+
+  /**
+   * Everything the finger has crossed since the last frame, in one write.
+   *
+   * A frame callback rather than the gesture callback itself, for the reason
+   * the transform commit above is one: touch arrives faster than the display,
+   * and a PTY handed a wheel event per touch sample is a program redrawing
+   * long after the finger has stopped. Registered and unregistered from the JS
+   * thread only -- `setActive` from a worklet corrupts reanimated's registry;
+   * the note on `gestureCommitFrame` has the measurement.
+   */
+  const touchInputFrame = useFrameCallback(() => {
+    'worklet';
+    if (!programDragActive.value) return;
+    const rows = programTravelRows.value - programEmittedRows.value;
+    const columns = programTravelColumns.value - programEmittedColumns.value;
+    if (rows === 0 && columns === 0) return;
+    programEmittedRows.value = programTravelRows.value;
+    programEmittedColumns.value = programTravelColumns.value;
+    scheduleOnRN(emitProgramDrag, {
+      row: programCellRow.value,
+      column: programCellColumn.value,
+      rows,
+      columns,
+      held: programDragHeld.value,
+    });
+  }, false);
+  const [programDragging, setProgramDragging] = useState(false);
+  useAnimatedReaction(
+    () => programDragActive.value,
+    (active, wasActive) => {
+      if (active !== wasActive) scheduleOnRN(setProgramDragging, active);
+    }
+  );
+  useEffect(() => {
+    touchInputFrame.setActive(programDragging);
+    return () => touchInputFrame.setActive(false);
+  }, [programDragging, touchInputFrame]);
+
+  /**
+   * The end of a drag the program owned.
+   *
+   * The tail matters: the callback above stops on the frame the finger leaves,
+   * and whatever cells were crossed after its last run would otherwise be
+   * dropped -- which on a short flick is the whole gesture. A held drag also
+   * owes the far side its release, and owes it exactly once however many
+   * recognisers finalize.
+   */
+  const endProgramDrag = useCallback(() => {
+    'worklet';
+    if (!programDragActive.value) return;
+    const rows = programTravelRows.value - programEmittedRows.value;
+    const columns = programTravelColumns.value - programEmittedColumns.value;
+    programEmittedRows.value = programTravelRows.value;
+    programEmittedColumns.value = programTravelColumns.value;
+    if (rows !== 0 || columns !== 0) {
+      scheduleOnRN(emitProgramDrag, {
+        row: programCellRow.value,
+        column: programCellColumn.value,
+        rows,
+        columns,
+        held: programDragHeld.value,
+      });
+    }
+    if (programDragHeld.value) {
+      scheduleOnRN(emitProgramRelease, {
+        row: programCellRow.value,
+        column: programCellColumn.value,
+      });
+    }
+    programDragHeld.value = false;
+    programDragActive.value = false;
+  }, [
+    emitProgramDrag,
+    emitProgramRelease,
+    programCellColumn,
+    programCellRow,
+    programDragActive,
+    programDragHeld,
+    programEmittedColumns,
+    programEmittedRows,
+    programTravelColumns,
+    programTravelRows,
+  ]);
+
   const panGesture = Gesture.Pan()
     .hitSlop({ left: -32 })
     .minDistance(2)
@@ -1343,7 +1688,14 @@ export function SkiaTerminal({
       // head start the JS thread needs to have held the frame before the first
       // pixel of movement. Nothing else happens here: a touch that turns out to
       // be a tap costs the pane one held refresh, released by onFinalize.
-      gesturing.value = true;
+      //
+      // Not in the two program layers. The freeze exists so a frame swap cannot
+      // land under a moving finger, and it is exactly wrong here: in those
+      // layers the drag IS what is changing the frame, and holding the picture
+      // would mean the reader drags through vim and sees nothing move until
+      // they lift. A two-finger drag in those layers is the scrollback again
+      // and takes the freeze back below.
+      if (terminalTouchLayer(touchModeBits.value) === 'scrollback') gesturing.value = true;
     })
     .onStart((event) => {
       // Selecting owns the finger. The transform is not touched at all -- not
@@ -1355,6 +1707,18 @@ export function SkiaTerminal({
         selectionDragActive.value = true;
         scheduleOnRN(startSelectionDrag);
         gesturing.value = true;
+        return;
+      }
+      // The program's finger. Nothing about the transform is touched -- not
+      // the running decay, which a reader who flicked and then dragged still
+      // wants to watch coast out, and not the follow ease. `gestureStartX/Y`
+      // are still recorded, because a second finger landing mid-drag hands the
+      // gesture back to the pan and it has to have somewhere to start from.
+      if (terminalTouchDragTarget(touchModeBits.value, event.numberOfPointers) === 'program') {
+        gestureStartX.value = translateX.value;
+        gestureStartY.value = translateY.value;
+        panAxis.value = AXIS_UNDECIDED;
+        beginProgramDrag(event);
         return;
       }
       cancelAnimation(translateX);
@@ -1420,6 +1784,25 @@ export function SkiaTerminal({
         });
         return;
       }
+      if (terminalTouchDragTarget(touchModeBits.value, event.numberOfPointers) === 'program') {
+        // A drag that began as a pan and is only now the program's -- the mode
+        // flipped under the finger, which `vim` does the instant it starts.
+        if (!programDragActive.value) beginProgramDrag(event);
+        else trackProgramDrag(event);
+        return;
+      }
+      if (programDragActive.value) {
+        // A second finger landed. The scrollback takes the gesture back, and
+        // has to take it back from where the content actually is: the pan is
+        // driven by `event.translationX/Y`, which has been accumulating for the
+        // whole of the program's part of this drag and would otherwise jump the
+        // content by all of it on the very next frame.
+        endProgramDrag();
+        gestureStartX.value = translateX.value - event.translationX;
+        gestureStartY.value = translateY.value - event.translationY;
+        panAxis.value = AXIS_UNDECIDED;
+        gesturing.value = true;
+      }
       // See `terminalPullOvershoot`: how far past the top stop this drag is
       // asking to go, independent of where the gesture itself started.
       const minY = animatedVisibleHeight.value - contentHeight * scale.value;
@@ -1483,6 +1866,15 @@ export function SkiaTerminal({
       }
     })
     .onEnd((event) => {
+      // No momentum for a program drag either, and for a sharper reason than
+      // the selection's: a decay would keep posting wheel events into a PTY
+      // for half a second after the finger left, and the program on the far
+      // side would still be redrawing when the reader reached for the next
+      // thing. The tail the frame callback had not yet sent goes out here.
+      if (programDragActive.value) {
+        endProgramDrag();
+        return;
+      }
       // No momentum for a selection: the far end is where the finger left it,
       // and a highlight that coasted on past would be a copy the reader did not
       // ask for.
@@ -1551,6 +1943,10 @@ export function SkiaTerminal({
       }
     })
     .onFinalize(() => {
+      // Idempotent, and reached from here as well as from `onEnd` because a
+      // cancelled drag -- a call arriving, the app going to the background --
+      // still owes the far side the release of a button it was told was down.
+      endProgramDrag();
       pullDistance.value = withTiming(0, timing('short'));
       panAxis.value = AXIS_UNDECIDED;
       gesturing.value = false;
@@ -1578,9 +1974,14 @@ export function SkiaTerminal({
       gestureStartY.value = translateY.value;
       focalX.value = event.focalX;
       focalY.value = event.focalY;
-      gesturing.value = true;
       // Watching, not zooming. Android begins this recogniser on the first
-      // pointer of any drag, so `began` is where a plain scroll lives too.
+      // pointer of any drag, so `began` is where a plain scroll lives too --
+      // and that is why the freeze is not taken here in the two program layers.
+      // One finger on Android reaches this line, and freezing the picture for
+      // it would hold vim's own redraw off the screen for the whole of a drag
+      // that is meant to be driving it. A real pinch takes the freeze in
+      // `onStart` below, which is the edge that only a zoom crosses.
+      if (terminalTouchLayer(touchModeBits.value) === 'scrollback') gesturing.value = true;
       pinchPhase.value = 'began';
     })
     // The recogniser has decided the two fingers really are changing the span:
@@ -1588,6 +1989,7 @@ export function SkiaTerminal({
     // `longPressArms` below, which must not let a long press win a race a
     // pinch already started.
     .onStart(() => {
+      gesturing.value = true;
       pinchPhase.value = 'active';
     })
     .onUpdate((event) => {
@@ -1686,6 +2088,16 @@ export function SkiaTerminal({
         clearSelection();
         return;
       }
+      // A program reporting the mouse gets the tap, and gets it before the link
+      // test rather than after. The links this pane draws are found by pattern
+      // in whatever text is on screen, and inside a full-screen program that
+      // text is a file being edited: a tap on a path in a vim buffer means
+      // "put the cursor here", never "open this". Nor does the keyboard fall,
+      // for the same reason -- the program asked for the click.
+      if (terminalTouchLayer(touchModeBits.value) === 'mouse') {
+        emitProgramTap(programCellAt(event.x, event.y));
+        return;
+      }
       const link = linkAtViewportPoint(
         links,
         event.x,
@@ -1768,6 +2180,27 @@ export function SkiaTerminal({
       ) {
         return;
       }
+      // Under `?1002` this press is the program's, not a selection: see
+      // `terminalTouchPressDrags`. The button goes down here and the pan, which
+      // is simultaneous with this and has not committed to an axis while the
+      // finger was still, carries the motion from wherever it goes next.
+      if (terminalTouchPressDrags(touchModeBits.value)) {
+        const target = programCellAt(event.x, event.y);
+        programCellRow.value = target.row;
+        programCellColumn.value = target.column;
+        programDragHeld.value = true;
+        programTravelRows.value = 0;
+        programTravelColumns.value = 0;
+        programEmittedRows.value = 0;
+        programEmittedColumns.value = 0;
+        // Active straight away, so a press that is lifted without ever moving
+        // still owes -- and sends -- its release. The origin arrives with the
+        // pan's next update; see `programRebase`.
+        programRebase.value = true;
+        programDragActive.value = true;
+        scheduleOnRN(emitProgramPress, { row: target.row, column: target.column });
+        return;
+      }
       const cell = cellAtViewportPoint(
         event.x,
         event.y,
@@ -1792,6 +2225,15 @@ export function SkiaTerminal({
       // side. The cell above is a usable selection on its own, so the highlight
       // is up on this frame and the widening lands a tick later.
       scheduleOnRN(beginSelection, cell);
+    })
+    // A press that armed the program's button and was then lifted without ever
+    // travelling far enough to activate the pan never reaches the pan's own
+    // finalizer, and the button would stay down. Only what this press armed,
+    // though: the recogniser also finalizes by FAILING, which is what an
+    // ordinary wheel drag does to it a few pixels in, and ending that drag from
+    // here would cut it in half.
+    .onFinalize(() => {
+      if (programDragHeld.value) endProgramDrag();
     });
 
   // One combined transform on a single group rather than a translate group

--- a/src/components/ssh-terminal-workspace.tsx
+++ b/src/components/ssh-terminal-workspace.tsx
@@ -24,6 +24,11 @@ import { PressableScale } from '@/components/pressable-scale';
 import { ScreenHeader } from '@/components/screen-header';
 import { SshHostKeyDialog, SshKeyboardInteractiveDialog } from '@/components/ssh-host-key-dialog';
 import { SkiaTerminal, type TerminalCellMetrics } from '@/components/skia-terminal';
+import {
+  TERMINAL_TOUCH_MODES_OFF,
+  terminalTouchModesOf,
+  type TerminalTouchModes,
+} from '@/terminal/touch-input';
 import { TerminalBoundary } from '@/components/terminal-boundary';
 import { TerminalComposer } from '@/components/terminal-composer';
 import { VirtualKeyboard } from '@/components/virtual-keyboard';
@@ -212,6 +217,15 @@ export function SshTerminalWorkspace({ hostId }: { hostId: string }) {
   const [cellMetrics, setCellMetrics] = useState<TerminalCellMetrics | null>(null);
   /** The emulator's alternate-screen flag, as of the last published frame. */
   const [alternateScreen, setAlternateScreen] = useState(false);
+  /**
+   * The modes the terminal's touch translation reads, as of the last published
+   * frame. A separate piece of state from `alternateScreen` above, and a
+   * separate one from the emulator's own live `modes` object, because this one
+   * has to be a NEW object whenever it differs: the terminal takes it as a prop
+   * and mirrors it onto the UI thread, and a live object mutated in place would
+   * never tell React there was anything to mirror.
+   */
+  const [touchModes, setTouchModes] = useState<TerminalTouchModes>(TERMINAL_TOUCH_MODES_OFF);
   /** The editor verdict, latched per alternate screen -- see `sshEditorPane`. */
   const [editorPane, setEditorPane] = useState(false);
   // The key row's toggle swaps the composer for the app's own keyboard, the
@@ -398,6 +412,27 @@ export function SshTerminalWorkspace({ hostId }: { hostId: string }) {
   );
   const gridRef = useLatestRef(grid);
 
+  /**
+   * The terminal's way to reach the shell with a finger.
+   *
+   * Held stable across renders, because the component mirrors it onto the UI
+   * thread and a new object every render would mean a new mirror every render.
+   * `send` is reached through a ref for the same reason -- it closes over the
+   * connection status and is therefore a different function on each pass --
+   * and it goes out with `stickBottom: false`, which is the whole reason
+   * `send` grew an option: a wheel event is not a keystroke and must not haul
+   * the reader to the bottom sixty times a second.
+   */
+  const sendRef = useLatestRef(send);
+  const touchInputChannel = useMemo(
+    () => ({
+      modes: touchModes,
+      rows: grid.rows,
+      send: (bytes: Uint8Array) => sendRef.current(bytes, { stickBottom: false }),
+    }),
+    [grid.rows, sendRef, touchModes]
+  );
+
   // Frames come off the emulator on its own schedule -- at most one per
   // animation frame, however many chunks landed in it -- and each is a new
   // object, which is what `SkiaTerminal` keys its picture on.
@@ -408,6 +443,11 @@ export function SshTerminalWorkspace({ hostId }: { hostId: string }) {
       // The mode is read beside the frame it belongs to, so a render never
       // pairs a new screen with an old answer to "whose screen is it".
       setAlternateScreen(terminal.modes.alternateScreen);
+      // Same reading, for the finger rather than for the chrome. Compared
+      // before it is stored: these change a handful of times in a session --
+      // once when vim starts, once when it exits -- and a fresh object on every
+      // frame would re-render the whole screen at output rate.
+      setTouchModes((previous) => terminalTouchModesOf(previous, terminal.modes));
     });
     return () => {
       unsubscribe();
@@ -705,12 +745,23 @@ export function SshTerminalWorkspace({ hostId }: { hostId: string }) {
     attemptRef.current?.abort();
   }
 
-  function send(bytes: Uint8Array) {
+  /**
+   * Bytes to the shell.
+   *
+   * `stickBottom` is what a typed key wants and what a touch does not. Every
+   * send used to snap the view to the newest line, which is right for a reader
+   * who just pressed Enter and wrong sixty times a second: a drag translated
+   * into wheel events would bump that counter on every frame of the drag, and
+   * each bump is a state change through the whole screen. The program's own
+   * repaint is what the reader is watching in that case, and it needs no help
+   * from us to arrive.
+   */
+  function send(bytes: Uint8Array, options?: { stickBottom?: boolean }) {
     const shell = sessionRef.current.shell;
     if (!shell || status.phase !== 'connected') return;
     try {
       shell.write(bytes);
-      setStickBottomNonce((value) => value + 1);
+      if (options?.stickBottom !== false) setStickBottomNonce((value) => value + 1);
     } catch (error) {
       showToast({
         variant: 'danger',
@@ -1009,6 +1060,12 @@ export function SshTerminalWorkspace({ hostId }: { hostId: string }) {
             // resolved against the app theme -- the gateway's rule, on the
             // same predicate.
             ownsScreen={editorPane}
+            // What turns a finger into the program's own input. The three-layer
+            // rule and its argument are in `@/terminal/touch-input`; what this
+            // screen contributes is the channel and the two facts the rule
+            // needs -- what the program has asked for, and how many rows of the
+            // frame are its live screen rather than the scrollback above it.
+            touchInput={touchInputChannel}
           />
         </TerminalBoundary>
         {/*

--- a/src/terminal/__tests__/resize-and-input-modes.test.ts
+++ b/src/terminal/__tests__/resize-and-input-modes.test.ts
@@ -156,14 +156,21 @@ describe('resize', () => {
   });
 });
 
+/** Every mode off, which is what a fresh emulator and a reset one both report. */
+const ALL_OFF = {
+  applicationCursorKeys: false,
+  bracketedPaste: false,
+  alternateScreen: false,
+  mouseButtons: false,
+  mouseButtonMotion: false,
+  mouseAnyMotion: false,
+  mouseSgrEncoding: false,
+};
+
 describe('input modes', () => {
   test('start off and reset off', () => {
     const term = emulator(10, 2);
-    expect(term.modes).toEqual({
-      applicationCursorKeys: false,
-      bracketedPaste: false,
-      alternateScreen: false,
-    });
+    expect(term.modes).toEqual(ALL_OFF);
   });
 
   test('DECCKM follows CSI ?1 h and l', () => {
@@ -192,6 +199,62 @@ describe('input modes', () => {
     }
   });
 
+  test('each mouse mode follows its own private mode', () => {
+    const cases = [
+      [1000, 'mouseButtons'],
+      [1002, 'mouseButtonMotion'],
+      [1003, 'mouseAnyMotion'],
+      [1006, 'mouseSgrEncoding'],
+    ] as const;
+    for (const [mode, flag] of cases) {
+      const term = emulator(10, 2);
+      term.write(`${CSI}?${mode}h`);
+      expect(term.modes).toEqual({ ...ALL_OFF, [flag]: true });
+      term.write(`${CSI}?${mode}l`);
+      expect(term.modes).toEqual(ALL_OFF);
+    }
+  });
+
+  test('the set every full-screen program sends arrives in one sequence', () => {
+    // What vim writes for `set mouse=a`, and tmux for `set -g mouse on`.
+    const term = emulator(10, 2);
+    term.write(`${CSI}?1000;1002;1006h`);
+    expect(term.modes).toEqual({
+      ...ALL_OFF,
+      mouseButtons: true,
+      mouseButtonMotion: true,
+      mouseSgrEncoding: true,
+    });
+    term.write(`${CSI}?1000;1002;1006l`);
+    expect(term.modes).toEqual(ALL_OFF);
+  });
+
+  test('a non-private 1000 is not a mouse mode', () => {
+    const term = emulator(10, 2);
+    term.write(`${CSI}1000h${CSI}1006h`);
+    expect(term.modes).toEqual(ALL_OFF);
+  });
+
+  test('leaving the alternate screen does not turn the mouse off by itself', () => {
+    // It is the program's job to send `?1000l`, and a program killed before it
+    // could is why the shell underneath sometimes still reports. Guessing here
+    // would silently drop reports a program that stays on the main screen and
+    // sets 1000 -- which is legal, and what a mouse-aware pager does -- asked
+    // for.
+    const term = emulator(10, 2);
+    term.write(`${CSI}?1049h${CSI}?1000h${CSI}?1049l`);
+    expect(term.modes.alternateScreen).toBe(false);
+    expect(term.modes.mouseButtons).toBe(true);
+  });
+
+  test('flipping a mouse mode does not touch the screen', () => {
+    const term = emulator(10, 2);
+    term.write('abc');
+    const before = term.frame();
+    term.write(`${CSI}?1000;1002;1003;1006h`);
+    expect(term.frame()).toEqual(before);
+  });
+
   test('reset leaves the alternate screen', () => {
     const term = emulator(10, 2);
     term.write(`${CSI}?1049h`);
@@ -202,31 +265,19 @@ describe('input modes', () => {
   test('several modes in one sequence', () => {
     const term = emulator(10, 2);
     term.write(`${CSI}?1;25;2004h`);
-    expect(term.modes).toEqual({
-      applicationCursorKeys: true,
-      bracketedPaste: true,
-      alternateScreen: false,
-    });
+    expect(term.modes).toEqual({ ...ALL_OFF, applicationCursorKeys: true, bracketedPaste: true });
   });
 
   test('a non-private mode 1 or 2004 is not DECCKM or bracketed paste', () => {
     const term = emulator(10, 2);
     term.write(`${CSI}1h${CSI}2004h`);
-    expect(term.modes).toEqual({
-      applicationCursorKeys: false,
-      bracketedPaste: false,
-      alternateScreen: false,
-    });
+    expect(term.modes).toEqual(ALL_OFF);
   });
 
   test('RIS clears them', () => {
     const term = emulator(10, 2);
-    term.write(`${CSI}?1h${CSI}?2004h\x1bc`);
-    expect(term.modes).toEqual({
-      applicationCursorKeys: false,
-      bracketedPaste: false,
-      alternateScreen: false,
-    });
+    term.write(`${CSI}?1h${CSI}?2004h${CSI}?1002h${CSI}?1006h\x1bc`);
+    expect(term.modes).toEqual(ALL_OFF);
   });
 
   test('the modes object is live, not a snapshot', () => {

--- a/src/terminal/__tests__/touch-input.test.ts
+++ b/src/terminal/__tests__/touch-input.test.ts
@@ -1,0 +1,368 @@
+// The three-layer touch rule and the two mouse encodings, as bytes.
+import { describe, expect, test } from 'bun:test';
+
+import {
+  TERMINAL_MOUSE_LEGACY_LIMIT,
+  TERMINAL_TOUCH_MODES_OFF,
+  TERMINAL_TOUCH_EVENTS_PER_EMISSION,
+  type TerminalTouchModes,
+  packTerminalTouchModes,
+  terminalMouseReport,
+  terminalMouseReporting,
+  terminalTouchCellAt,
+  terminalTouchDragBytes,
+  terminalTouchDragTarget,
+  terminalTouchLayer,
+  terminalTouchModesOf,
+  terminalTouchPressBytes,
+  terminalTouchPressDrags,
+  terminalTouchReleaseBytes,
+  terminalTouchTapBytes,
+  unpackTerminalTouchModes,
+} from '@/terminal/touch-input';
+
+const OFF: TerminalTouchModes = TERMINAL_TOUCH_MODES_OFF;
+
+function bits(overrides: Partial<TerminalTouchModes> = {}): number {
+  return packTerminalTouchModes({ ...OFF, ...overrides });
+}
+
+function text(bytes: Uint8Array | null): string {
+  if (!bytes) return '';
+  return Array.from(bytes, (byte) => String.fromCharCode(byte)).join('');
+}
+
+const cell = { column: 4, row: 7 };
+
+describe('packing', () => {
+  test('every mode survives a round trip, alone and together', () => {
+    const keys = Object.keys(OFF) as (keyof TerminalTouchModes)[];
+    for (const key of keys) {
+      expect(unpackTerminalTouchModes(bits({ [key]: true }))).toEqual({ ...OFF, [key]: true });
+    }
+    const all = Object.fromEntries(keys.map((key) => [key, true])) as TerminalTouchModes;
+    expect(unpackTerminalTouchModes(packTerminalTouchModes(all))).toEqual(all);
+    expect(unpackTerminalTouchModes(packTerminalTouchModes(OFF))).toEqual(OFF);
+  });
+
+  test('no two modes share a bit', () => {
+    const keys = Object.keys(OFF) as (keyof TerminalTouchModes)[];
+    const seen = new Set(keys.map((key) => bits({ [key]: true })));
+    expect(seen.size).toBe(keys.length);
+    expect(seen.has(0)).toBe(false);
+  });
+});
+
+describe('terminalTouchModesOf', () => {
+  test('keeps the previous object when nothing this module reads changed', () => {
+    const previous = { ...OFF, alternateScreen: true };
+    // A live emulator object with the same six flags, plus one this module has
+    // no opinion about.
+    const live = { ...previous, bracketedPaste: true } as TerminalTouchModes;
+    expect(terminalTouchModesOf(previous, live)).toBe(previous);
+  });
+
+  test('copies out a new object the moment one of them moves', () => {
+    const previous = { ...OFF };
+    const next = terminalTouchModesOf(previous, { ...OFF, mouseButtons: true });
+    expect(next).not.toBe(previous);
+    expect(next).toEqual({ ...OFF, mouseButtons: true });
+  });
+
+  test('the copy does not alias the emulator that is still mutating it', () => {
+    const live = { ...OFF };
+    const copied = terminalTouchModesOf({ ...OFF, alternateScreen: true }, live);
+    live.mouseButtons = true;
+    expect(copied.mouseButtons).toBe(false);
+  });
+});
+
+describe('terminalMouseReporting', () => {
+  test('any of 1000, 1002 and 1003 is enough, and 1006 alone is not', () => {
+    expect(terminalMouseReporting(bits({ mouseButtons: true }))).toBe(true);
+    expect(terminalMouseReporting(bits({ mouseButtonMotion: true }))).toBe(true);
+    expect(terminalMouseReporting(bits({ mouseAnyMotion: true }))).toBe(true);
+    expect(terminalMouseReporting(bits({ mouseSgrEncoding: true }))).toBe(false);
+    expect(terminalMouseReporting(bits())).toBe(false);
+  });
+});
+
+describe('terminalTouchLayer', () => {
+  test('mouse reporting wins, on either screen', () => {
+    for (const alternateScreen of [false, true]) {
+      for (const key of ['mouseButtons', 'mouseButtonMotion', 'mouseAnyMotion'] as const) {
+        expect(terminalTouchLayer(bits({ alternateScreen, [key]: true }))).toBe('mouse');
+      }
+    }
+  });
+
+  test('the alternate screen without a mouse mode is arrows', () => {
+    expect(terminalTouchLayer(bits({ alternateScreen: true }))).toBe('arrows');
+    expect(terminalTouchLayer(bits({ alternateScreen: true, mouseSgrEncoding: true }))).toBe(
+      'arrows'
+    );
+  });
+
+  test('the main screen without a mouse mode is the scrollback', () => {
+    expect(terminalTouchLayer(bits())).toBe('scrollback');
+    expect(terminalTouchLayer(bits({ applicationCursorKeys: true }))).toBe('scrollback');
+  });
+});
+
+describe('terminalTouchPressDrags', () => {
+  test('only 1002 turns a long press into the program drag', () => {
+    expect(terminalTouchPressDrags(bits({ mouseButtonMotion: true }))).toBe(true);
+    expect(terminalTouchPressDrags(bits({ mouseButtons: true, mouseButtonMotion: true }))).toBe(
+      true
+    );
+    expect(terminalTouchPressDrags(bits({ mouseButtons: true }))).toBe(false);
+    expect(terminalTouchPressDrags(bits({ mouseAnyMotion: true }))).toBe(false);
+    expect(terminalTouchPressDrags(bits({ alternateScreen: true }))).toBe(false);
+    expect(terminalTouchPressDrags(bits())).toBe(false);
+  });
+});
+
+describe('terminalTouchDragTarget', () => {
+  test('a second finger is the scrollback in every layer', () => {
+    for (const modes of [{}, { alternateScreen: true }, { mouseButtons: true }]) {
+      expect(terminalTouchDragTarget(bits(modes), 2)).toBe('scrollback');
+      expect(terminalTouchDragTarget(bits(modes), 3)).toBe('scrollback');
+    }
+  });
+
+  test('one finger goes to the program in the two program layers', () => {
+    expect(terminalTouchDragTarget(bits({ mouseButtons: true }), 1)).toBe('program');
+    expect(terminalTouchDragTarget(bits({ alternateScreen: true }), 1)).toBe('program');
+    expect(terminalTouchDragTarget(bits(), 1)).toBe('scrollback');
+    expect(terminalTouchDragTarget(bits(), 0)).toBe('scrollback');
+  });
+});
+
+describe('terminalTouchCellAt', () => {
+  test('the alternate screen, where the frame is the screen', () => {
+    expect(
+      terminalTouchCellAt({ row: 0, column: 0, lineCount: 24, screenRows: 24, columns: 80 })
+    ).toEqual({ row: 1, column: 1 });
+    expect(
+      terminalTouchCellAt({ row: 23, column: 79, lineCount: 24, screenRows: 24, columns: 80 })
+    ).toEqual({ row: 24, column: 80 });
+  });
+
+  test('the main screen, where the live screen is the tail of the scrollback', () => {
+    // 500 lines drawn, the last 24 of which are the screen: the first of those
+    // is row 476 of the drawing and row 1 of the screen.
+    expect(
+      terminalTouchCellAt({ row: 476, column: 0, lineCount: 500, screenRows: 24, columns: 80 })
+    ).toEqual({ row: 1, column: 1 });
+    expect(
+      terminalTouchCellAt({ row: 499, column: 9, lineCount: 500, screenRows: 24, columns: 80 })
+    ).toEqual({ row: 24, column: 10 });
+  });
+
+  test('a touch in the history above the screen clamps to its first row', () => {
+    expect(
+      terminalTouchCellAt({ row: 0, column: 3, lineCount: 500, screenRows: 24, columns: 80 })
+    ).toEqual({ row: 1, column: 4 });
+  });
+
+  test('a touch past the end clamps to the last row and column', () => {
+    expect(
+      terminalTouchCellAt({ row: 99, column: 999, lineCount: 24, screenRows: 24, columns: 80 })
+    ).toEqual({ row: 24, column: 80 });
+  });
+
+  test('a frame shorter than the screen still reports from the screen top', () => {
+    // Trailing blank rows are trimmed out of a frame, so a fresh alternate
+    // screen can be two lines long inside a 24-row grid.
+    expect(
+      terminalTouchCellAt({ row: 1, column: 0, lineCount: 2, screenRows: 24, columns: 80 })
+    ).toEqual({ row: 2, column: 1 });
+  });
+
+  test('degenerate sizes do not produce a zero or negative cell', () => {
+    expect(
+      terminalTouchCellAt({ row: 0, column: 0, lineCount: 0, screenRows: 0, columns: 0 })
+    ).toEqual({ row: 1, column: 1 });
+  });
+});
+
+describe('terminalMouseReport', () => {
+  test('SGR press, release and motion', () => {
+    expect(text(terminalMouseReport({ button: 0, cell, released: false }, true))).toBe(
+      '\x1b[<0;4;7M'
+    );
+    expect(text(terminalMouseReport({ button: 0, cell, released: true }, true))).toBe(
+      '\x1b[<0;4;7m'
+    );
+    expect(text(terminalMouseReport({ button: 32, cell, released: false }, true))).toBe(
+      '\x1b[<32;4;7M'
+    );
+  });
+
+  test('X10 offsets every field by 32 and cannot name the button that came up', () => {
+    expect(Array.from(terminalMouseReport({ button: 0, cell, released: false }, false)!)).toEqual([
+      0x1b, 0x5b, 0x4d, 32, 36, 39,
+    ]);
+    // Release is button 3 -- "something was released" -- whichever button it was.
+    expect(Array.from(terminalMouseReport({ button: 0, cell, released: true }, false)!)).toEqual([
+      0x1b, 0x5b, 0x4d, 35, 36, 39,
+    ]);
+  });
+
+  test('X10 reaches exactly 223 and gives up past it; SGR has no such limit', () => {
+    const edge = { column: TERMINAL_MOUSE_LEGACY_LIMIT, row: TERMINAL_MOUSE_LEGACY_LIMIT };
+    const legacy = terminalMouseReport({ button: 0, cell: edge, released: false }, false);
+    expect(legacy).not.toBeNull();
+    expect(legacy![4]).toBe(255);
+    expect(legacy![5]).toBe(255);
+    const past = { column: TERMINAL_MOUSE_LEGACY_LIMIT + 1, row: 1 };
+    expect(terminalMouseReport({ button: 0, cell: past, released: false }, false)).toBeNull();
+    expect(
+      terminalMouseReport({ button: 0, cell: { column: 1, row: 400 }, released: false }, false)
+    ).toBeNull();
+    expect(text(terminalMouseReport({ button: 0, cell: past, released: false }, true))).toBe(
+      '\x1b[<0;224;1M'
+    );
+  });
+});
+
+describe('a tap', () => {
+  test('is a press and a release in one write, in SGR', () => {
+    expect(
+      text(terminalTouchTapBytes(cell, bits({ mouseButtons: true, mouseSgrEncoding: true })))
+    ).toBe('\x1b[<0;4;7M\x1b[<0;4;7m');
+  });
+
+  test('is the same pair in X10', () => {
+    expect(text(terminalTouchTapBytes(cell, bits({ mouseButtons: true })))).toBe(
+      '\x1b[M\x20\x24\x27\x1b[M\x23\x24\x27'
+    );
+  });
+
+  test('is nothing when no mouse mode is on', () => {
+    expect(terminalTouchTapBytes(cell, bits({ alternateScreen: true }))).toBeNull();
+    expect(terminalTouchTapBytes(cell, bits({ mouseSgrEncoding: true }))).toBeNull();
+  });
+
+  test('is nothing when X10 cannot name the cell', () => {
+    expect(terminalTouchTapBytes({ column: 300, row: 1 }, bits({ mouseButtons: true }))).toBeNull();
+  });
+
+  test('the press and release halves are also available on their own', () => {
+    const held = bits({ mouseButtonMotion: true, mouseSgrEncoding: true });
+    expect(text(terminalTouchPressBytes(cell, held))).toBe('\x1b[<0;4;7M');
+    expect(text(terminalTouchReleaseBytes(cell, held))).toBe('\x1b[<0;4;7m');
+    expect(terminalTouchPressBytes(cell, bits())).toBeNull();
+    expect(terminalTouchReleaseBytes(cell, bits())).toBeNull();
+  });
+});
+
+describe('a drag in the mouse layer', () => {
+  const mouse = bits({ mouseButtons: true, mouseSgrEncoding: true });
+
+  test('downwards is the wheel turning up, one event per cell crossed', () => {
+    expect(text(terminalTouchDragBytes({ cell, rows: 3, columns: 0, held: false }, mouse))).toBe(
+      '\x1b[<64;4;7M'.repeat(3)
+    );
+  });
+
+  test('upwards is the wheel turning down', () => {
+    expect(text(terminalTouchDragBytes({ cell, rows: -2, columns: 0, held: false }, mouse))).toBe(
+      '\x1b[<65;4;7M'.repeat(2)
+    );
+  });
+
+  test('sideways alone says nothing -- the wheel has no useful horizontal', () => {
+    expect(terminalTouchDragBytes({ cell, rows: 0, columns: 5, held: false }, mouse)).toBeNull();
+  });
+
+  test('X10 spells the same wheel', () => {
+    const legacy = bits({ mouseButtons: true });
+    expect(text(terminalTouchDragBytes({ cell, rows: 1, columns: 0, held: false }, legacy))).toBe(
+      '\x1b[M\x60\x24\x27'
+    );
+  });
+
+  test('a held drag is one motion report at the newest cell, not one per cell', () => {
+    const drag = bits({ mouseButtonMotion: true, mouseSgrEncoding: true });
+    expect(text(terminalTouchDragBytes({ cell, rows: 4, columns: 2, held: true }, drag))).toBe(
+      '\x1b[<32;4;7M'
+    );
+    expect(text(terminalTouchDragBytes({ cell, rows: 0, columns: 1, held: true }, drag))).toBe(
+      '\x1b[<32;4;7M'
+    );
+    expect(terminalTouchDragBytes({ cell, rows: 0, columns: 0, held: true }, drag)).toBeNull();
+  });
+
+  test('a flick is capped at a screenful of wheel events', () => {
+    const bytes = terminalTouchDragBytes({ cell, rows: 400, columns: 0, held: false }, mouse);
+    expect(text(bytes).split('M').length - 1).toBe(TERMINAL_TOUCH_EVENTS_PER_EMISSION);
+  });
+});
+
+describe('a drag in the arrows layer', () => {
+  const arrows = bits({ alternateScreen: true });
+  const applicationArrows = bits({ alternateScreen: true, applicationCursorKeys: true });
+
+  test('downwards is Up, one per cell, and CSI without DECCKM', () => {
+    expect(text(terminalTouchDragBytes({ cell, rows: 2, columns: 0, held: false }, arrows))).toBe(
+      '\x1b[A\x1b[A'
+    );
+  });
+
+  test('upwards is Down', () => {
+    expect(text(terminalTouchDragBytes({ cell, rows: -1, columns: 0, held: false }, arrows))).toBe(
+      '\x1b[B'
+    );
+  });
+
+  test('rightwards is Left and leftwards is Right, the content convention', () => {
+    expect(text(terminalTouchDragBytes({ cell, rows: 0, columns: 2, held: false }, arrows))).toBe(
+      '\x1b[D\x1b[D'
+    );
+    expect(text(terminalTouchDragBytes({ cell, rows: 0, columns: -1, held: false }, arrows))).toBe(
+      '\x1b[C'
+    );
+  });
+
+  test('both axes travel in one emission, vertical first', () => {
+    expect(text(terminalTouchDragBytes({ cell, rows: 1, columns: 1, held: false }, arrows))).toBe(
+      '\x1b[A\x1b[D'
+    );
+  });
+
+  test('DECCKM moves them to SS3', () => {
+    expect(
+      text(terminalTouchDragBytes({ cell, rows: -1, columns: -1, held: false }, applicationArrows))
+    ).toBe('\x1bOB\x1bOC');
+  });
+
+  test('a standstill is silence', () => {
+    expect(terminalTouchDragBytes({ cell, rows: 0, columns: 0, held: false }, arrows)).toBeNull();
+  });
+
+  test('each axis is capped on its own', () => {
+    const bytes = terminalTouchDragBytes({ cell, rows: 400, columns: 400, held: false }, arrows);
+    expect(bytes!.length).toBe(TERMINAL_TOUCH_EVENTS_PER_EMISSION * 3 * 2);
+  });
+
+  test('a held flag means nothing here -- there is no button to hold', () => {
+    expect(text(terminalTouchDragBytes({ cell, rows: 1, columns: 0, held: true }, arrows))).toBe(
+      '\x1b[A'
+    );
+  });
+});
+
+describe('a drag in the scrollback layer', () => {
+  test('produces no bytes at all, whatever it did', () => {
+    for (const held of [false, true]) {
+      expect(terminalTouchDragBytes({ cell, rows: 5, columns: 5, held }, bits())).toBeNull();
+    }
+    expect(
+      terminalTouchDragBytes(
+        { cell, rows: 5, columns: 0, held: false },
+        bits({ applicationCursorKeys: true, mouseSgrEncoding: true })
+      )
+    ).toBeNull();
+  });
+});

--- a/src/terminal/terminal-core.ts
+++ b/src/terminal/terminal-core.ts
@@ -76,7 +76,9 @@ type TerminalOptions = {
 /**
  * The terminal modes a program flips that change what the *input* side has to
  * send, rather than how the screen is drawn. Read by whoever encodes keys for
- * a PTY (`@/lib/ssh-key-bytes`); nothing in the renderer looks at them.
+ * a PTY (`@/lib/ssh-key-bytes`) and by the touch translation that turns a
+ * finger into the same kind of input (`@/terminal/touch-input`); nothing in
+ * the renderer looks at them.
  */
 export type TerminalModes = {
   /** DECCKM (`CSI ?1 h/l`): arrows and Home/End go out as `ESC O x`, not `ESC [ x`. */
@@ -90,6 +92,25 @@ export type TerminalModes = {
    * program own the screen", which a gateway pane can only guess from names.
    */
   alternateScreen: boolean;
+  /**
+   * `CSI ?1000 h/l`: the program wants to be told about button presses and
+   * releases. The weakest of the three mouse modes and the one every other
+   * implies -- a program that asks for motion is also asking for buttons --
+   * so "is the mouse on at all" is the OR of this, `mouseButtonMotion` and
+   * `mouseAnyMotion`, never this one alone.
+   */
+  mouseButtons: boolean;
+  /** `CSI ?1002 h/l`: buttons, plus motion for as long as one is held. */
+  mouseButtonMotion: boolean;
+  /** `CSI ?1003 h/l`: buttons, plus motion whether or not one is held. */
+  mouseAnyMotion: boolean;
+  /**
+   * `CSI ?1006 h/l`: the reports above are to be written in SGR form
+   * (`CSI < b ; x ; y M`) rather than in the X10 byte form. Not a mode that
+   * turns reporting on -- it only decides how a report that is already being
+   * sent is spelled -- which is why it is tracked apart from the three above.
+   */
+  mouseSgrEncoding: boolean;
 };
 
 const CSI_FINAL = /[@-~]/;
@@ -151,6 +172,10 @@ export class TerminalEmulator {
     applicationCursorKeys: false,
     bracketedPaste: false,
     alternateScreen: false,
+    mouseButtons: false,
+    mouseButtonMotion: false,
+    mouseAnyMotion: false,
+    mouseSgrEncoding: false,
   };
   /**
    * The tail of the last `write` that could not be acted on yet: an escape
@@ -214,6 +239,10 @@ export class TerminalEmulator {
     this.modeState.applicationCursorKeys = false;
     this.modeState.bracketedPaste = false;
     this.modeState.alternateScreen = false;
+    this.modeState.mouseButtons = false;
+    this.modeState.mouseButtonMotion = false;
+    this.modeState.mouseAnyMotion = false;
+    this.modeState.mouseSgrEncoding = false;
     this.pending = '';
     this.openRun = false;
   }
@@ -712,6 +741,14 @@ export class TerminalEmulator {
       else if (privateMode && mode === 7) this.autoWrap = enabled;
       else if (privateMode && mode === 25) this.cursorVisible = enabled;
       else if (privateMode && mode === 2004) this.modeState.bracketedPaste = enabled;
+      // The mouse modes. Tracked but never acted on here: nothing in the
+      // emulator or the renderer cares, and the one reader is the touch
+      // translation that turns a finger into the reports these ask for
+      // (`@/terminal/touch-input`).
+      else if (privateMode && mode === 1000) this.modeState.mouseButtons = enabled;
+      else if (privateMode && mode === 1002) this.modeState.mouseButtonMotion = enabled;
+      else if (privateMode && mode === 1003) this.modeState.mouseAnyMotion = enabled;
+      else if (privateMode && mode === 1006) this.modeState.mouseSgrEncoding = enabled;
       else if (privateMode && (mode === 47 || mode === 1047 || mode === 1049)) {
         if (enabled) {
           if (mode === 1049) this.saveCursor();

--- a/src/terminal/touch-input.ts
+++ b/src/terminal/touch-input.ts
@@ -1,0 +1,430 @@
+/**
+ * A finger on the grid, in the bytes the program on the far side is asking for.
+ *
+ * The terminal used to answer every touch the same way: one finger panned
+ * muqun's own scrollback, a pinch zoomed, a long press selected. That is the
+ * right set for a pane that PRINTS -- a shell, an agent's log -- where the
+ * scrollback is the document and nothing on the far side has any use for a
+ * pointer. It is the wrong set for everything a reader actually opens over
+ * SSH. vim, tmux, less, htop, fzf and lazygit paint a screen; there is no
+ * scrollback under them to pan, so a swipe moved nothing at all, and the
+ * inputs they do want -- a mouse, or arrows -- were reachable only one key at
+ * a time off the virtual keyboard.
+ *
+ * So the answer to a touch is decided by what the program has said about
+ * itself, in three layers:
+ *
+ *  1. **It turned mouse reporting on** (`?1000`, `?1002` or `?1003`). Touch
+ *     becomes mouse. A tap is a click where it landed; a drag is the wheel.
+ *  2. **It is on the alternate screen and did not** -- stock vim, `man`, tmux
+ *     with the mouse off. A drag becomes arrow keys, one per cell crossed.
+ *  3. **Neither.** Unchanged: a drag pans muqun's scrollback, which is what a
+ *     pane that prints has always wanted.
+ *
+ * Two fingers always mean layer 3, in every layer, so history is never out of
+ * reach -- that rule lives in the component, because it is about pointers
+ * rather than about bytes.
+ *
+ * Pure, and worklet-safe throughout: the layer decision runs on the UI thread
+ * inside the pan gesture (it decides whether the transform moves at all, and
+ * that cannot wait for a hop to JS), while the byte building runs on the JS
+ * thread once per frame with whatever the finger accumulated. The mode facts
+ * cross that boundary as a packed integer rather than as an object, because a
+ * shared value read every frame should be a number.
+ */
+
+/** The emulator's answer to "what is the program doing", as this module needs it. */
+export type TerminalTouchModes = {
+  /** DECCKM (`?1`): arrows go out as `ESC O x` rather than `ESC [ x`. */
+  applicationCursorKeys: boolean;
+  /** `?47` / `?1047` / `?1049`: the program has taken the screen. */
+  alternateScreen: boolean;
+  /** `?1000`: button presses and releases. */
+  mouseButtons: boolean;
+  /** `?1002`: buttons, plus motion while one is held. */
+  mouseButtonMotion: boolean;
+  /** `?1003`: buttons, plus motion with nothing held. */
+  mouseAnyMotion: boolean;
+  /** `?1006`: SGR encoding for whichever of the above is on. */
+  mouseSgrEncoding: boolean;
+};
+
+/** Every mode off: a fresh emulator, a reset one, and a pane with no channel. */
+export const TERMINAL_TOUCH_MODES_OFF: TerminalTouchModes = {
+  applicationCursorKeys: false,
+  alternateScreen: false,
+  mouseButtons: false,
+  mouseButtonMotion: false,
+  mouseAnyMotion: false,
+  mouseSgrEncoding: false,
+};
+
+/**
+ * The emulator's live mode state as a value React can hold.
+ *
+ * The emulator hands out one object and mutates it in place, which is right
+ * for a key encoder reading it at the moment a key is sent and wrong for a
+ * prop: a component handed the same object every frame has no way to know it
+ * changed. This copies the six flags that matter here -- and returns
+ * `previous` unchanged when none of them moved, so the copy costs a render
+ * only on the frame vim actually starts rather than on every frame it draws.
+ */
+export function terminalTouchModesOf(
+  previous: TerminalTouchModes,
+  modes: TerminalTouchModes
+): TerminalTouchModes {
+  return packTerminalTouchModes(previous) === packTerminalTouchModes(modes)
+    ? previous
+    : {
+        applicationCursorKeys: modes.applicationCursorKeys,
+        alternateScreen: modes.alternateScreen,
+        mouseButtons: modes.mouseButtons,
+        mouseButtonMotion: modes.mouseButtonMotion,
+        mouseAnyMotion: modes.mouseAnyMotion,
+        mouseSgrEncoding: modes.mouseSgrEncoding,
+      };
+}
+
+/** Which of the three rules above a touch falls under. */
+export type TerminalTouchLayer = 'mouse' | 'arrows' | 'scrollback';
+
+const BIT_APPLICATION_CURSOR = 1;
+const BIT_ALTERNATE_SCREEN = 2;
+const BIT_MOUSE_BUTTONS = 4;
+const BIT_MOUSE_BUTTON_MOTION = 8;
+const BIT_MOUSE_ANY_MOTION = 16;
+const BIT_MOUSE_SGR = 32;
+
+/**
+ * The modes as one integer, so the gesture can hold them in a shared value and
+ * read them on the UI thread without reaching for a JS object.
+ */
+export function packTerminalTouchModes(modes: TerminalTouchModes): number {
+  'worklet';
+  return (
+    (modes.applicationCursorKeys ? BIT_APPLICATION_CURSOR : 0) |
+    (modes.alternateScreen ? BIT_ALTERNATE_SCREEN : 0) |
+    (modes.mouseButtons ? BIT_MOUSE_BUTTONS : 0) |
+    (modes.mouseButtonMotion ? BIT_MOUSE_BUTTON_MOTION : 0) |
+    (modes.mouseAnyMotion ? BIT_MOUSE_ANY_MOTION : 0) |
+    (modes.mouseSgrEncoding ? BIT_MOUSE_SGR : 0)
+  );
+}
+
+/** The inverse of `packTerminalTouchModes`, for the byte builders below. */
+export function unpackTerminalTouchModes(bits: number): TerminalTouchModes {
+  'worklet';
+  return {
+    applicationCursorKeys: (bits & BIT_APPLICATION_CURSOR) !== 0,
+    alternateScreen: (bits & BIT_ALTERNATE_SCREEN) !== 0,
+    mouseButtons: (bits & BIT_MOUSE_BUTTONS) !== 0,
+    mouseButtonMotion: (bits & BIT_MOUSE_BUTTON_MOTION) !== 0,
+    mouseAnyMotion: (bits & BIT_MOUSE_ANY_MOTION) !== 0,
+    mouseSgrEncoding: (bits & BIT_MOUSE_SGR) !== 0,
+  };
+}
+
+/**
+ * Whether the program is reporting the mouse at all.
+ *
+ * Any one of the three is enough. They are not a ladder a program climbs in
+ * order: `?1003` is often set without `?1000` beside it, and a program that
+ * wants motion certainly wants the click that starts it.
+ */
+export function terminalMouseReporting(bits: number): boolean {
+  'worklet';
+  return (bits & (BIT_MOUSE_BUTTONS | BIT_MOUSE_BUTTON_MOTION | BIT_MOUSE_ANY_MOTION)) !== 0;
+}
+
+/** Which rule a one-finger touch falls under; see the module comment. */
+export function terminalTouchLayer(bits: number): TerminalTouchLayer {
+  'worklet';
+  if (terminalMouseReporting(bits)) return 'mouse';
+  return (bits & BIT_ALTERNATE_SCREEN) !== 0 ? 'arrows' : 'scrollback';
+}
+
+/**
+ * Whether a drag with this many fingers belongs to the program or to muqun's
+ * own scrollback.
+ *
+ * Two fingers are always the scrollback, in every layer. A reader inside vim
+ * still has muqun's history of the session above them and must be able to get
+ * at it, and there is no way back to it if the only vertical gesture the pane
+ * has is being spent on the program.
+ */
+export function terminalTouchDragTarget(
+  bits: number,
+  pointerCount: number
+): 'program' | 'scrollback' {
+  'worklet';
+  if (pointerCount > 1) return 'scrollback';
+  return terminalTouchLayer(bits) === 'scrollback' ? 'scrollback' : 'program';
+}
+
+/**
+ * Whether a long press hands the finger to the program rather than starting a
+ * selection.
+ *
+ * Only under `?1002`, which is precisely the mode that says "tell me where the
+ * pointer goes while a button is held" -- so it is the only mode under which a
+ * held drag has anywhere to go. tmux sets it to let a divider be dragged and
+ * vim to let a visual selection be swept, and both are gestures the reader has
+ * no other way to make on a phone.
+ *
+ * The plain drag stays the wheel in every mouse mode, `?1002` included, and
+ * that is deliberate. A drag cannot be both a scroll and a sweep, and scrolling
+ * is what a reader does a hundred times to every once they select: a vim or a
+ * tmux whose only drag was a visual selection would be a terminal you cannot
+ * read. Press-and-hold, then drag, is how every touch surface that emulates a
+ * pointer spells the other one.
+ *
+ * Where this takes the long press, muqun's own selection is still reachable by
+ * a double tap, which takes the line.
+ */
+export function terminalTouchPressDrags(bits: number): boolean {
+  'worklet';
+  return terminalMouseReporting(bits) && (bits & BIT_MOUSE_BUTTON_MOTION) !== 0;
+}
+
+/** A cell of the live screen, 1-based, which is how a mouse report spells one. */
+export type TerminalTouchCell = {
+  column: number;
+  row: number;
+};
+
+/**
+ * A hit-tested cell of the drawn frame, as the cell the program would name.
+ *
+ * Two conversions in one. The obvious one is 0-based to 1-based. The other is
+ * that the frame the canvas draws is not the screen: on the main screen it is
+ * the whole scrollback with the live screen as its last `screenRows` rows, so
+ * a report has to be measured from the top of THAT window rather than from the
+ * top of the drawing. On the alternate screen the two coincide, because an
+ * alternate buffer keeps no scrollback -- but the arithmetic is the same and
+ * costs nothing, so there is one path rather than a branch that could rot.
+ *
+ * Clamped rather than rejected. A finger below the last row of a short frame
+ * is a finger on the bottom row of the screen, which is what a mouse pointer
+ * held against the bottom edge of a window reports too.
+ */
+export function terminalTouchCellAt(hit: {
+  row: number;
+  column: number;
+  lineCount: number;
+  screenRows: number;
+  columns: number;
+}): TerminalTouchCell {
+  'worklet';
+  const screenRows = hit.screenRows > 0 ? hit.screenRows : 1;
+  const columns = hit.columns > 0 ? hit.columns : 1;
+  const screenTop = Math.max(0, hit.lineCount - screenRows);
+  return {
+    row: Math.max(1, Math.min(screenRows, hit.row - screenTop + 1)),
+    column: Math.max(1, Math.min(columns, hit.column + 1)),
+  };
+}
+
+const ESC = 0x1b;
+
+/**
+ * The largest cell the X10 encoding can name.
+ *
+ * Every field of that form is `32 + value` in one byte, so 223 is where the
+ * byte runs out. Wider than that and there is no report to send: xterm's own
+ * answer is to send nothing rather than a wrapped coordinate, because a
+ * coordinate that wrapped is a click somewhere the reader did not touch. The
+ * fix on the reader's side is the program's, not ours -- `?1006` has no such
+ * limit, and everything that sets a mouse mode this decade sets it too.
+ */
+export const TERMINAL_MOUSE_LEGACY_LIMIT = 223;
+
+/**
+ * How many wheel or arrow events one emission may carry.
+ *
+ * A drag is coalesced to whole cells crossed since the last emission, which
+ * for an ordinary drag is one or two. A hard flick across a tall screen in a
+ * frame the app was late for is the case this bounds: without a cap the pane
+ * would post a hundred wheel events into a PTY in one write, and the program
+ * would still be redrawing its way through them long after the finger had
+ * stopped. A screenful at a time is as fast as a wheel can usefully go.
+ */
+export const TERMINAL_TOUCH_EVENTS_PER_EMISSION = 32;
+
+/** Left button, the only one a finger can be. */
+const BUTTON_LEFT = 0;
+/** X10's "some button was released"; SGR names the button instead. */
+const BUTTON_LEGACY_RELEASE = 3;
+/** Added to a button code to say the pointer moved while it was held. */
+const BUTTON_MOTION = 32;
+/** The wheel, which reports as buttons rather than as an axis. */
+const BUTTON_WHEEL_UP = 64;
+const BUTTON_WHEEL_DOWN = 65;
+
+function ascii(text: string): Uint8Array {
+  const out = new Uint8Array(text.length);
+  for (let index = 0; index < text.length; index += 1) out[index] = text.charCodeAt(index) & 0x7f;
+  return out;
+}
+
+function concat(parts: Uint8Array[]): Uint8Array | null {
+  let length = 0;
+  for (const part of parts) length += part.length;
+  if (length === 0) return null;
+  const out = new Uint8Array(length);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+/**
+ * One mouse report.
+ *
+ * `released` picks the terminator in SGR form and the button code in X10 form,
+ * which is the whole difference between the two encodings that matters here:
+ * SGR says which button came up, X10 can only say that something did. That is
+ * also why a program that wants to tell a left-drag from a right-drag has to
+ * ask for `?1006`, and why every program that cares does.
+ *
+ * Returns null when the X10 form cannot name the cell; see
+ * `TERMINAL_MOUSE_LEGACY_LIMIT`.
+ */
+export function terminalMouseReport(
+  report: { button: number; cell: TerminalTouchCell; released: boolean },
+  sgr: boolean
+): Uint8Array | null {
+  const { button, cell, released } = report;
+  if (sgr) {
+    return ascii(`\x1b[<${button};${cell.column};${cell.row}${released ? 'm' : 'M'}`);
+  }
+  if (cell.column > TERMINAL_MOUSE_LEGACY_LIMIT || cell.row > TERMINAL_MOUSE_LEGACY_LIMIT) {
+    return null;
+  }
+  const code = released ? BUTTON_LEGACY_RELEASE : button;
+  return Uint8Array.from([ESC, 0x5b, 0x4d, 32 + code, 32 + cell.column, 32 + cell.row]);
+}
+
+/**
+ * A tap, as a click: press and release at the same cell, in one write.
+ *
+ * One write rather than two because the pair is one event to the program and
+ * splitting it across two `write` calls only gives the far side a chance to
+ * redraw between them.
+ */
+export function terminalTouchTapBytes(cell: TerminalTouchCell, bits: number): Uint8Array | null {
+  if (!terminalMouseReporting(bits)) return null;
+  const sgr = (bits & BIT_MOUSE_SGR) !== 0;
+  const press = terminalMouseReport({ button: BUTTON_LEFT, cell, released: false }, sgr);
+  const release = terminalMouseReport({ button: BUTTON_LEFT, cell, released: true }, sgr);
+  if (!press || !release) return null;
+  return concat([press, release]);
+}
+
+/** The press half on its own, for a drag the program is to see as held. */
+export function terminalTouchPressBytes(cell: TerminalTouchCell, bits: number): Uint8Array | null {
+  if (!terminalMouseReporting(bits)) return null;
+  return terminalMouseReport(
+    { button: BUTTON_LEFT, cell, released: false },
+    (bits & BIT_MOUSE_SGR) !== 0
+  );
+}
+
+/** The release half, sent when the finger leaves. */
+export function terminalTouchReleaseBytes(
+  cell: TerminalTouchCell,
+  bits: number
+): Uint8Array | null {
+  if (!terminalMouseReporting(bits)) return null;
+  return terminalMouseReport(
+    { button: BUTTON_LEFT, cell, released: true },
+    (bits & BIT_MOUSE_SGR) !== 0
+  );
+}
+
+/** What a drag has accumulated since the last emission. */
+export type TerminalTouchDrag = {
+  /** Where the finger is now, on the live screen. */
+  cell: TerminalTouchCell;
+  /** Whole cells crossed downwards since the last emission; negative is upwards. */
+  rows: number;
+  /** Whole cells crossed rightwards since the last emission. */
+  columns: number;
+  /**
+   * Whether the program is to see this as a drag with the button down rather
+   * than as the wheel. Only ever true under `?1002`, and only after a long
+   * press: see the component, which is where that arbitration lives.
+   */
+  held: boolean;
+};
+
+/**
+ * A cursor key, honouring DECCKM.
+ *
+ * The same rule and the same table as `@/lib/ssh-key-bytes` -- SS3 in
+ * application mode, CSI outside it. Not shared with it, because that module
+ * maps key NAMES from a keyboard and this one has a direction; a common
+ * two-byte helper would be longer than either copy.
+ */
+function cursorKey(final: string, applicationMode: boolean): Uint8Array {
+  return Uint8Array.from([ESC, applicationMode ? 0x4f : 0x5b, final.charCodeAt(0)]);
+}
+
+function repeat(unit: Uint8Array, count: number): Uint8Array[] {
+  const capped = Math.min(count, TERMINAL_TOUCH_EVENTS_PER_EMISSION);
+  const parts: Uint8Array[] = [];
+  for (let index = 0; index < capped; index += 1) parts.push(unit);
+  return parts;
+}
+
+/**
+ * The bytes for one frame's worth of drag, whichever layer the program put us in.
+ *
+ * The direction convention is the content's, not the pointer's, and it is the
+ * one muqun's own scrollback already uses: pulling the finger DOWN brings
+ * earlier lines into view. So a downward finger is the wheel turning up, and
+ * an Up arrow, in the layers that spell it those ways. Getting this backwards
+ * is the difference between a terminal that feels like every other surface on
+ * the phone and one that feels inverted, and there is no setting for it here
+ * for the same reason there is none on the scrollback.
+ *
+ * Horizontal movement is arrows only. The wheel has buttons 66 and 67 for a
+ * horizontal wheel, but almost nothing reads them and the ones that do treat
+ * them as scroll rather than as cursor movement, so a sideways drag in mouse
+ * mode is silence rather than a guess.
+ */
+export function terminalTouchDragBytes(drag: TerminalTouchDrag, bits: number): Uint8Array | null {
+  const layer = terminalTouchLayer(bits);
+  if (layer === 'scrollback') return null;
+
+  if (layer === 'mouse') {
+    const sgr = (bits & BIT_MOUSE_SGR) !== 0;
+    if (drag.held) {
+      // One report per emission, not one per cell: motion is a position, and
+      // the program only ever wanted the newest one.
+      if (drag.rows === 0 && drag.columns === 0) return null;
+      return terminalMouseReport(
+        { button: BUTTON_LEFT + BUTTON_MOTION, cell: drag.cell, released: false },
+        sgr
+      );
+    }
+    if (drag.rows === 0) return null;
+    const button = drag.rows > 0 ? BUTTON_WHEEL_UP : BUTTON_WHEEL_DOWN;
+    const unit = terminalMouseReport({ button, cell: drag.cell, released: false }, sgr);
+    if (!unit) return null;
+    return concat(repeat(unit, Math.abs(drag.rows)));
+  }
+
+  const application = (bits & BIT_APPLICATION_CURSOR) !== 0;
+  const parts: Uint8Array[] = [];
+  if (drag.rows !== 0) {
+    parts.push(...repeat(cursorKey(drag.rows > 0 ? 'A' : 'B', application), Math.abs(drag.rows)));
+  }
+  if (drag.columns !== 0) {
+    parts.push(
+      ...repeat(cursorKey(drag.columns > 0 ? 'D' : 'C', application), Math.abs(drag.columns))
+    );
+  }
+  return concat(parts);
+}


### PR DESCRIPTION
## The rule

What a touch means is now decided by what the program on the far side has said
about itself, in three layers:

| Layer | The program | One finger | Two fingers |
| --- | --- | --- | --- |
| 1 | has turned mouse reporting on (`?1000`, `?1002` or `?1003`) | tap = click at that cell; drag = the wheel; long press under `?1002` puts the button down and the drag that follows is the program's own | muqun's scrollback |
| 2 | is on the alternate screen and has not | drag = arrow keys, one per cell crossed, on both axes, honouring DECCKM | muqun's scrollback |
| 3 | neither | unchanged: drag pans muqun's scrollback | muqun's scrollback |

Pinch stays pinch everywhere. Long press stays muqun's own selection everywhere
except under `?1002`, where it is the program's button; the double tap that
selects a line is untouched, so a highlight is still reachable there.

## Where the ambiguity was resolved

The brief describes both "a drag sends wheel events" and "with 1002 on, a drag
sends motion events with the button held". A drag cannot be both, so:

* **the plain one-finger drag is the wheel in every mouse mode, `?1002`
  included.** Scrolling is what a reader does a hundred times to every once
  they select, and a vim or a tmux whose only drag was a visual selection would
  be a terminal you cannot read.
* **press-and-hold, then drag, is the button-held drag,** and only under
  `?1002` -- which is exactly the mode that says "tell me where the pointer goes
  while a button is held", so it is the only mode where such a drag has anywhere
  to go. This is how every touch surface that emulates a pointer spells it.

Both were exercised on device; see below.

## Encoding

* **SGR (`?1006`)** -- `CSI < b ; x ; y M` for a press or motion, `... m` for a
  release, 1-based cell coordinates.
* **X10 otherwise** -- `CSI M Cb Cx Cy`, every field `32 + value`.
* **The 223 limit.** X10's fields are one byte each, so 223 is where a
  coordinate stops fitting. Past it the report is **not sent** rather than sent
  wrapped: a wrapped coordinate is a click somewhere the reader did not touch.
  `?1006` has no such limit and everything that sets a mouse mode this decade
  sets it too.
* **Release.** SGR names the button that came up; X10 can only say that
  something did (button 3). That difference is the whole reason a program that
  cares asks for `?1006`.
* **The wheel** is buttons 64 (up) and 65 (down), press form only, no release.
  Horizontal is silence rather than a guess -- buttons 66/67 exist and almost
  nothing reads them.
* **Motion with the button held** is the button code plus 32.
* **Direction** follows the content, not the pointer, which is the convention
  muqun's own scrollback already uses: pulling the finger *down* brings earlier
  lines into view, so a downward finger is the wheel turning up, and an Up
  arrow, in the layers that spell it those ways.

## Shape

* `src/terminal/terminal-core.ts` -- `?1000`, `?1002`, `?1003` and `?1006` join
  `applicationCursorKeys`, `bracketedPaste` and `alternateScreen` in
  `TerminalModes`. Tracked, never acted on: nothing in the emulator or the
  renderer cares. Leaving the alternate screen deliberately does **not** clear
  them -- a mouse-aware pager on the main screen is legal, and it is the
  program's job to send `?1000l`.
* `src/terminal/touch-input.ts` (new) -- every byte the rules produce, pure and
  worklet-safe, with `src/terminal/__tests__/touch-input.test.ts` beside it.
* `src/components/skia-terminal.tsx` -- a narrow `touchInput` prop (`modes`,
  `rows`, `send`). The modes cross to the UI thread as one **packed integer**,
  because the pan reads them on every touch sample to decide whether it may move
  the transform at all -- a decision that cannot wait for a hop to JS without
  the first frames of every drag scrolling the wrong thing.
* `src/components/ssh-terminal-workspace.tsx` -- publishes the modes beside the
  frame they belong to (compared before storing, so vim starting is one render,
  not one per frame), and `send` grew a `stickBottom` option so a wheel event
  does not haul the reader to the bottom sixty times a second.

### Pacing (PR #24 is untouched)

`gestureCommitFrame` and its `setActive`-from-a-`useEffect` are exactly as #24
left them. The byte emission is a **second** frame callback, registered the same
way from the JS thread only, and it emits at most once per display frame with
whatever whole cells the finger crossed since the last emission -- so a flick
across forty rows is one write of forty wheel events, not forty writes, and a
thumb wandering inside one cell writes nothing. The tail the callback had not
sent goes out in `onEnd`, and a held drag owes its release exactly once however
many recognisers finalize.

A program-layer drag also does **not** take the frame freeze. The freeze exists
so a frame swap cannot land under a moving finger; here the drag is what is
changing the frame, and freezing would mean dragging through vim and seeing
nothing until you lift. On Android that meant guarding the pinch recogniser's
`onBegin` too, since Android begins it on the first pointer of any drag.

## The gateway

Unwired, and not by omission. A gateway pane's output arrives already rendered
by tmux, so the `DECSET`s a program sent were consumed on the far side and never
reach the app -- there is no mode fact to read. The send path is key *names* and
text over HTTP, so there is no raw-byte channel either. `touchInput` is
therefore optional; with it absent the packed modes are `0`, every layer
resolves to the scrollback, and the component behaves exactly as it did before
this change. The two-finger tab swipe is untouched and was re-checked.

## Verification

### Unit

`src/terminal/__tests__/touch-input.test.ts` -- every mode combination, the
layer rule, the two-finger rule, SGR vs X10 including the 223 edge, the
coordinate conversion from a drawn row to a live-screen row on both screens,
the direction convention, DECCKM, and the per-emission cap.
`src/terminal/__tests__/resize-and-input-modes.test.ts` -- the four new private
modes, the `?1000;1002;1006h` set that vim and tmux actually send, the
non-private forms, and reset.

### On device

A russh server built in the scratchpad (from
`react-native-ssh/rust/rnssh-testserver`, copied and given a real PTY-backed
`/bin/zsh`; the source repo was not modified) served a real shell on this Mac to
both devices. iOS 26.5 iPhone 17 simulator and a Pixel-class Android emulator,
same build, same host.

| Program | What was checked | iOS | Android |
| --- | --- | --- | --- |
| shell (main screen) | tap dismisses the keyboard; one-finger pan scrolls the scrollback; two fingers too | 290 -> 251 -> 227 | 168 -> 148 -> 129 |
| `vim -c 'set mouse=a'` | tap moves the cursor to the tapped cell | line 018 col 14 | line 010 col 11 |
| `vim -c 'set mouse=a'` | drag scrolls the buffer, both directions | 008 -> 050 -> 017 | 001 -> 037 |
| `vim -c 'set mouse=a'` | two-finger drag sends nothing | buffer unchanged | buffer unchanged |
| `vim -c 'set mouse=a'` | long press is the program's click, not a muqun selection | cursor moved, no Copy bar | -- |
| `vim -c 'set mouse=a'` (`?1002`) | press-and-hold then drag | `-- VISUAL --` | `-- VISUAL --` |
| `tmux -f` + `set -g mouse on`, two panes | tap switches the active pane | pane 2 -> 1, `echo` landed in the left pane | left tap -> `LEFT_PANE` left, right tap -> `RIGHT_PANE` right |
| `tmux` divider | press-and-hold then drag resizes | 25x29/24x29 -> 26x29/23x29 | not reproduced through the synthesizer |
| `less` (long file) | drag scrolls (layer 2, arrows) | 001 -> 009 | 001 -> 010 |
| `man ls` | drag scrolls (layer 2, arrows) | NAME -> OPTIONS | ditto |
| `vim -u NONE` (no mouse) | drag moves the cursor by arrows, both axes | 001:1 -> 010:11 | 001:1 -> 010:12 |
| back at the shell | one-finger pan scrolls muqun's history again | 200 -> 174 | 268 -> 248 |

Screenshots for every row are in
`/private/tmp/claude-501/-Users-okk--repos/02537bcb-c24e-4611-82d1-fb899988ba1a/scratchpad/evidence`
(`ios-*.png`, `and-*.png`), named for the row they belong to.

Two notes from the device work, neither a change in this PR:

* On the alternate screen the emulator draws the alternate buffer, which keeps
  no scrollback, so the two-finger drag has nothing to move there. The gesture
  is correct -- it reaches muqun's scrollback and sends the program nothing --
  but under a full-screen program there is no muqun history to reach. That is
  the emulator's existing shape, not this change's.
* A full-screen program killed with `SIGKILL` never sends `?1049l` or `?1000l`,
  so the terminal stays in layer 1 or 2 under the shell that comes back. Every
  terminal behaves this way and `reset` fixes it; the alternative -- clearing
  the mouse modes when the alternate screen is left -- would silently drop the
  reports a mouse-aware pager on the main screen asked for.

### `dumpsys gfxinfo` on Android

The same drag, eight times, in mouse mode inside `vim` and on the main screen
scrolling muqun's own scrollback. Host load average 7.97 during both (a
background service on this machine), so the arms are compared against each
other rather than against an absolute.

```
mouse mode (vim, ?1000;1002;1006)      main screen (scrollback pan)
Total frames rendered: 26              Total frames rendered: 46
50th percentile: 17ms                  50th percentile: 48ms
90th percentile: 32ms                  90th percentile: 89ms
95th percentile: 34ms                  95th percentile: 250ms
Number Missed Vsync: 0                 Number Missed Vsync: 6
Number High input latency: 0           Number High input latency: 44
HISTOGRAM (frames over 33ms): 2        HISTOGRAM (frames over 33ms): 40
```

Two frames over 33ms in mouse mode against forty for the same drag on the main
screen. The emission is not what costs: a mouse-mode drag never writes the
transform, so it skips the property commit, the scene re-record and the
full-surface redraw that a scrollback pan pays for on every frame. Raw dumps in
`gfx-mouse.txt` and `gfx-main.txt` beside the screenshots.

### Gates

```
$ npx tsc --noEmit
(no output)

$ bun run lint
$ oxlint --deny-warnings

$ bun run format:check
$ oxfmt --check
All matched files use the correct format.
Finished in 301ms on 432 files using 12 threads.

$ bun test src
 2653 pass
 2 skip
 0 fail
 13942 expect() calls
Ran 2655 tests across 100 files. [8.26s]
```

`bash scripts/e2e.sh` is **already red on `main`** on this machine and cannot
serve as a signal here. A clean-install run on `origin/main` (2729c5c, nothing
of this branch applied) failed 7 of 11 flows; the same suite on this branch
failed 8, the difference being `demo-tour`, which fails deterministically on
*both* at `tapOn: 'Close quick actions'` -- the sheet does not dismiss, and
`Show what is running` behind it is then unreachable. Repeated
`bash scripts/e2e.sh --smoke` on `origin/main` and on this branch both fail at
that same step. The flows that touch the terminal (`terminal-interactions`,
`pad-workspace`) fail identically on both arms, at
`tapOn: 'Switch to zsh'` -- a pane strip that an editor pane no longer shows
since #23. Baseline and branch logs are in the scratchpad
(`e2e-base.log`, `e2e-mine3.log`, `e2e-base-smoke1.log`, `e2e-smoke1.log`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
