### PR TITLE
chore(format): oxfmt ignores the pulled store config

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -14,6 +14,7 @@
     "src/i18n/locales/**",
     "src/api/api.ts",
     "src/api/types.ts",
-    "patches/**"
+    "store.config.json",
+    "store/**"
   ]
 }


### PR DESCRIPTION
`store.config.json` is gitignored App Store Connect data written by `eas metadata:pull`, but oxfmt formats the working tree rather than the index, so its presence turned `bun run format:check` red on every branch for anyone who had pulled the listing — it did for me while verifying #28. Ignored, together with the `store/` screenshot tree. `patches/**` goes: the directory no longer exists since #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)