### PR TITLE
fix(editor): the keyboard sits where a keyboard sits, and only the handle floats

### DIFF
--- a/src/components/editor-controls.tsx
+++ b/src/components/editor-controls.tsx
@@ -1,6 +1,6 @@
 import { useLingui } from '@lingui/react/macro';
 import { useThemeTokens } from '@osuki-dev/ui';
-import { ChevronDown, ChevronUp, Keyboard as KeyboardIcon } from 'lucide-react-native';
+import { Keyboard as KeyboardIcon } from 'lucide-react-native';
 import { useCallback, type ReactNode } from 'react';
 import {
   StyleSheet,
@@ -18,16 +18,21 @@ import Animated, {
 import { GlassChrome } from '@/components/glass-chrome';
 import { PressableScale } from '@/components/pressable-scale';
 import { appChrome } from '@/constants/appearance';
-import { withAlpha } from '@/lib/color';
+import {
+  nextHandleCorner,
+  reseatFloatingHandle,
+  snapFloatingHandle,
+  type HandleBounds,
+} from '@/lib/floating-handle';
 import { fadeIn, fadeOutDown, riseIn, settleTo, zoomIn, zoomOut } from '@/lib/motion';
 
 /**
- * The controls an editor pane is left with, floating over the grid.
+ * The controls an editor pane is left with, over the grid.
  *
- * ## Why it floats
+ * ## Why nothing here is measured into the terminal
  *
  * The maintainer's brief, in one line: if nvim is open then this is a whole
- * nvim, and the keyboard and the input float over it and come out when tapped.
+ * nvim, and the keyboard and the input come over it and out again when tapped.
  *
  * A dock cannot do that. A dock is height, height comes out of the terminal,
  * and on an editor the height it comes out of is nvim's status line and its
@@ -44,87 +49,72 @@ import { fadeIn, fadeOutDown, riseIn, settleTo, zoomIn, zoomOut } from '@/lib/mo
  * the dock is measured into the terminal's bottom inset, and this deliberately
  * is not measured into anything.
  *
- * ## Why it moves
+ * ## The two states are one control, and only one of them floats
  *
- * The rest of the brief: what floats can be dragged, with some animation,
- * because sometimes it covers the content. A fixed overlay on an editor is a
- * bet about which rows the reader cares about, and the bet is lost the moment
- * they are editing the line the panel is standing on. So the
- * cluster is dragged vertically, and it settles where the throw was going --
- * `settleTo`, the app's one spring, critically damped so it absorbs the
- * velocity without bouncing (see `lib/motion.ts`).
+ * Collapsed it is a small round button. That button is the only chrome over
+ * the file, so it is the thing the reader moves out of the way of the line
+ * they are reading -- and it moves the way every floating control on a phone
+ * moves: it follows the finger in both axes and parks against the left or the
+ * right rail when the finger lifts (AssistiveTouch, a chat head, a
+ * picture-in-picture window). Where it goes is `lib/floating-handle`; how it
+ * gets there is `settleTo`, the app's one spring, critically damped so it
+ * absorbs the throw without bouncing. A drag is not the only way: the button
+ * carries a move action that walks the four corners, for a reader who cannot
+ * make the gesture.
  *
- * Dragging is not the only way. The panel carries a visible pair of chevrons
- * that step it by a quarter of the pane, and both sizes answer the standard
- * "move up"/"move down" accessibility actions, so the cluster is movable by
- * someone who cannot make the gesture -- and by someone who has not guessed
- * that it is draggable at all.
- *
- * ## The two sizes are one control
- *
- * Collapsed it is a handle in the bottom corner -- not the corner itself, and
- * not on the last row of the grid, so it is over an editor's own chrome as
- * little as possible while staying under a thumb. Tapped, it becomes a panel
- * carrying the app's keyboard, the editor keys and the way to the composer.
- * The position is shared between the two, so a reader who moved the handle out
- * of the way finds the panel where they left it.
+ * Tapped, it becomes the keyboard -- and the keyboard does not float. It is a
+ * keyboard, so it sits where a keyboard sits: across the bottom of the pane,
+ * over the last rows, in the seat the ordinary dock has on every other pane.
+ * There is nothing above it to grab, no chevrons and no second dismissal. It
+ * was briefly given all three, and a header row of controls over an on-screen
+ * keyboard reads as neither a keyboard nor a dock: the way out of it is the
+ * keyboard's own toggle, which is where the reader has just been looking, and
+ * the button comes back exactly where they left it.
  */
 
 /**
- * How far above the bottom of the pane the cluster rests before it is moved.
+ * How far above the bottom of the pane the button rests before it is moved.
  *
  * Two rows of a terminal at the default text size, not a decorative margin.
  * nvim's status line and its command line are the bottom two rows of the
  * screen, and they are what a reader is looking at while they type `:w` -- so
- * the one place the controls must not start is on top of them.
+ * the one place the button must not start is on top of them.
  */
 const RESTING_GAP = 40;
-/** Inset of the collapsed handle from the right-hand edge. */
+/** Inset of the button from the rail it is parked against. */
 const HANDLE_GAP = 14;
 const HANDLE_SIZE = 46;
-/** What one press of a chevron, or one accessibility action, is worth. */
-const STEP_FRACTION = 0.25;
-/** Movement before the drag takes the touch off the control underneath it. */
+/** Movement before the drag takes the touch off the button underneath it. */
 const DRAG_SLOP = 6;
-/**
- * How much of the release velocity, in seconds, the throw is projected over.
- *
- * Not a duration -- it is the horizon the flick is aimed at, and the spring
- * decides how long getting there takes. Small on purpose: a cluster that flew
- * the length of a flick would leave the pane on any real gesture.
- */
-const FLING_PROJECTION_S = 0.06;
-/** How long the handle is held before the hold is a move rather than a tap. */
-const LONG_PRESS_MS = 400;
 
 export interface EditorControlsProps {
-  /** The cluster is open: the panel rather than the handle. */
+  /** The keyboard is out, rather than the button that opens it. */
   expanded: boolean;
   onExpand: () => void;
-  onCollapse: () => void;
   /**
-   * Where the cluster has been dragged to, in points above its resting place.
+   * Where the reader has parked the button, in points from its resting corner.
    *
    * Owned by the screen rather than by this component so that the position
-   * outlives a trip out of the editor and back: leaving nvim unmounts the
-   * cluster, and a reader who moved it should not have to move it again.
+   * outlives a trip out of the editor and back: leaving nvim unmounts this,
+   * and a reader who moved the button should not have to move it again. `x` is
+   * zero on the right rail and negative on the left; `y` is negative upwards.
    */
-  offset: SharedValue<number>;
-  /** Clearance at the top of the pane -- the header the cluster must not reach. */
+  offsetX: SharedValue<number>;
+  offsetY: SharedValue<number>;
+  /** Clearance at the top of the pane -- the header the button must not reach. */
   topInset?: number;
   /** Clearance at the bottom: the safe area, and anything standing in it. */
   bottomInset?: number;
   /**
    * The system keyboard's height as it animates, negative while it is up.
    *
-   * The cluster rides it rather than the terminal doing so, and that is a
+   * The panel rides it rather than the terminal doing so, and that is a
    * deliberate choice rather than a convenience: shrinking the terminal for the
    * phone's keyboard is a grid resize, and a grid resize on an editor is a
    * `SIGWINCH` and a full repaint for the ten seconds it takes to paste a line
    * -- twice, once on the way up and once on the way down. What the reader
    * needs to see while typing is the field they are typing into, and the field
-   * travels with this. What the keyboard covers is the editor's own bottom
-   * rows, and moving the cluster is how those are recovered.
+   * travels with this.
    */
   keyboardOffset?: SharedValue<number>;
   /** The panel's body: the keyboard, the keys, the composer. */
@@ -136,8 +126,8 @@ export interface EditorControlsProps {
 export function EditorControls({
   expanded,
   onExpand,
-  onCollapse,
-  offset,
+  offsetX,
+  offsetY,
   topInset = 0,
   bottomInset = 0,
   keyboardOffset,
@@ -147,137 +137,142 @@ export function EditorControls({
   const { t } = useLingui();
   const theme = useThemeTokens();
   const chromeText = theme.colors.text;
-  const chromeGlass = withAlpha(theme.colors.text, appChrome.opacity.chromeControl);
 
-  /** The pane's own height, and the cluster's -- the two numbers the clamp needs. */
+  /** The pane's own size: the two numbers every bound below is derived from. */
+  const trackWidth = useSharedValue(0);
   const trackHeight = useSharedValue(0);
-  const clusterHeight = useSharedValue(0);
   const resting = bottomInset + RESTING_GAP;
 
   /**
-   * How far up the cluster may go: the pane, less what it already occupies at
-   * rest and the clearance it must leave at the top.
+   * The rectangle of offsets the button may rest at.
    *
-   * Recomputed inside the worklets rather than stored, so that a panel opening
-   * (which changes `clusterHeight` between two frames) can never be dragged
-   * against a limit measured for the handle.
+   * Recomputed inside the worklets rather than stored, so a rotation between
+   * two frames can never be dragged against a limit measured for the old
+   * screen.
    */
-  const travel = useCallback(() => {
+  const bounds = useCallback((): HandleBounds => {
     'worklet';
-    return Math.max(0, trackHeight.value - clusterHeight.value - resting - topInset);
-  }, [clusterHeight, resting, topInset, trackHeight]);
+    return {
+      minX: -Math.max(0, trackWidth.value - HANDLE_SIZE - HANDLE_GAP * 2),
+      maxX: 0,
+      minY: -Math.max(0, trackHeight.value - HANDLE_SIZE - resting - topInset),
+      maxY: Math.max(0, RESTING_GAP - HANDLE_GAP),
+    };
+  }, [resting, topInset, trackHeight, trackWidth]);
 
-  const clusterStyle = useAnimatedStyle(() => ({
-    // The drag and the keyboard are one translation, clamped together: a
-    // cluster already dragged near the top of the pane must not be pushed off
-    // it by the keyboard arriving underneath.
-    transform: [{ translateY: Math.max(-travel(), offset.value + (keyboardOffset?.value ?? 0)) }],
+  /**
+   * The bounds the button was last settled against.
+   *
+   * Kept so that a pane which changes size knows which rail the remembered
+   * offset *meant*, rather than re-deriving it from the new rectangle: on a
+   * screen that got wider, an offset that was the left rail is nearer the
+   * right one, and reseating by nearest alone walks the button across the pane
+   * on every rotation.
+   */
+  const settledBounds = useSharedValue<HandleBounds | null>(null);
+
+  const handleStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: offsetX.value }, { translateY: offsetY.value }],
   }));
 
   /**
-   * Keeps the cluster inside the pane after it changes size or the pane does.
+   * The keyboard's own travel, and the only thing that moves the panel.
    *
-   * Both measurements or nothing. React Native lays children out before their
-   * parents, so the cluster reports its height while the pane's is still zero
-   * -- and a clamp run against a zero-height pane says "no travel", which would
-   * throw away a remembered position on the first frame of every arrival.
+   * The safe area is subtracted because the phone's keyboard covers it: the
+   * panel already pads for it, and translating by the raw height would leave
+   * that padding as a band of terminal between the keys and the keyboard --
+   * which is what the ordinary dock's own animated style has always avoided,
+   * by exactly this arithmetic.
    */
-  const reclamp = useCallback(() => {
-    'worklet';
-    if (trackHeight.value <= 0 || clusterHeight.value <= 0) return;
-    const limit = -travel();
-    if (offset.value < limit) settleTo(offset, limit);
-    else if (offset.value > 0) settleTo(offset, 0);
-  }, [clusterHeight, offset, trackHeight, travel]);
-
-  function measureTrack(event: LayoutChangeEvent) {
-    trackHeight.value = event.nativeEvent.layout.height;
-    reclamp();
-  }
-
-  function measureCluster(event: LayoutChangeEvent) {
-    clusterHeight.value = event.nativeEvent.layout.height;
-    reclamp();
-  }
-
-  /** One chevron press, or one accessibility action. Negative is upward. */
-  const step = useCallback(
-    (direction: -1 | 1) => {
-      const limit = -travel();
-      const by = direction * Math.max(1, trackHeight.value * STEP_FRACTION);
-      settleTo(offset, Math.min(0, Math.max(limit, offset.value + by)));
-    },
-    [offset, trackHeight, travel]
-  );
-
-  const moveUpLabel = t`Move the controls up`;
-  const moveDownLabel = t`Move the controls down`;
-  // Two vocabularies for the same pair, because the two sizes are different
-  // kinds of control. The handle is a button -- activating it opens the panel
-  // -- so moving it has to be a *custom* action hung off that button. The grip
-  // does nothing when activated and everything when adjusted, which is what
-  // `adjustable` means, and increment/decrement are the actions the platforms
-  // already bind to a swipe up and a swipe down on one.
-  const handleActions = [
-    { name: 'moveUp', label: moveUpLabel },
-    { name: 'moveDown', label: moveDownLabel },
-  ];
-  const gripActions = [
-    { name: 'increment', label: moveUpLabel },
-    { name: 'decrement', label: moveDownLabel },
-  ];
-  function onAccessibilityAction(event: AccessibilityActionEvent) {
-    const action = event.nativeEvent.actionName;
-    if (action === 'moveUp' || action === 'increment') step(-1);
-    if (action === 'moveDown' || action === 'decrement') step(1);
-  }
-
-  // The drag itself. `activeOffsetY` is what lets the handle stay a button: the
-  // pan does not claim the touch until the finger has actually travelled, so a
-  // tap reaches the `Pressable` underneath and only a drag takes it away.
-  const startOffset = useSharedValue(0);
-  const drag = Gesture.Pan()
-    .activeOffsetY([-DRAG_SLOP, DRAG_SLOP])
-    .failOffsetX([-DRAG_SLOP * 3, DRAG_SLOP * 3])
-    .onStart(() => {
-      startOffset.value = offset.value;
-    })
-    .onUpdate((event) => {
-      const limit = -travel();
-      offset.value = Math.min(0, Math.max(limit, startOffset.value + event.translationY));
-    })
-    .onEnd((event) => {
-      const limit = -travel();
-      // Where the throw was going, not where the finger stopped: a flick that
-      // ends mid-pane should carry, and `settleTo` is what carries it.
-      const projected = offset.value + event.velocityY * FLING_PROJECTION_S;
-      settleTo(offset, Math.min(0, Math.max(limit, projected)), event.velocityY);
-    });
+  const panelStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: -Math.max(0, -(keyboardOffset?.value ?? 0) - bottomInset) }],
+  }));
 
   /**
-   * Hold the handle: it jumps to the far end of its travel, and again to come
-   * back. The third way to move it, for a thumb already resting on it.
+   * Keeps a remembered position inside a pane that has changed size under it.
    *
-   * The `Pressable`'s own long press rather than a gesture racing the pan:
-   * React Native does not fire `onPress` on a release that has already been
-   * reported as a long press, so the same touch cannot both move the cluster
-   * and open it -- which is exactly what a `LongPress` gesture beside the
-   * button would have done.
+   * Measured or nothing: React Native reports a zero-height box before it
+   * reports a real one, and a reseat run against a zero-height pane says "no
+   * travel", which would throw away a remembered position on the first frame
+   * of every arrival.
    */
-  const toggleEnds = useCallback(() => {
-    const limit = -travel();
-    settleTo(offset, offset.value < limit / 2 ? 0 : limit);
-  }, [offset, travel]);
+  function measureTrack(event: LayoutChangeEvent) {
+    const { width, height } = event.nativeEvent.layout;
+    trackWidth.value = width;
+    trackHeight.value = height;
+    if (width <= 0 || height <= 0) return;
+    const next = bounds();
+    const previous = settledBounds.value;
+    const rest = previous
+      ? reseatFloatingHandle({ x: offsetX.value, y: offsetY.value }, previous, next)
+      : snapFloatingHandle({ x: offsetX.value, y: offsetY.value }, next);
+    settledBounds.value = next;
+    if (rest.x !== offsetX.value) settleTo(offsetX, rest.x);
+    if (rest.y !== offsetY.value) settleTo(offsetY, rest.y);
+  }
 
-  // The gesture wraps a plain `View` in both sizes rather than the animated or
-  // glass one it contains: `GestureDetector` attaches to its child by ref, and
-  // `GlassChrome` renders three different surfaces depending on the platform,
-  // none of which forwards one.
+  /**
+   * The move action: one corner on, clockwise from the top left.
+   *
+   * A custom action hung off the button rather than increment/decrement,
+   * because activating the button opens the keyboard -- it is a button first,
+   * and a thing that can be relocated second.
+   */
+  const moveLabel = t`Move the editor controls`;
+  const handleActions = [{ name: 'move', label: moveLabel }];
+  const moveToNextCorner = useCallback(() => {
+    const next = bounds();
+    const corner = nextHandleCorner({ x: offsetX.value, y: offsetY.value }, next);
+    settledBounds.value = next;
+    settleTo(offsetX, corner.x);
+    settleTo(offsetY, corner.y);
+  }, [bounds, offsetX, offsetY, settledBounds]);
+  function onAccessibilityAction(event: AccessibilityActionEvent) {
+    if (event.nativeEvent.actionName === 'move') moveToNextCorner();
+  }
+
+  // The drag itself. `minDistance` is what lets the button stay a button: the
+  // pan does not claim the touch until the finger has actually travelled, so a
+  // tap reaches the `Pressable` underneath and only a drag takes it away.
+  const startX = useSharedValue(0);
+  const startY = useSharedValue(0);
+  const drag = Gesture.Pan()
+    .minDistance(DRAG_SLOP)
+    .onStart(() => {
+      startX.value = offsetX.value;
+      startY.value = offsetY.value;
+    })
+    .onUpdate((event) => {
+      // Free in both axes while the finger is down: the button is under the
+      // touch, not on a track beside it. Bounded by the pane and nothing else
+      // -- a control dragged past the edge of the screen is a control the
+      // reader cannot get back.
+      const edge = bounds();
+      offsetX.value = Math.min(edge.maxX, Math.max(edge.minX, startX.value + event.translationX));
+      offsetY.value = Math.min(edge.maxY, Math.max(edge.minY, startY.value + event.translationY));
+    })
+    .onEnd((event) => {
+      const next = bounds();
+      const rest = snapFloatingHandle(
+        { x: offsetX.value, y: offsetY.value, velocityX: event.velocityX },
+        next
+      );
+      settledBounds.value = next;
+      // The spring carries the throw's own velocity into the rail it was
+      // heading for, so a flick lands rather than being taken away and put
+      // down by the app.
+      settleTo(offsetX, rest.x, event.velocityX);
+      settleTo(offsetY, rest.y, event.velocityY);
+    });
+
+  // The gesture wraps a plain `View` rather than the animated or glass one it
+  // contains: `GestureDetector` attaches to its child by ref, and `GlassChrome`
+  // renders three different surfaces depending on the platform, none of which
+  // forwards one.
   const handle = (
-    // `box-none` on the row: it is the width of the pane and only the circle in
-    // it is a control, so without this the whole line would eat taps aimed at
-    // the editor behind it.
-    <View pointerEvents="box-none" style={styles.handleRow}>
+    <Animated.View
+      pointerEvents="box-none"
+      style={[styles.handleAnchor, { bottom: resting, right: HANDLE_GAP }, handleStyle]}>
       <GestureDetector gesture={drag}>
         <View>
           <Animated.View entering={zoomIn('short')} exiting={zoomOut('micro')}>
@@ -291,8 +286,6 @@ export function EditorControls({
                 feedback="selection"
                 pressedScale={0.9}
                 onPress={onExpand}
-                onLongPress={toggleEnds}
-                delayLongPress={LONG_PRESS_MS}
                 style={styles.handleFace}>
                 <KeyboardIcon size={20} color={chromeText} />
               </PressableScale>
@@ -300,82 +293,30 @@ export function EditorControls({
           </Animated.View>
         </View>
       </GestureDetector>
-    </View>
+    </Animated.View>
   );
 
   const panel = (
-    <GlassChrome
-      face="floating"
-      entering={riseIn()}
-      exiting={fadeOutDown('short')}
-      style={styles.panel}>
-      {/* The grip: what the drag is aimed at once the panel is open, so a
-          finger looking for it never lands on a letter. The chevrons beside it
-          are the same movement without the gesture, and the chevron down at the
-          end is the way back to the bare editor. */}
-      <GestureDetector gesture={drag}>
-        <View style={styles.gripRow}>
-          <PressableScale
-            accessibilityRole="button"
-            accessibilityLabel={moveUpLabel}
-            feedback="selection"
-            pressedScale={0.9}
-            onPress={() => step(-1)}
-            style={[styles.gripButton, { backgroundColor: chromeGlass }]}>
-            <ChevronUp size={16} color={chromeText} />
-          </PressableScale>
-          {/* The bar between the chevrons is what the drag is aimed at, and it
-              is its own accessibility element rather than a decoration inside
-              an accessible row: making the *row* accessible would collapse the
-              chevrons and the close button into it and leave a screen reader
-              with one control where there are four. */}
-          <View
-            accessible
-            accessibilityRole="adjustable"
-            accessibilityLabel={t`Move the editor controls`}
-            accessibilityActions={gripActions}
-            onAccessibilityAction={onAccessibilityAction}
-            style={styles.gripBarWrap}>
-            <View style={[styles.gripBar, { backgroundColor: chromeGlass }]} />
-          </View>
-          <PressableScale
-            accessibilityRole="button"
-            accessibilityLabel={moveDownLabel}
-            feedback="selection"
-            pressedScale={0.9}
-            onPress={() => step(1)}
-            style={[styles.gripButton, { backgroundColor: chromeGlass }]}>
-            <ChevronDown size={16} color={chromeText} />
-          </PressableScale>
-          <PressableScale
-            accessibilityRole="button"
-            accessibilityLabel={t`Hide the editor controls`}
-            feedback="selection"
-            pressedScale={0.9}
-            onPress={onCollapse}
-            style={[styles.gripButton, { backgroundColor: chromeGlass }]}>
-            <KeyboardIcon size={16} color={theme.colors.primary} />
-          </PressableScale>
+    <Animated.View pointerEvents="box-none" style={[styles.panelAnchor, panelStyle]}>
+      <GlassChrome
+        face="floating"
+        entering={riseIn()}
+        exiting={fadeOutDown('short')}
+        style={[styles.panel, { paddingBottom: Math.max(bottomInset, 10) }]}>
+        <View
+          // The body is inert while the pane cannot take input -- a reconnecting
+          // SSH shell, a pane the gateway has not answered for.
+          pointerEvents={disabled ? 'none' : 'auto'}
+          style={[styles.panelBody, disabled ? styles.panelBodyDisabled : null]}>
+          {children}
         </View>
-      </GestureDetector>
-      <View
-        // The body is inert while the pane cannot take input -- a reconnecting
-        // SSH shell, a pane the gateway has not answered for.
-        pointerEvents={disabled ? 'none' : 'auto'}
-        style={[styles.panelBody, disabled ? styles.panelBodyDisabled : null]}>
-        {children}
-      </View>
-    </GlassChrome>
+      </GlassChrome>
+    </Animated.View>
   );
 
   return (
     <View pointerEvents="box-none" style={StyleSheet.absoluteFill} onLayout={measureTrack}>
-      <Animated.View
-        pointerEvents="box-none"
-        onLayout={measureCluster}
-        style={[styles.cluster, { bottom: resting }, clusterStyle]}>
-        {expanded ? panel : handle}
-      </Animated.View>
+      {expanded ? panel : handle}
     </View>
   );
 }
@@ -392,20 +333,24 @@ export const editorPanelRow = {
 };
 
 const styles = StyleSheet.create({
-  cluster: {
+  /**
+   * The button's resting corner. Everything the drag does is a translation off
+   * this, so the remembered offset means the same thing on every screen size.
+   */
+  handleAnchor: {
     position: 'absolute',
-    left: 0,
-    right: 0,
-    // Above the pane's own floating chrome -- the "jump to latest" pill and the
-    // history spinner -- which are the only other things over the grid.
+    // Above the pane's own floating chrome -- the history spinner, the
+    // quick-action pair -- which are the only other things over the grid.
     zIndex: 12,
     elevation: 12,
   },
-  handleRow: {
-    flexDirection: 'row',
-    justifyContent: 'flex-end',
-    paddingHorizontal: HANDLE_GAP,
-  },
+  /**
+   * Unchanged from the dock-era handle, and deliberately: measured against the
+   * app's other floating chrome -- `GlassChrome`, `PressableScale`, the dock's
+   * key-row toggles -- the size, the radius, the fill, the shadow and the
+   * centred icon already agree with them. What was wrong with this control was
+   * where it went, not what it looked like.
+   */
   handle: {
     width: HANDLE_SIZE,
     height: HANDLE_SIZE,
@@ -420,45 +365,26 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
+  /** Where a keyboard goes: the full width of the pane, along the bottom of it. */
+  panelAnchor: {
+    position: 'absolute',
+    zIndex: 12,
+    elevation: 12,
+    left: 0,
+    right: 0,
+    bottom: 0,
+  },
+  /** The ordinary dock's own shape, because this stands in the dock's seat. */
   panel: {
-    marginHorizontal: 8,
-    paddingHorizontal: 8,
-    paddingTop: 4,
-    paddingBottom: 6,
-    gap: 6,
-    borderRadius: appChrome.radius.composerDock,
+    paddingTop: 8,
+    paddingHorizontal: 10,
+    borderTopLeftRadius: appChrome.radius.composerDock,
+    borderTopRightRadius: appChrome.radius.composerDock,
     borderCurve: 'continuous',
-    overflow: 'hidden',
     boxShadow: appChrome.shadow.composerDock,
   },
-  gripRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-    paddingVertical: 4,
-  },
-  gripButton: {
-    width: 34,
-    height: 30,
-    borderRadius: 10,
-    borderCurve: 'continuous',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  /** The grip is the whole space between the chevrons, not just the bar in it. */
-  gripBarWrap: {
-    flex: 1,
-    height: 30,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  gripBar: {
-    width: 44,
-    height: 5,
-    borderRadius: 2.5,
-  },
   panelBody: {
-    gap: 6,
+    gap: 8,
   },
   panelBodyDisabled: {
     opacity: appChrome.opacity.disabled,

--- a/src/components/server-terminal-workspace.tsx
+++ b/src/components/server-terminal-workspace.tsx
@@ -1289,14 +1289,17 @@ export function ServerTerminalWorkspace({
   }, [fullScreenPane, selection.paneId]);
 
   /**
-   * Where the reader dragged the editor's floating cluster.
+   * Where the reader parked the editor's floating button. Two axes, because
+   * the button is dragged in two and rests against a rail rather than on a
+   * track.
    *
    * Held by the screen rather than by the component so it survives leaving nvim
    * and coming back, and switching to another pane and back: a reader who moved
-   * the controls off the line they were editing has said something, and saying
+   * the button off the line they were editing has said something, and saying
    * it again on every arrival is the defect the drag exists to fix.
    */
-  const editorControlsOffset = useSharedValue(0);
+  const editorHandleX = useSharedValue(0);
+  const editorHandleY = useSharedValue(0);
 
   // Leaving the pane, or the keyboard, ends the visit a revealed composer
   // belonged to: the next arrival starts with the file having the height again.
@@ -2644,6 +2647,41 @@ export function ServerTerminalWorkspace({
     </ScrollView>
   );
 
+  /**
+   * The way back to a composer the app's keyboard stood down.
+   *
+   * A circle, and it rides in the trailing seat of the terminal keys' row --
+   * opposite the leading seat the ordinary key row keeps for the keyboard
+   * toggle. It used to have a row of its own, which cost the pane a full line
+   * for one control, out of the height the keyboard had just been opened to
+   * get.
+   */
+  const composerEntry = (
+    <PressableScale
+      accessibilityRole="button"
+      accessibilityLabel={t`Write a line`}
+      feedback="selection"
+      pressedScale={0.9}
+      onPress={() => setComposerRevealed(true)}
+      style={[styles.keyRowToggle, { backgroundColor: chromeGlass }]}>
+      <PenLine size={16} color={chromeText} />
+    </PressableScale>
+  );
+
+  /**
+   * The row the keyboard carries on its own behalf: the terminal keys, and the
+   * one control that is not a key.
+   *
+   * The same element in the dock and in the editor panel, because it is the
+   * same keyboard in both.
+   */
+  const keyboardShortcuts = dock.keysInKeyboard ? (
+    <View style={styles.keyRowWrap}>
+      {terminalKeyStrip}
+      {dock.composerEntry ? composerEntry : null}
+    </View>
+  ) : undefined;
+
   /*
     The input, written once because it is the same field in two places now: in
     the dock on an ordinary pane, and floating in the editor panel on an editor.
@@ -2751,7 +2789,7 @@ export function ServerTerminalWorkspace({
           onText={typeText}
           onKey={typeKey}
           onClose={() => setKeyboardMode(false)}
-          shortcuts={dock.keysInKeyboard ? terminalKeyStrip : undefined}
+          shortcuts={keyboardShortcuts}
         />
       ) : null}
       {dock.keyRow ? (
@@ -2772,22 +2810,6 @@ export function ServerTerminalWorkspace({
             <KeyboardIcon size={16} color={theme.colors.primary} />
           </PressableScale>
           {terminalKeyStrip}
-        </Animated.View>
-      ) : null}
-      {dock.composerEntry ? (
-        <Animated.View
-          entering={fadeIn('micro')}
-          exiting={fadeOutDown('short')}
-          style={styles.composerEntryRow}>
-          <PressableScale
-            accessibilityRole="button"
-            accessibilityLabel={t`Write a line`}
-            feedback="selection"
-            pressedScale={0.9}
-            onPress={() => setComposerRevealed(true)}
-            style={[styles.keyRowToggle, { backgroundColor: chromeGlass }]}>
-            <PenLine size={16} color={chromeText} />
-          </PressableScale>
         </Animated.View>
       ) : null}
       {dock.composer ? composerField : null}
@@ -3228,8 +3250,8 @@ export function ServerTerminalWorkspace({
                 Keyboard.dismiss();
                 setKeyboardMode(true);
               }}
-              onCollapse={() => setKeyboardMode(false)}
-              offset={editorControlsOffset}
+              offsetX={editorHandleX}
+              offsetY={editorHandleY}
               keyboardOffset={keyboardOffset}
               // The floating header is chrome the cluster must not disappear
               // behind: the same clearance the grid itself takes above.
@@ -3363,31 +3385,8 @@ export function ServerTerminalWorkspace({
                         onText={typeText}
                         onKey={typeKey}
                         onClose={() => setKeyboardMode(false)}
-                        shortcuts={dock.keysInKeyboard ? terminalKeyStrip : undefined}
+                        shortcuts={keyboardShortcuts}
                       />
-                    </Animated.View>
-                  ) : null}
-                  {/* The way back to the composer without putting the keyboard away.
-                Closing the keyboard was the only route to it, which on an
-                editor meant giving up `esc`, `:w` and the Ctrl chords for as
-                long as it took to paste a line. A single control, so it floats
-                in the dock's corner rather than taking a row -- the same rent
-                argument as `floatingActions`. */}
-                  {dock.composerEntry ? (
-                    <Animated.View
-                      entering={fadeIn('micro')}
-                      exiting={fadeOutDown('short')}
-                      layout={dockRowLayout}
-                      style={styles.composerEntryRow}>
-                      <PressableScale
-                        accessibilityRole="button"
-                        accessibilityLabel={t`Write a line`}
-                        feedback="selection"
-                        pressedScale={0.9}
-                        onPress={() => setComposerRevealed(true)}
-                        style={[styles.keyRowToggle, { backgroundColor: chromeGlass }]}>
-                        <PenLine size={16} color={chromeText} />
-                      </PressableScale>
                     </Animated.View>
                   ) : null}
                   {!dock.virtualKeyboard ? (
@@ -4198,15 +4197,6 @@ const styles = StyleSheet.create({
     borderCurve: 'continuous',
     alignItems: 'center',
     justifyContent: 'center',
-  },
-  /**
-   * The lone control that summons the composer back over the keyboard. Right-
-   * aligned, where the send button it stands in for would be, so the thumb that
-   * reaches for one reaches for the other.
-   */
-  composerEntryRow: {
-    flexDirection: 'row',
-    justifyContent: 'flex-end',
   },
   padKeyRowEntry: {
     width: 34,

--- a/src/components/skia-terminal.tsx
+++ b/src/components/skia-terminal.tsx
@@ -56,6 +56,7 @@ import { PressableScale } from '@/components/pressable-scale';
 import { useCoalescedValue } from '@/hooks/use-coalesced-value';
 import { useFreezeGate, useFrozenValue } from '@/hooks/use-frozen-value';
 import { useLatestRef } from '@/hooks/use-render-refs';
+import { latestPillVisible } from '@/lib/dock-presentation';
 import { feedback } from '@/lib/feedback';
 import { fadeOut, timing, zoomIn, zoomOut } from '@/lib/motion';
 import { isSafeExternalLink } from '@/lib/safe-link';
@@ -2727,12 +2728,18 @@ export function SkiaTerminal({
           </Button>
         </View>
       ) : null}
-      {!following && !selection ? (
+      {latestPillVisible({ following, selecting: selection !== null, ownsScreen }) ? (
         // One of the most frequently seen controls in the app, and until now the
         // only one that appeared and vanished between two frames. It comes up
         // when the reader leaves the tail of a live stream, which is a moment
         // they are already reading through, so it arrives rather than being
         // suddenly there.
+        //
+        // Whether it may be here at all is `latestPillVisible`, and it is a
+        // function in `dock-presentation` rather than the three `&&`s that used
+        // to be on this line: the third of them -- that an editor has no
+        // "latest" to jump to -- is a rule about the app, not about this view,
+        // and a rule about the app belongs somewhere a test can read it.
         <Animated.View
           entering={zoomIn('micro')}
           exiting={zoomOut('micro')}

--- a/src/components/ssh-terminal-workspace.tsx
+++ b/src/components/ssh-terminal-workspace.tsx
@@ -358,10 +358,12 @@ export function SshTerminalWorkspace({ hostId }: { hostId: string }) {
   }, [editorPane]);
 
   /**
-   * Where the reader dragged the floating cluster, kept here rather than in the
-   * component so it outlives a trip out of nvim and back into it.
+   * Where the reader parked the editor's floating button, kept here rather
+   * than in the component so it outlives a trip out of nvim and back into it.
+   * Two axes, because the button is dragged in two.
    */
-  const editorControlsOffset = useSharedValue(0);
+  const editorHandleX = useSharedValue(0);
+  const editorHandleY = useSharedValue(0);
 
   // The row follows what the shell is running: nvim's own actions on top of
   // the shell set while an editor is up, and only Esc and the basics while
@@ -905,6 +907,26 @@ export function SshTerminalWorkspace({ hostId }: { hostId: string }) {
     </ScrollView>
   );
 
+  /**
+   * The way to the composer from a surface that has stood it down.
+   *
+   * A circle, and it rides in the trailing seat of the terminal keys' row --
+   * opposite the leading seat that row keeps for the keyboard toggle. It used
+   * to have a row of its own, which cost the pane a full line for one control
+   * and took it out of the height the keyboard had just been opened to get.
+   */
+  const composerEntry = (
+    <PressableScale
+      accessibilityRole="button"
+      accessibilityLabel={t`Write a line`}
+      feedback="selection"
+      pressedScale={0.9}
+      onPress={() => setComposerRevealed(true)}
+      style={[styles.keyRowToggle, { backgroundColor: chromeGlass }]}>
+      <PenLine size={16} color={chromeText} />
+    </PressableScale>
+  );
+
   /** The app's own keyboard, wherever it is standing: in the dock, or floating. */
   const virtualKeyboard = (
     <VirtualKeyboard
@@ -912,23 +934,15 @@ export function SshTerminalWorkspace({ hostId }: { hostId: string }) {
       onText={typeText}
       onKey={typeKey}
       onClose={() => setKeyboardMode(false)}
-      shortcuts={dock.keysInKeyboard ? <View style={styles.keyRow}>{keyStrip}</View> : undefined}
+      shortcuts={
+        dock.keysInKeyboard ? (
+          <View style={styles.keyRow}>
+            {keyStrip}
+            {dock.composerEntry ? composerEntry : null}
+          </View>
+        ) : undefined
+      }
     />
-  );
-
-  /** The way to the composer from a surface that has stood it down. */
-  const composerEntry = (
-    <View style={styles.composerEntryRow}>
-      <PressableScale
-        accessibilityRole="button"
-        accessibilityLabel={t`Write a line`}
-        feedback="selection"
-        pressedScale={0.9}
-        onPress={() => setComposerRevealed(true)}
-        style={[styles.keyRowToggle, { backgroundColor: chromeGlass }]}>
-        <PenLine size={16} color={chromeText} />
-      </PressableScale>
-    </View>
   );
 
   const composer = (
@@ -997,7 +1011,6 @@ export function SshTerminalWorkspace({ hostId }: { hostId: string }) {
           {keyStrip}
         </Animated.View>
       ) : null}
-      {dock.composerEntry ? composerEntry : null}
       {dock.composer ? composer : null}
     </>
   );
@@ -1080,12 +1093,13 @@ export function SshTerminalWorkspace({ hostId }: { hostId: string }) {
           <EditorControls
             expanded={dock.editorPanel}
             onExpand={openVirtualKeyboard}
-            onCollapse={() => setKeyboardMode(false)}
-            offset={editorControlsOffset}
+            offsetX={editorHandleX}
+            offsetY={editorHandleY}
             keyboardOffset={keyboardHeight}
             // The terminal's box runs to the bottom of the screen now that the
-            // dock is out of its flow, so the safe area is the cluster's to
-            // clear -- the same inset the grid already leaves nvim.
+            // dock is out of its flow, so the safe area is the panel's to pad
+            // for and the button's to clear -- the same inset the grid already
+            // leaves nvim.
             bottomInset={insets.bottom}
             disabled={!connected}>
             {editorPanelBody}
@@ -1118,9 +1132,6 @@ export function SshTerminalWorkspace({ hostId }: { hostId: string }) {
           style={[styles.dockOverlay, dockKeyboardStyle]}>
           <GlassChrome style={[styles.dock, { paddingBottom: Math.max(insets.bottom, 10) }]}>
             {dock.virtualKeyboard ? virtualKeyboard : null}
-            {/* The way back to the composer without putting the keyboard away:
-                one control in the corner where Send would be, as on the gateway. */}
-            {dock.composerEntry ? composerEntry : null}
             {dock.keyRow ? (
               <View style={styles.keyRow}>
                 {keyboardToggle}
@@ -1351,11 +1362,6 @@ const styles = StyleSheet.create({
     gap: 6,
     paddingHorizontal: 1,
     alignItems: 'center',
-  },
-  /** Right-aligned, where the send button it stands in for would be. */
-  composerEntryRow: {
-    flexDirection: 'row',
-    justifyContent: 'flex-end',
   },
   terminalKey: {
     height: KEY_ROW_HEIGHT,

--- a/src/components/virtual-keyboard.tsx
+++ b/src/components/virtual-keyboard.tsx
@@ -488,8 +488,32 @@ const KEY_GAP = 5;
 const ARROW_GAP = 3;
 /** Keeps ten-unit rows comfortably key-sized instead of stretching across a Pad pane. */
 const VIRTUAL_KEYBOARD_MAX_WIDTH = 640;
-/** The platform-neutral minimum touch target shared by letter and function keys. */
-const MINIMUM_KEY_HEIGHT = 44;
+/**
+ * The height of every key, letter and function alike.
+ *
+ * Measured against what the reader has just had under their thumb rather than
+ * against a guideline. An iPhone's own letter keys are about 42 points tall on
+ * a 390-wide phone and Gboard is within a point of that; the terminal keyboards
+ * this one is judged beside -- Blink, Termius -- run 36 to 40. This sits inside
+ * that band.
+ *
+ * What it is *not* allowed below is the touch target, and the target is this
+ * plus `KEY_GAP`: the gap between two keys is dead space that belongs to
+ * whichever of them the finger is nearer, so the reachable area of a key is its
+ * height plus one gap. 38 + 5 is 43, which clears the 44-point guideline within
+ * a point and clears the 40 this app holds itself to outright. The test below
+ * asserts the sum rather than the height, because the height on its own is not
+ * the number that decides whether a key can be hit.
+ *
+ * It was 44, which put the pitch at 49 and cost five rows 30 points of the
+ * file -- close to two terminal rows on a phone, taken from the one surface
+ * where the whole argument was that the program owns every row.
+ *
+ * One value, and deliberately not a density prop: the dock's keyboard and the
+ * editor panel's are the same keyboard, and a reader who learns where `g` is
+ * with the dock up must find it in the same place when nvim opens.
+ */
+const KEY_HEIGHT = 38;
 
 // Every weight below is in key widths, and every row adds up to ROW_UNITS
 // exactly -- 1.5 + 3.2 + 3.8 + 1.5 on the bottom row, 4.25 + 4.25 + 1.5 on the
@@ -515,7 +539,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   key: {
-    height: MINIMUM_KEY_HEIGHT,
+    height: KEY_HEIGHT,
     borderRadius: 8,
     borderCurve: 'continuous',
     alignItems: 'center',

--- a/src/lib/__tests__/dock-presentation.test.ts
+++ b/src/lib/__tests__/dock-presentation.test.ts
@@ -5,7 +5,11 @@
  */
 import { describe, expect, test } from 'bun:test';
 
-import { dockPresentation, type DockPresentationInput } from '@/lib/dock-presentation';
+import {
+  dockPresentation,
+  latestPillVisible,
+  type DockPresentationInput,
+} from '@/lib/dock-presentation';
 import type { PaneApproval } from '@/lib/pane-approval';
 
 const APPROVAL: PaneApproval = {
@@ -390,5 +394,95 @@ describe('dock presentation', () => {
         }
       }
     });
+  });
+  // One circle does not get a line of the pane. The entry had a row to itself,
+  // which is the same rent `floatingActions` refuses -- and it was charging it
+  // out of the height the keyboard had just been opened to get.
+  describe('the way back to the composer rides in a row that already exists', () => {
+    test('with the keys up, the entry rides in their row', () => {
+      const dock = dockPresentation(input({ keyboardMode: true }));
+      expect(dock.keysInKeyboard).toBe(true);
+      expect(dock.composerEntry).toBe(true);
+      expect(dock.composer).toBe(false);
+    });
+
+    test('with the key row switched off there is no seat, so the field shows instead', () => {
+      // The alternative is a row grown to hold one button, which costs exactly
+      // what taking the button's row away just saved. So this state shows the
+      // destination rather than the door to it.
+      const dock = dockPresentation(input({ keyboardMode: true, showTerminalKeyRow: false }));
+      expect(dock.keysInKeyboard).toBe(false);
+      expect(dock.composerEntry).toBe(false);
+      expect(dock.composer).toBe(true);
+    });
+
+    test('the entry is never on screen without a row under it', () => {
+      // The whole rule, over every combination the screen can be in: if the
+      // button is showing, the keys' row is showing, because that is where it
+      // sits.
+      for (const keyboardMode of [true, false]) {
+        for (const editorPane of [true, false]) {
+          for (const composerRevealed of [true, false]) {
+            for (const showTerminalKeyRow of [true, false]) {
+              const dock = dockPresentation(
+                input({ keyboardMode, editorPane, composerRevealed, showTerminalKeyRow })
+              );
+              if (dock.composerEntry) expect(dock.keysInKeyboard).toBe(true);
+              // And there is always exactly one of the two: a way to the
+              // composer, or the composer -- never neither, unless the pane has
+              // nothing on it at all.
+              if (!dock.approvalOnly && !dock.editorHandle) {
+                expect(dock.composer || dock.composerEntry).toBe(true);
+              }
+              expect(dock.composer && dock.composerEntry).toBe(false);
+            }
+          }
+        }
+      }
+    });
+
+    test('the same rule on an editor, where there is no dock to fall back on', () => {
+      const open = { editorPane: true, keyboardMode: true };
+      expect(dockPresentation(input(open)).composerEntry).toBe(true);
+      const noKeys = dockPresentation(input({ ...open, showTerminalKeyRow: false }));
+      expect(noKeys.composerEntry).toBe(false);
+      expect(noKeys.composer).toBe(true);
+    });
+  });
+});
+
+// The pill is a way back to the bottom of a scrollback. It is a function
+// rather than a condition in a render because the third of its three clauses
+// is a statement about the app -- what "latest" means on a pane whose program
+// paints the whole viewport -- and a statement about the app should be
+// somewhere a test can read it.
+describe('the jump-to-latest pill', () => {
+  const scrolled = { following: false, selecting: false, ownsScreen: false };
+
+  test('offered to a reader who has left the tail', () => {
+    expect(latestPillVisible(scrolled)).toBe(true);
+  });
+
+  test('not offered to one who is already on it', () => {
+    expect(latestPillVisible({ ...scrolled, following: true })).toBe(false);
+  });
+
+  test('not offered under a selection, which has the seat', () => {
+    expect(latestPillVisible({ ...scrolled, selecting: true })).toBe(false);
+  });
+
+  test('never on a pane whose program owns the screen', () => {
+    // nvim repaints its own viewport and keeps nothing behind it, so there is
+    // no "latest" to jump to -- and the offer was being made in the corner of
+    // a file, over a surface whose author has an opinion about every cell.
+    expect(latestPillVisible({ ...scrolled, ownsScreen: true })).toBe(false);
+  });
+
+  test('and not even when every other reason to show it holds', () => {
+    for (const following of [true, false]) {
+      for (const selecting of [true, false]) {
+        expect(latestPillVisible({ following, selecting, ownsScreen: true })).toBe(false);
+      }
+    }
   });
 });

--- a/src/lib/__tests__/floating-handle.test.ts
+++ b/src/lib/__tests__/floating-handle.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Where the editor's floating handle lands.
+ *
+ * The rule is one sentence -- it rests on a rail, never in the middle of the
+ * file -- and it is the sentence a drag can break in four different ways, so
+ * it is a table rather than three clamps read off a worklet.
+ */
+import { describe, expect, test } from 'bun:test';
+
+import {
+  FLING_PROJECTION_S,
+  handleCorners,
+  nextHandleCorner,
+  reseatFloatingHandle,
+  snapFloatingHandle,
+  type HandleBounds,
+} from '@/lib/floating-handle';
+
+/** A phone-sized pane: the handle is anchored bottom-right, so left and up are negative. */
+const BOUNDS: HandleBounds = { minX: -320, maxX: 0, minY: -560, maxY: 26 };
+
+describe('the handle rests on a rail', () => {
+  test('a slow release goes to the nearer edge', () => {
+    // Left of the middle, barely moving: the left rail.
+    expect(snapFloatingHandle({ x: -260, y: -100, velocityX: 0 }, BOUNDS).x).toBe(BOUNDS.minX);
+    // Right of it: the right rail.
+    expect(snapFloatingHandle({ x: -40, y: -100, velocityX: 0 }, BOUNDS).x).toBe(BOUNDS.maxX);
+  });
+
+  test('it never comes to rest between the rails', () => {
+    for (let x = BOUNDS.minX; x <= BOUNDS.maxX; x += 10) {
+      const rest = snapFloatingHandle({ x, y: -200, velocityX: 0 }, BOUNDS);
+      expect([BOUNDS.minX, BOUNDS.maxX]).toContain(rest.x);
+    }
+  });
+
+  test('the vertical is left where the finger left it', () => {
+    expect(snapFloatingHandle({ x: -10, y: -211, velocityX: 0 }, BOUNDS).y).toBe(-211);
+  });
+});
+
+describe('a flick carries', () => {
+  test('a throw crosses the middle it never reached', () => {
+    // Released just left of centre, moving right fast: the rail it was heading
+    // for, not the one it happened to be nearest when the finger lifted.
+    const rest = snapFloatingHandle({ x: -170, y: -100, velocityX: 2400 }, BOUNDS);
+    expect(rest.x).toBe(BOUNDS.maxX);
+  });
+
+  test('and the same throw the other way', () => {
+    expect(snapFloatingHandle({ x: -150, y: -100, velocityX: -2400 }, BOUNDS).x).toBe(BOUNDS.minX);
+  });
+
+  test('a drift is not a throw', () => {
+    // A finger creeping right at the end of a slow drag must not throw the
+    // handle across the pane: below the projection horizon it is still nearest
+    // wins.
+    const drift = 40 / FLING_PROJECTION_S / 4;
+    expect(snapFloatingHandle({ x: -260, y: -100, velocityX: drift }, BOUNDS).x).toBe(BOUNDS.minX);
+  });
+});
+
+describe('bounds are respected in both axes', () => {
+  test('the vertical is clamped clear of the header and the safe area', () => {
+    expect(snapFloatingHandle({ x: 0, y: -9000, velocityX: 0 }, BOUNDS).y).toBe(BOUNDS.minY);
+    expect(snapFloatingHandle({ x: 0, y: 9000, velocityX: 0 }, BOUNDS).y).toBe(BOUNDS.maxY);
+  });
+
+  test('a pane with no room left snaps to the one rail it has', () => {
+    const narrow: HandleBounds = { minX: 0, maxX: 0, minY: 0, maxY: 0 };
+    expect(snapFloatingHandle({ x: -80, y: -80, velocityX: -3000 }, narrow)).toEqual({
+      x: 0,
+      y: 0,
+    });
+  });
+});
+
+describe('the accessibility action walks the corners', () => {
+  test('clockwise from the top left', () => {
+    expect(handleCorners(BOUNDS)).toEqual([
+      { x: -320, y: -560 },
+      { x: 0, y: -560 },
+      { x: 0, y: 26 },
+      { x: -320, y: 26 },
+    ]);
+  });
+
+  test('each action moves one corner on and the fourth comes back', () => {
+    const corners = handleCorners(BOUNDS);
+    let at = corners[0];
+    for (const expected of [corners[1], corners[2], corners[3], corners[0]]) {
+      at = nextHandleCorner(at, BOUNDS);
+      expect(at).toEqual(expected);
+    }
+  });
+
+  test('it continues from where a drag left the handle, not from a step count', () => {
+    // Dropped near the bottom right by hand: the next action is the bottom
+    // left, the corner after that one -- not wherever a remembered index had
+    // got to.
+    expect(nextHandleCorner({ x: -8, y: 20 }, BOUNDS)).toEqual({ x: -320, y: 26 });
+  });
+});
+
+describe('a pane that changed size under a remembered position', () => {
+  const LANDSCAPE: HandleBounds = { minX: -700, maxX: 0, minY: -260, maxY: 26 };
+
+  test('a handle on the left rail is still on the left rail after a rotation', () => {
+    // The nearest rail of the *new* bounds would be the right one -- 320 in
+    // from it against 380 from the left -- which is exactly the answer that
+    // walks the handle across the pane on every rotation.
+    expect(reseatFloatingHandle({ x: -320, y: -400 }, BOUNDS, LANDSCAPE)).toEqual({
+      x: -700,
+      y: -260,
+    });
+  });
+
+  test('and one on the right rail stays on the right', () => {
+    expect(reseatFloatingHandle({ x: 0, y: -100 }, BOUNDS, LANDSCAPE)).toEqual({
+      x: 0,
+      y: -100,
+    });
+  });
+
+  test('a position below the new floor is brought back up to it', () => {
+    expect(reseatFloatingHandle({ x: 0, y: 26 }, BOUNDS, { ...LANDSCAPE, maxY: 8 }).y).toBe(8);
+  });
+});

--- a/src/lib/__tests__/virtual-keyboard-layout.test.ts
+++ b/src/lib/__tests__/virtual-keyboard-layout.test.ts
@@ -50,7 +50,10 @@ function rows(table: string): string[][] {
 
 const ROW_UNITS = Number(source.match(/const ROW_UNITS = (\d+)/)?.[1]);
 const SHIFT_UNITS = Number(source.match(/const SHIFT_UNITS = ([0-9.]+)/)?.[1]);
-const MINIMUM_KEY_HEIGHT = Number(source.match(/const MINIMUM_KEY_HEIGHT = ([0-9.]+)/)?.[1]);
+const KEY_HEIGHT = Number(source.match(/const KEY_HEIGHT = ([0-9.]+)/)?.[1]);
+const KEY_GAP = Number(source.match(/const KEY_GAP = ([0-9.]+)/)?.[1]);
+/** The smallest hit area, key plus gap, this keyboard is allowed to ship. */
+const MINIMUM_TOUCH_TARGET = 40;
 const VIRTUAL_KEYBOARD_MAX_WIDTH = Number(
   source.match(/const VIRTUAL_KEYBOARD_MAX_WIDTH = ([0-9.]+)/)?.[1]
 );
@@ -155,9 +158,25 @@ describe('the keyboard adapts without stretching its keys', () => {
     expect(VIRTUAL_KEYBOARD_MAX_WIDTH).toBeLessThanOrEqual(640);
   });
 
-  test('every key keeps a 44pt minimum touch target', () => {
-    expect(MINIMUM_KEY_HEIGHT).toBeGreaterThanOrEqual(44);
-    expect(styleBody('key')).toContain('height: MINIMUM_KEY_HEIGHT');
+  test('a key is still comfortably hittable at the height it was cut to', () => {
+    // The hit area is the key plus one gap -- the space between two keys
+    // belongs to whichever of them the finger is nearer -- so that sum is what
+    // the floor applies to, not the height on its own. Shrinking the keyboard
+    // to give the file back its rows is only allowed to go this far.
+    expect(KEY_HEIGHT + KEY_GAP).toBeGreaterThanOrEqual(MINIMUM_TOUCH_TARGET);
+    // And not so far that it stops reading as a keyboard: the terminal
+    // keyboards this one is measured against run 36 to 40.
+    expect(KEY_HEIGHT).toBeGreaterThanOrEqual(36);
+    expect(styleBody('key')).toContain('height: KEY_HEIGHT');
     expect(source.match(/\bfunctionKey:\s*\{[^}]*\bheight:/s)).toBeNull();
+  });
+
+  test('there is one keyboard, at one size', () => {
+    // The dock's keyboard and the editor panel's are the same component, and
+    // the height is a constant rather than a prop, so neither surface can grow
+    // a keyboard of its own with the letters in different places.
+    expect((source.match(/height: KEY_HEIGHT/g) ?? []).length).toBe(1);
+    // No prop reaches the height, so no caller can pass a second one.
+    expect(/height:\s*(?:props\.|keyHeight|compact)/.test(source)).toBe(false);
   });
 });

--- a/src/lib/dock-presentation.ts
+++ b/src/lib/dock-presentation.ts
@@ -97,12 +97,11 @@ export interface DockPresentation {
    * covers the two rows the reader is typing into.
    *
    * So on these panes the dock does not shrink or rearrange -- it goes, and
-   * what is left floats over the grid: `editorHandle` when it is out of the
-   * way, `editorPanel` when it has been asked for. Nothing that floats is
-   * allowed to change the terminal's layout, which is the other half of the
-   * same sentence: a dock that reserved height would resize the grid, and a
-   * grid resize is a SIGWINCH and a full repaint every time a reader reaches
-   * for `esc`.
+   * what is left lies over the grid: `editorHandle` when it is out of the way,
+   * `editorPanel` when it has been asked for. Neither is allowed to change the
+   * terminal's layout, which is the other half of the same sentence: a dock
+   * that reserved height would resize the grid, and a grid resize is a
+   * SIGWINCH and a full repaint every time a reader reaches for `esc`.
    *
    * A standing question outranks it. An approval clears the dock down to
    * itself on every pane, editor included, and an answerable question with the
@@ -112,13 +111,24 @@ export interface DockPresentation {
   /**
    * The one small control left over the editor: the way back to the keyboard.
    *
-   * Collapsed state of the cluster. Mutually exclusive with `editorPanel`,
-   * because they are the same object in its two sizes.
+   * This is the half that floats. It is dragged in both axes and parks on the
+   * left or the right rail, because it is the only chrome over the file and
+   * the reader moves it for one reason -- it is standing on the line they are
+   * reading. Mutually exclusive with `editorPanel`: they are the same control
+   * in its two states, and tapping one is what produces the other.
    */
   editorHandle: boolean;
   /**
-   * The cluster opened: the app's keyboard, the editor keys, and the way to
-   * the composer -- all of it floating over an unchanged grid.
+   * The keyboard opened: the app's QWERTY, the editor keys, and the way to the
+   * composer, over an unchanged grid.
+   *
+   * This half does *not* float. It is a keyboard, so it sits where a keyboard
+   * sits -- across the bottom of the pane, over the last rows, with nothing
+   * above it to grab. It carries no grip, no chevrons and no second dismissal:
+   * the keyboard's own toggle closes it, and the handle comes back where the
+   * reader left it. What makes it an overlay rather than a dock is unchanged
+   * and is the whole point -- it reserves no height, so opening it cannot
+   * re-derive the grid.
    */
   editorPanel: boolean;
   /** The pane strip. */
@@ -151,11 +161,18 @@ export interface DockPresentation {
   /** The input, its send button, and the popups that hang off the caret. */
   composer: boolean;
   /**
-   * The way back to a composer that stood down for an editor's keyboard.
+   * The way back to a composer that stood down for the app's keyboard.
    *
-   * A floating button rather than a row, for the same reason `floatingActions`
-   * is one: a line of the pane is too much rent for a single control, and the
-   * height it would take is the height the keyboard was opened to get.
+   * It rides in the terminal keys' own row -- which, while the keyboard is up,
+   * is the row inside the keyboard -- and never anywhere else. It had a row of
+   * its own, and a full-width line of the pane holding one circle is the same
+   * rent `floatingActions` exists to refuse: the height it took was the height
+   * the keyboard had been opened to get.
+   *
+   * There is no state where this is true and no row is up to carry it. When
+   * the reader has switched the key row off there is nothing to ride in, and
+   * the answer then is not a row with a button on it but the thing the button
+   * summons: `composer` is true instead, and the field itself is what shows.
    */
   composerEntry: boolean;
   /**
@@ -242,6 +259,19 @@ export function dockPresentation({
   // handle, so a text field cannot be among what is left whether or not the
   // reader asked for one earlier.
   const composerStandsDown = editorHandle || ((virtualKeyboard || editorMode) && !composerRevealed);
+  // Where the way back to it sits, and what happens when there is nowhere.
+  //
+  // The entry is one circle. A circle does not get a row -- it rides in the
+  // trailing seat of the terminal keys' row, opposite the leading seat that
+  // row already keeps for the keyboard toggle. While the app's keyboard is up
+  // that row is inside the keyboard, which is what `keysInKeyboard` names, and
+  // that is the only state a standing-down composer is ever in.
+  //
+  // With the key row switched off there is no seat, and a row grown to hold
+  // the entry would cost exactly what taking the entry's row away just saved.
+  // So that state shows the field rather than the button for it: one row
+  // either way, and the one that is already the destination.
+  const composerEntrySeat = keysInKeyboard;
 
   return {
     approvalOnly: answerable,
@@ -254,11 +284,11 @@ export function dockPresentation({
     floatingActions: entriesShown && !showTerminalKeyRow,
     attachEntry: dockRows && attachmentsAvailable,
     attachmentStrip: dockRows && stagedAttachments > 0,
-    composer: !answerable && !composerStandsDown,
+    composer: !answerable && !editorHandle && (!composerStandsDown || !composerEntrySeat),
     // The handle is the only thing over a collapsed editor, and it is already
-    // the way to the composer -- a second floating button beside it would be
-    // two controls for one door.
-    composerEntry: composerStandsDown && !editorHandle,
+    // the way to the keyboard the composer lives in -- a second control beside
+    // it would be two doors to one room.
+    composerEntry: composerStandsDown && !editorHandle && composerEntrySeat,
     keysInKeyboard,
     // Derived from the two surfaces that carry a real `esc` rather than from
     // the flag alone, so that a rule which one day keeps the row up through
@@ -267,4 +297,38 @@ export function dockPresentation({
     bannerEscape: answerable && !keyRow && !virtualKeyboard,
     animateReflow: screenOnTop,
   };
+}
+
+/** What the "jump to latest output" pill is decided from. */
+export interface LatestPillInput {
+  /** The canvas is pinned to the tail of the stream. */
+  following: boolean;
+  /** A selection is up, and its own controls have the seat the pill sits in. */
+  selecting: boolean;
+  /**
+   * A full-screen program owns the pane: nvim, an editor, a pager, an agent
+   * painting its own screen.
+   */
+  ownsScreen: boolean;
+}
+
+/**
+ * Whether the "jump to latest output" pill may be on the pane at all.
+ *
+ * Two of these are the affordance's own business and have always been: it is
+ * for getting back to a tail the reader has left, so it is not offered while
+ * they are already on it, and it stands down for a selection because the
+ * selection's controls take the seat it sits in.
+ *
+ * The third is why this is a function rather than three `&&`s in a render.
+ * "Latest" is a statement about a scrollback: somewhere below the reader there
+ * is newer output, and this is the way down to it. A program that owns the
+ * screen has no such place. nvim paints the whole viewport every frame and
+ * keeps no history behind it, so the pill offers a journey to where the reader
+ * already is -- and it offers it over the file, in the corner, on a surface
+ * whose author has an opinion about every cell. It was the one piece of the
+ * app's chrome that stayed on an editor after the dock left for it.
+ */
+export function latestPillVisible({ following, selecting, ownsScreen }: LatestPillInput): boolean {
+  return !following && !selecting && !ownsScreen;
 }

--- a/src/lib/floating-handle.ts
+++ b/src/lib/floating-handle.ts
@@ -1,0 +1,136 @@
+/**
+ * Where a floating handle comes to rest.
+ *
+ * The editor's collapsed control is the one piece of chrome left over a
+ * full-screen program, and the reader moves it for exactly one reason: it is
+ * standing on the line they are reading. So it follows the finger in both
+ * axes -- AssistiveTouch, a chat head, a picture-in-picture window -- and the
+ * only question this file answers is where it goes when the finger lifts.
+ *
+ * It goes to an edge. A control released in the middle of the pane is a
+ * control sitting on the text, which is the state the drag existed to get out
+ * of; parking it against the left or the right rail costs the file one column
+ * instead of a hole in the middle of it. The vertical is left exactly where
+ * the reader put it, because that is the axis they were actually aiming with.
+ *
+ * Pure and free of Reanimated so the rule is a table in a test rather than
+ * three clamps inside a worklet. The gesture supplies the numbers; this
+ * decides the answer; `settleTo` carries the value there.
+ */
+
+/** The rectangle of offsets the handle may rest at, in points. */
+export interface HandleBounds {
+  /** Left rail. Negative, because the handle is anchored to the right one. */
+  minX: number;
+  /** Right rail, which is the anchor itself: zero unless the pane is tiny. */
+  maxX: number;
+  /** As high as the handle may go -- negative, and clear of the header. */
+  minY: number;
+  /** As low as it may go, clear of the bottom safe area. */
+  maxY: number;
+}
+
+/** A point in the same offset space. */
+export interface HandlePoint {
+  x: number;
+  y: number;
+}
+
+/**
+ * How much of the release velocity, in seconds, the throw is projected over.
+ *
+ * Not a duration -- it is the horizon the flick is aimed at, and only the edge
+ * it picks out matters, because the spring lands on a rail either way. Enough
+ * that a deliberate flick across the pane crosses the midpoint, small enough
+ * that letting go while barely moving does not.
+ */
+export const FLING_PROJECTION_S = 0.12;
+
+function clamp(value: number, low: number, high: number): number {
+  'worklet';
+  return Math.min(high, Math.max(low, value));
+}
+
+/**
+ * The rest point for a release: the nearer rail, or the one the throw was
+ * heading for.
+ *
+ * A slow release goes to whichever rail is closer to the finger. A flick is
+ * projected forward first, so a handle thrown from the left half to the right
+ * lands on the right even though it never got past the middle -- which is what
+ * "the edge it was heading for" means and what a plain nearest-edge test gets
+ * wrong on every fast gesture.
+ */
+export function snapFloatingHandle(
+  release: HandlePoint & { velocityX?: number },
+  bounds: HandleBounds
+): HandlePoint {
+  'worklet';
+  const projected = clamp(
+    release.x + (release.velocityX ?? 0) * FLING_PROJECTION_S,
+    bounds.minX,
+    bounds.maxX
+  );
+  const middle = (bounds.minX + bounds.maxX) / 2;
+  return {
+    x: projected < middle ? bounds.minX : bounds.maxX,
+    y: clamp(release.y, bounds.minY, bounds.maxY),
+  };
+}
+
+/**
+ * The four rest positions, in the order the accessibility action walks them.
+ *
+ * Clockwise from the top left, which is the order a reader describes a screen
+ * in. Someone who cannot make the drag gesture gets the same four places a
+ * drag can leave the handle, one action at a time.
+ */
+export function handleCorners(bounds: HandleBounds): HandlePoint[] {
+  return [
+    { x: bounds.minX, y: bounds.minY },
+    { x: bounds.maxX, y: bounds.minY },
+    { x: bounds.maxX, y: bounds.maxY },
+    { x: bounds.minX, y: bounds.maxY },
+  ];
+}
+
+/**
+ * The next corner round from wherever the handle is now.
+ *
+ * "Wherever it is now" is the nearest corner rather than an index held
+ * somewhere: the handle can also be dragged, and an action that continued from
+ * a remembered step would send it back across the pane it was just moved off.
+ */
+export function nextHandleCorner(from: HandlePoint, bounds: HandleBounds): HandlePoint {
+  const corners = handleCorners(bounds);
+  let nearest = 0;
+  let best = Number.POSITIVE_INFINITY;
+  for (const [index, corner] of corners.entries()) {
+    const distance = (corner.x - from.x) ** 2 + (corner.y - from.y) ** 2;
+    if (distance < best) {
+      best = distance;
+      nearest = index;
+    }
+  }
+  return corners[(nearest + 1) % corners.length];
+}
+
+/**
+ * Keeps a remembered position inside bounds that have changed under it.
+ *
+ * A rotation, a text-size change, a pane that grew: the offset the reader left
+ * is measured against a rectangle that no longer exists. Which rail the handle
+ * was on is read off the bounds it was resting in rather than off the new
+ * ones, because those are two different answers -- on a screen that got wider,
+ * an offset that was the left rail is nearer the right one, and a handle the
+ * reader parked on the left would cross the pane on a rotation.
+ */
+export function reseatFloatingHandle(
+  at: HandlePoint,
+  from: HandleBounds,
+  to: HandleBounds
+): HandlePoint {
+  'worklet';
+  const wasLeft = at.x < (from.minX + from.maxX) / 2;
+  return { x: wasLeft ? to.minX : to.maxX, y: clamp(at.y, to.minY, to.maxY) };
+}


### PR DESCRIPTION
Five defects the maintainer found on a real phone, all of them in the editor overlay #23 introduced. The constraint #23 was built around holds throughout: nothing here is measured into the terminal, so none of it can re-derive the grid or resize the PTY. Every pair of screenshots below has the nvim text band at the same pixel row on both sides.

Evidence branch: [`evidence/editor-overlay-polish`](https://github.com/osuki-dev/muqun-app/tree/evidence/editor-overlay-polish).

---

## 1. The floating handle

Measured against the app's other floating chrome first, because that is what the report suspected: `GlassChrome`'s material, the 46pt circle, the 23pt radius, `appChrome.shadow.floatingPill`, the `chromeControl` fill, `PressableScale`'s 0.9 press, the centred 20pt icon. All of them already agree with the dock's key-row toggles and the "jump to latest" pill. A pixel diff of the handle between `main` and this branch is **0 differing pixels of 10,492** on iOS -- the control's appearance is untouched, and the section below says so rather than inventing a token change.

| | |
|---|---|
| iOS | ![](https://raw.githubusercontent.com/osuki-dev/muqun-app/evidence/editor-overlay-polish/zoom-ios-handle.png) |
| Android | ![](https://raw.githubusercontent.com/osuki-dev/muqun-app/evidence/editor-overlay-polish/zoom-and-handle.png) |

What was wrong with it was **where it went**, in three ways, and all three are visible rather than argued.

**It travelled on a vertical track and parked in the middle of the file.** A control that is over the text is the state the drag exists to get out of, and a track can only trade one row of the file for another. It now follows the finger in both axes and settles on the left or the right rail -- AssistiveTouch, a chat head, picture-in-picture. The same drag gesture, on both platforms:

| | |
|---|---|
| iOS | ![](https://raw.githubusercontent.com/osuki-dev/muqun-app/evidence/editor-overlay-polish/pair-ios-2-drag.png) |
| Android | ![](https://raw.githubusercontent.com/osuki-dev/muqun-app/evidence/editor-overlay-polish/pair-and-2-drag.png) |

**Opening it from anywhere but the bottom threw the panel under the nav header.** The panel shared the handle's offset, so a handle moved up produced a panel with its first row behind the title pill and the file completely covered. This is the same gesture as above, followed by a tap:

| | |
|---|---|
| iOS | ![](https://raw.githubusercontent.com/osuki-dev/muqun-app/evidence/editor-overlay-polish/pair-ios-3b-dragged.png) |
| Android | ![](https://raw.githubusercontent.com/osuki-dev/muqun-app/evidence/editor-overlay-polish/pair-and-3b-dragged.png) |

**It collided with the "jump to latest" pill** in the bottom-right corner -- see section 3, where the Android before-shot has the pill tucked under the circle.

At the top of its travel it stops clear of the header and is not clipped ([ios-after-07-handle-top.png](https://raw.githubusercontent.com/osuki-dev/muqun-app/evidence/editor-overlay-polish/ios-after-07-handle-top.png)); at the bottom it rests two terminal rows above nvim's status line, as before. Light theme on both platforms, keyboard up and down, and after the panel opens and closes it comes back exactly where it was left.

Where it lands is a pure function with a table of its own, `src/lib/floating-handle.ts`: nearest rail for a slow release, the projected rail for a flick, the vertical left where the finger left it, and a corner cycle for the accessibility action. `reseatFloatingHandle` reads the rail off the bounds the handle was resting in rather than the new ones, which is what stops a rotation from walking it across a wider pane.

## 2. The soft keyboard was in the wrong position

The panel is anchored to the bottom of the pane and pads for the safe area, and it was then translated by the **raw** keyboard height. The safe area was therefore counted twice, and the composer floated that far above the keys it belongs on. It now uses the ordinary dock's own arithmetic, `-max(0, -height - bottomInset)`, which is the line `dockKeyboardStyle` in `ssh-terminal-workspace.tsx` has always used.

Measured off the screenshots -- the gap between the bottom edge of the composer surface and the top edge of the system keyboard:

| | before | after |
|---|---|---|
| iOS, software keyboard (hardware keyboard disconnected) | composer ends 464, keyboard starts 539 -- **74pt** | one continuous surface, **0** |
| Android, Gboard (`com.google.android.inputmethod.latin`) | composer ends 514, Gboard starts 578 -- **63dp** | one continuous surface, **0** |

| | |
|---|---|
| iOS | ![](https://raw.githubusercontent.com/osuki-dev/muqun-app/evidence/editor-overlay-polish/pair-ios-4-composer.png) |
| Android | ![](https://raw.githubusercontent.com/osuki-dev/muqun-app/evidence/editor-overlay-polish/pair-and-4-composer.png) |

The grid underneath is unchanged in both: the nvim text band sits on the same row on both sides of each pair, which is the rule from #23 and the reason the PTY is still never resized for a keyboard that is up for one line.

## 3. No Latest button in nvim

"Latest" is a statement about a scrollback: somewhere below the reader there is newer output and this is the way down to it. A program that repaints its whole viewport has no such place, and the offer was being made in the corner of a file -- on Android, on top of the handle.

The rule is a pure function next to the dock's, with the three clauses named:

```ts
export function latestPillVisible({ following, selecting, ownsScreen }: LatestPillInput): boolean {
  return !following && !selecting && !ownsScreen;
}
```

`skia-terminal.tsx` calls it where three `&&`s used to be, so the gesture layer is untouched apart from that one line. Its test is in `dock-presentation.test.ts`:

```ts
test('never on a pane whose program owns the screen', () => {
  expect(latestPillVisible({ ...scrolled, ownsScreen: true })).toBe(false);
});

test('and not even when every other reason to show it holds', () => {
  for (const following of [true, false]) {
    for (const selecting of [true, false]) {
      expect(latestPillVisible({ following, selecting, ownsScreen: true })).toBe(false);
    }
  }
});
```

Both shots are the same pane, scrolled off the tail by the same gesture:

| | |
|---|---|
| iOS | ![](https://raw.githubusercontent.com/osuki-dev/muqun-app/evidence/editor-overlay-polish/pair-ios-5-pill.png) |
| Android | ![](https://raw.githubusercontent.com/osuki-dev/muqun-app/evidence/editor-overlay-polish/pair-and-5-pill.png) |

## 4. Two keyboard icons

The panel carried its own dismissal in the grip row, and the keyboard it hosted carried the one it has on every other pane. Both were a keyboard glyph in the primary colour, six points apart in the QWERTY state -- and in the composer state the second one meant something different from the first, which is worse than a duplicate. Both are in the before-shots of sections 1 and 5.

Resolved by section 5 rather than by a flag: the grip row is gone, so the keyboard's own toggle is the only one, in both of the panel's states. In the composer state the single keyboard glyph is the key row's "back to the on-screen keyboard", and it is the only one on screen.

## 5. The keys did not need to be that tall, and the panel did not need a header

The panel was a floating card with a header row of its own -- two chevrons, a drag bar and a dismissal -- resting a gap plus a safe area above the bottom of the pane, with the way back to the composer on a full-width row of its own underneath the keys.

It is a keyboard. It now sits where a keyboard sits: across the bottom, full width, in the seat the ordinary dock has on every other pane, with nothing above it to grab and no second dismissal. Only the handle floats.

**Key height.** Measured against what the reader has just had under their thumb rather than against a guideline. An iPhone's own letter keys are about 42pt tall on a 390-wide phone and Gboard is within a point of that; the terminal keyboards this one is judged beside -- Blink, Termius -- run 36 to 40. 44 on a 49 pitch was outside that band in the wrong direction. It is now **38 on a 43 pitch**: one constant, no density prop, so the dock's keyboard and the panel's stay the same keyboard with the letters in the same places. The floor the test asserts is the *hit area* -- key plus one gap, because the space between two keys belongs to whichever of them the finger is nearer -- and 43 clears the 40 this app holds itself to.

```ts
test('a key is still comfortably hittable at the height it was cut to', () => {
  expect(KEY_HEIGHT + KEY_GAP).toBeGreaterThanOrEqual(MINIMUM_TOUCH_TARGET);
  expect(KEY_HEIGHT).toBeGreaterThanOrEqual(36);
});
```

**The metric that matters** -- terminal rows visible above the panel, in nvim on the demo workspace, same file, same text size, same device:

| | panel top, before | panel top, after | given back | rows visible above the panel |
|---|---|---|---|---|
| iOS (17.5pt line) | 417 | 575 | **158pt** | 17 -> **26** |
| Android (18.7dp line) | 491 | 639 | **148dp** | 20 -> **28** |

| | |
|---|---|
| iOS | ![](https://raw.githubusercontent.com/osuki-dev/muqun-app/evidence/editor-overlay-polish/pair-ios-3-panel.png) |
| Android | ![](https://raw.githubusercontent.com/osuki-dev/muqun-app/evidence/editor-overlay-polish/pair-and-3-panel.png) |

Dragging still moves the handle, and the panel comes back at the bottom regardless of where the handle was left -- so a reader who moved the button out of the way of a line does not then get a keyboard standing on a different one.

## 6. The composer entry had a row to itself, in the ordinary dock too

Reported against the SSH screen with the app's keyboard up, and it is the same rule on both screens, so it is decided in one place. The entry is one circle. A circle does not get a full-width line of the pane -- that is the rent `floatingActions` already exists to refuse, and it was being charged out of the height the keyboard had just been opened to get.

It rides the trailing seat of the terminal keys' row, opposite the leading seat that row already keeps for the keyboard toggle. While the app's keyboard is up that row is inside the keyboard, which is the only state a stood-down composer is ever in:

```ts
const composerEntrySeat = keysInKeyboard;
...
composer: !answerable && !editorHandle && (!composerStandsDown || !composerEntrySeat),
composerEntry: composerStandsDown && !editorHandle && composerEntrySeat,
```

With the key row switched off there is no seat, and a row grown to hold the entry costs exactly what taking its row away just saved -- so that state shows the field rather than the button for it. The invariant is swept over every combination the screen can be in:

```ts
test('the entry is never on screen without a row under it', () => {
  ...
  if (dock.composerEntry) expect(dock.keysInKeyboard).toBe(true);
  if (!dock.approvalOnly && !dock.editorHandle) {
    expect(dock.composer || dock.composerEntry).toBe(true);
  }
  expect(dock.composer && dock.composerEntry).toBe(false);
});
```

SSH demo shell, app keyboard up, dock top edge measured off the screenshots:

| | before | after | reclaimed |
|---|---|---|---|
| iOS | 500 | 574 | **74pt** |
| Android | 565 | 639 | **74dp** |

Which is the entry row (36) plus its gap (8) plus five key rows at six points each (30), exactly.

| | |
|---|---|
| iOS | ![](https://raw.githubusercontent.com/osuki-dev/muqun-app/evidence/editor-overlay-polish/pair-ios-6-ssh-dock.png) |
| Android | ![](https://raw.githubusercontent.com/osuki-dev/muqun-app/evidence/editor-overlay-polish/pair-and-6-ssh-dock.png) |

---

## What the drag lost, and why that is the whole change

`EditorControls` is 462 lines lighter in its expanded half. Gone with the grip row: the panel's share of the pan gesture, the clamp that had to be recomputed every frame because the cluster changed height between two of them, the accessibility increment/decrement pair that spoke for a control the reader could not see, and the long-press that jumped it to the far end. The spring survives, in the one place a throw still has to land: the handle.

`settleTo` is still the app's only spring and still critically damped, so `motion-tokens.test.ts` passes untouched.

## Gates

```
$ npx tsc --noEmit
(exit 0)

$ bun run lint
$ oxlint --deny-warnings

$ bun run format:check
$ oxfmt --check
All matched files use the correct format.
Finished in 287ms on 434 files using 12 threads.

$ bun test src
 2677 pass
 2 skip
 0 fail
 14043 expect() calls
Ran 2679 tests across 101 files. [8.26s]
```

Rebased onto `d0a6cf3`, so #28's gesture layer is in and the only line this touches in `skia-terminal.tsx` is the pill's condition.

Devices: `muqun-ios` (iOS 26.5 simulator, software keyboard, `ConnectHardwareKeyboard` off) and `muqun_android` (AVD, real Gboard selected with `adb shell ime set`, `show_ime_with_hard_keyboard` on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
