### PR TITLE
fix(ssh): the shell hears about a new dock, not about a growing composer

### DIFF
--- a/src/components/ssh-terminal-workspace.tsx
+++ b/src/components/ssh-terminal-workspace.tsx
@@ -34,7 +34,7 @@ import { TerminalComposer } from '@/components/terminal-composer';
 import { VirtualKeyboard } from '@/components/virtual-keyboard';
 import { appChrome } from '@/constants/appearance';
 import { useLatestRef, useLazyRef } from '@/hooks/use-render-refs';
-import { useSettledHeight } from '@/hooks/use-settled-height';
+import { useDockMeasurement } from '@/hooks/use-settled-height';
 import { useTerminalTheme } from '@/hooks/use-theme-pack';
 import { editorActionDescription, terminalKeyDescription } from '@/i18n/labels';
 import { withAlpha } from '@/lib/color';
@@ -305,7 +305,54 @@ export function SshTerminalWorkspace({ hostId }: { hostId: string }) {
     `onLayout` is a nested update, and the dock's padding can alternate while
     the keyboard animates.
   */
-  const [dockHeight, measureDockHeight] = useSettledHeight(96);
+  // What the dock shows: the gateway's rule with the gateway's concerns
+  // absent -- no approval can stand here, there is one pane, and a shell has
+  // nothing to attach. The setting that hides the key row is honoured the same
+  // way; with the row gone, its keyboard toggle moves in beside the composer.
+  const dock = useMemo(
+    () =>
+      dockPresentation({
+        approval: null,
+        keyboardMode,
+        paneCount: 1,
+        showTerminalKeyRow,
+        attachmentsAvailable: false,
+        stagedAttachments: 0,
+        screenOnTop: true,
+        editorPane,
+        composerRevealed,
+      }),
+    [composerRevealed, editorPane, keyboardMode, showTerminalKeyRow]
+  );
+  /*
+    What the dock is showing, as one string.
+
+    The grid is sized by the dock's height, and that height may only reach the
+    grid when the dock has genuinely become a different dock -- see
+    `useDockMeasurement`. This is that "different dock", spelled out.
+
+    Read off the dock's own rule rather than off the facts behind it, which is
+    the difference between one window change per keyboard and two: opening the
+    app's keyboard stands the composer down, so `composerRevealed` falls in a
+    render of its own a beat after `keyboardMode` rises. Both are inputs, only
+    one of them is a dock, and `dockPresentation` is what already knows the
+    composer was gone the moment the keyboard arrived.
+
+    The safe area is deliberately *not* part of it, though the dock pads itself
+    by it. Android hands back the navigation bar's inset while the system
+    keyboard is up, so the dock's padding -- and its measured height -- moves by
+    a row every time the phone's own keyboard opens and closes. Reading that as
+    a new dock would resize the PTY on the way up and again on the way down,
+    which is the one thing `bottomChrome` above promises never to do. A rotation
+    changes the inset too, and re-measures the viewport while it is at it, so
+    the grid still follows that through `viewport`.
+  */
+  const dockShape = `${dock.approvalOnly}:${dock.editorMode}:${dock.virtualKeyboard}:${dock.keyRow}:${dock.composer}`;
+  const {
+    live: dockHeight,
+    steady: steadyDockHeight,
+    measure: measureDockHeight,
+  } = useDockMeasurement(96, dockShape);
 
   useEffect(
     () => () => {
@@ -396,6 +443,21 @@ export function SshTerminalWorkspace({ hostId }: { hostId: string }) {
     two are the same answer, since no approval can stand on an SSH shell.
   */
   const bottomChrome = editorPane ? insets.bottom : dockHeight;
+  /*
+    The same measurement, held still while the dock keeps its shape, and the
+    one the grid is allowed to read.
+
+    `bottomChrome` above is what covers the terminal *now*, which is what the
+    canvas insets by: it costs a redraw and nothing else, so it may follow the
+    composer wrapping onto a second line frame by frame. The PTY may not. Every
+    number it is given is a `SIGWINCH`, and a shell with a two-line prompt
+    answers each one by reprinting the whole prompt -- one prompt per keystroke
+    down the screen, which is the bug this split exists for. So the far side
+    hears about the keyboard opening, the key row being switched off and an
+    editor taking the screen, and hears nothing at all about a composer growing
+    a line while a command is typed into it.
+  */
+  const permanentChrome = editorPane ? insets.bottom : steadyDockHeight;
   // The canvas's own cell size, once it has measured its font. Until then the
   // advance ratio stands in; the first report re-sizes the grid once.
   const grid = useMemo(
@@ -403,14 +465,14 @@ export function SshTerminalWorkspace({ hostId }: { hostId: string }) {
       viewport.width > 0 && viewport.height > 0
         ? terminalGridFor({
             width: viewport.width,
-            height: Math.max(1, viewport.height - bottomChrome),
+            height: Math.max(1, viewport.height - permanentChrome),
             fontSize,
             cellWidth: cellMetrics?.cellWidth,
             lineHeight: cellMetrics?.lineHeight,
             pixelRatio: PixelRatio.get(),
           })
         : TERMINAL_GRID_DEFAULT,
-    [bottomChrome, cellMetrics, fontSize, viewport.height, viewport.width]
+    [permanentChrome, cellMetrics, fontSize, viewport.height, viewport.width]
   );
   const gridRef = useLatestRef(grid);
 
@@ -825,25 +887,6 @@ export function SshTerminalWorkspace({ hostId }: { hostId: string }) {
   const connected = status.phase === 'connected';
   const connecting = status.phase === 'connecting';
   const hasDraft = draft.trim().length > 0;
-  // What the dock shows: the gateway's rule with the gateway's concerns
-  // absent -- no approval can stand here, there is one pane, and a shell has
-  // nothing to attach. The setting that hides the key row is honoured the same
-  // way; with the row gone, its keyboard toggle moves in beside the composer.
-  const dock = useMemo(
-    () =>
-      dockPresentation({
-        approval: null,
-        keyboardMode,
-        paneCount: 1,
-        showTerminalKeyRow,
-        attachmentsAvailable: false,
-        stagedAttachments: 0,
-        screenOnTop: true,
-        editorPane,
-        composerRevealed,
-      }),
-    [composerRevealed, editorPane, keyboardMode, showTerminalKeyRow]
-  );
   const chromeText = theme.colors.text;
   const chromeGlass = withAlpha(theme.colors.text, appChrome.opacity.chromeControl);
 

--- a/src/hooks/__tests__/use-settled-height.test.ts
+++ b/src/hooks/__tests__/use-settled-height.test.ts
@@ -1,0 +1,108 @@
+// The dock height the PTY is sized by (the multi-line prompt regression).
+//
+// `useDockMeasurement` is `useSettledHeight` plus a ref around
+// `nextSteadyHeight`, so driving the pure rule through a sequence of
+// measurements is the same thing as driving the hook: each step is one
+// `onLayout`, and what it returns is the height the grid is sized by on the
+// render that follows.
+//
+// The rows below are the numbers that actually reach the far side. A shell
+// with a two-line prompt reprints the whole prompt on every one of them, so
+// "how many distinct row counts did this sequence produce" is the same
+// question as "how many copies of the prompt did the reader watch march down
+// the screen".
+import { describe, expect, test } from 'bun:test';
+import { nextSteadyHeight, type SteadyHeight } from '@/hooks/use-settled-height';
+import { terminalGridFor } from '@/lib/ssh-grid-metrics';
+
+/** A phone-sized terminal box, less the header and the status line. */
+const VIEWPORT = { width: 393, height: 720, fontSize: 13 } as const;
+
+/** The dock as it is measured while the app's keyboard is up. */
+const KEYBOARD_UP = 'true:true:false:false:34';
+/** The same dock with the keyboard closed: the key row and the composer only. */
+const KEYBOARD_DOWN = 'false:true:false:false:34';
+
+/** The rows the shell is told, for each measurement the dock reports. */
+function rowsTold(measurements: readonly SteadyHeight[]): number[] {
+  let steady: SteadyHeight = { shape: null, height: 96 };
+  return measurements.map((measurement) => {
+    steady = nextSteadyHeight(steady, measurement);
+    return terminalGridFor({ ...VIEWPORT, height: VIEWPORT.height - steady.height }).rows;
+  });
+}
+
+/** How many window changes a run of measurements would send. */
+function resizesSent(measurements: readonly SteadyHeight[]): number {
+  const rows = rowsTold(measurements);
+  return rows.filter((value, index) => index > 0 && value !== rows[index - 1]).length;
+}
+
+describe('nextSteadyHeight', () => {
+  test('takes the first measurement, whatever the shape', () => {
+    expect(
+      nextSteadyHeight({ shape: null, height: 96 }, { shape: KEYBOARD_UP, height: 300 })
+    ).toEqual({ shape: KEYBOARD_UP, height: 300 });
+  });
+
+  test('holds the same object while the dock keeps its shape', () => {
+    const held: SteadyHeight = { shape: KEYBOARD_DOWN, height: 140 };
+    // The identical object, so a re-measure stops at React rather than
+    // becoming a render -- which is the other half of card #20.
+    expect(nextSteadyHeight(held, { shape: KEYBOARD_DOWN, height: 178 })).toBe(held);
+  });
+
+  test('follows the dock when the dock becomes a different dock', () => {
+    expect(
+      nextSteadyHeight({ shape: KEYBOARD_DOWN, height: 140 }, { shape: KEYBOARD_UP, height: 320 })
+    ).toEqual({ shape: KEYBOARD_UP, height: 320 });
+  });
+});
+
+describe('the rows the shell is told', () => {
+  test('hold still across a run of key presses', () => {
+    // What the dock measured while `nvim .` was typed on the app's keyboard,
+    // one key at a time: the composer wraps, the key row swaps what it is
+    // carrying, and none of it is a row of the terminal. Every one of these
+    // used to be a window change, and every window change was a fresh copy of
+    // the prompt.
+    const pressing = [140, 141, 140, 159, 178, 178, 140].map((height) => ({
+      shape: KEYBOARD_DOWN,
+      height,
+    }));
+    expect(new Set(rowsTold(pressing)).size).toBe(1);
+    expect(resizesSent(pressing)).toBe(0);
+  });
+
+  test('change once, and only once, when the keyboard opens and closes', () => {
+    const transition = [
+      { shape: KEYBOARD_DOWN, height: 140 },
+      // The dock is re-measured a few times on the way up; the far side hears
+      // one number, not four.
+      { shape: KEYBOARD_UP, height: 320 },
+      { shape: KEYBOARD_UP, height: 322 },
+      { shape: KEYBOARD_UP, height: 320 },
+      { shape: KEYBOARD_DOWN, height: 140 },
+    ];
+    expect(resizesSent(transition)).toBe(2);
+  });
+
+  test('settle on the height measured under the shape that is now showing', () => {
+    // The failure this rules out is a latch that freezes on the *old* dock's
+    // height: the keyboard opens, the shape changes, and the far side is told
+    // the row count for a dock that is no longer on screen. The height that
+    // wins has to be the one that arrived with the new shape.
+    let steady: SteadyHeight = { shape: null, height: 96 };
+    for (const measurement of [
+      { shape: KEYBOARD_DOWN, height: 140 },
+      { shape: KEYBOARD_UP, height: 320 },
+      { shape: KEYBOARD_UP, height: 358 },
+    ]) {
+      steady = nextSteadyHeight(steady, measurement);
+    }
+    expect(steady).toEqual({ shape: KEYBOARD_UP, height: 320 });
+    expect(terminalGridFor({ ...VIEWPORT, height: VIEWPORT.height - steady.height }).rows).toBe(
+      terminalGridFor({ ...VIEWPORT, height: VIEWPORT.height - 320 }).rows
+    );
+  });
+});

--- a/src/hooks/use-settled-height.ts
+++ b/src/hooks/use-settled-height.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { useLatestRef } from '@/hooks/use-render-refs';
+
 /**
  * How long a measurement is given to settle before it becomes state.
  *
@@ -67,4 +69,85 @@ export function useSettledHeight(initial: number): [number, (height: number) => 
   );
 
   return [height, measure];
+}
+
+/**
+ * A measured height and the dock shape it was measured under.
+ *
+ * `shape` is null before anything has been measured at all, which is the one
+ * state that must adopt whatever arrives next: the initial height is a guess.
+ */
+export interface SteadyHeight {
+  shape: string | null;
+  height: number;
+}
+
+/**
+ * The dock height the PTY is sized by: the height the dock had when it last
+ * became a different dock.
+ *
+ * `useSettledHeight` answers "how tall is the dock now", and that is the right
+ * question for the canvas, which insets by it and pays nothing for a new
+ * answer. It is the wrong question for the PTY. A new answer there is a
+ * `window-change`, a `SIGWINCH`, and -- on any shell whose prompt spans more
+ * than one line -- a full reprint of the prompt, because that is how zsh's line
+ * editor redraws after the screen has changed size underneath it. One reprint
+ * per keystroke is the defect this exists for.
+ *
+ * The measured height is not "how much of the bottom is permanently gone",
+ * which is what the grid arithmetic above it claims to be subtracting. It moves
+ * for reasons the terminal's size has nothing to do with: the composer wraps
+ * onto a second line as a long command is typed, the composer takes focus and
+ * grows, the key row swaps what it is carrying. Measured on a booted emulator,
+ * typing one long line into the composer walked the PTY from 32 rows to 30, a
+ * window change per wrap, each one answered by a fresh copy of the prompt.
+ *
+ * So the height the grid is sized by follows the dock's *shape* instead -- the
+ * app's keyboard is up or it is not, there is a key row or there is not, an
+ * editor owns the screen or it does not. While that holds this holds, whatever
+ * the dock measures in the meantime; when it changes, the dock is a different
+ * dock and the next thing it measures is the new answer. The shape is recorded
+ * at measurement time rather than at render time on purpose: `onLayout` runs
+ * after the dock has been laid out for its new shape, so the pair that arrives
+ * there is the only pair known to belong together.
+ */
+export function nextSteadyHeight(previous: SteadyHeight, measurement: SteadyHeight): SteadyHeight {
+  // The same dock, measured again. Whatever it says now, it is covering what it
+  // was covering, and the far side is not told anything.
+  if (previous.shape === measurement.shape) return previous;
+  return measurement;
+}
+
+/**
+ * One measurement of the dock, read two ways: as the height the canvas insets
+ * by right now, and as the height the grid -- and therefore the PTY -- is
+ * sized by for as long as the dock keeps its shape.
+ *
+ * Both come off the same `onLayout`, because they are the same measurement and
+ * two of them would be two things to keep in step. `measure` writes the settled
+ * half on every call (see `useSettledHeight` for why that is throttled) and the
+ * steady half only when the shape it arrives with is new, so the nested update
+ * card #20 is about cannot come back through this door: a dock that is merely
+ * re-measured returns the identical object and React stops there.
+ */
+export function useDockMeasurement(
+  initial: number,
+  shape: string
+): { live: number; steady: number; measure: (height: number) => void } {
+  const [live, measureLive] = useSettledHeight(initial);
+  const [steady, setSteady] = useState<SteadyHeight>({ shape: null, height: initial });
+  // The shape the *next* measurement will arrive under. A ref rather than a
+  // dependency because `measure` is handed to an `onLayout` and must not be
+  // rebuilt every time the dock changes what it is showing.
+  const shapeRef = useLatestRef(shape);
+
+  const measure = useCallback(
+    (height: number) => {
+      measureLive(height);
+      setSteady((previous) => nextSteadyHeight(previous, { shape: shapeRef.current, height }));
+    },
+    [measureLive, shapeRef]
+  );
+
+  return { live, steady: steady.height, measure };
 }

--- a/src/terminal/__tests__/fixtures/snapshot-goldens.json
+++ b/src/terminal/__tests__/fixtures/snapshot-goldens.json
@@ -202,5 +202,13 @@
   "snapshot:full screen program": "c7c9bc9243c12a65:7493",
   "snapshot@60:full screen program": "3013d0e83218edaf:7493",
   "snapshot-full:full screen program": "c7c9bc9243c12a65:7493",
-  "emulator:full screen program": "37dae42a478437e9:6695"
+  "emulator:full screen program": "37dae42a478437e9:6695",
+  "snapshot:multi-line prompt redraw": "6767dfd70a740898:4319",
+  "snapshot@60:multi-line prompt redraw": "ba45c92147521cae:4319",
+  "snapshot-full:multi-line prompt redraw": "6767dfd70a740898:4319",
+  "emulator:multi-line prompt redraw": "807e64ed9b5f9aca:4319",
+  "snapshot:line editor redraw at the top row": "8d89c251aa000930:1288",
+  "snapshot@60:line editor redraw at the top row": "72534b93d8336896:1288",
+  "snapshot-full:line editor redraw at the top row": "8d89c251aa000930:1288",
+  "emulator:line editor redraw at the top row": "6f7a63ff6f7cf532:1288"
 }

--- a/src/terminal/__tests__/stream-corpus.ts
+++ b/src/terminal/__tests__/stream-corpus.ts
@@ -70,6 +70,30 @@ export const STREAM_CORPUS: readonly (readonly [string, string])[] = [
   ['crlf split point', 'line\r\nnext\r'],
   ['empty', ''],
   [
+    // zsh's line editor redrawing a two-line prompt, byte for byte off a real
+    // PTY: the prompt is reprinted from the top on every window change, and it
+    // gets back to the top with CR, CR, CUU, then erases what was there with
+    // ED. Nothing else in this corpus moves the cursor *up* and then writes
+    // over what it passed, and the whole of the multi-line-prompt regression
+    // lived in whether that lands on the old prompt or below it.
+    'multi-line prompt redraw',
+    `\r\n${CSI}36mosuki${CSI}39m ${CSI}35mmain${CSI}39m \u276f ${CSI}K` +
+      ['n', 'nv', 'nvi', 'nvim']
+        .map(
+          (buffer) =>
+            `\r\r${CSI}A${CSI}0m${CSI}27m${CSI}24m${CSI}J\r` +
+            `\n${CSI}36mosuki${CSI}39m ${CSI}35mmain${CSI}39m \u276f ${buffer}`
+        )
+        .join(''),
+  ],
+  [
+    // The same idiom in the form a single-line prompt uses it: erase the line,
+    // step up, erase again, reprint. Kept separate because it never leaves the
+    // top row and so exercises the CUU clamp rather than the fold.
+    'line editor redraw at the top row',
+    `${CSI}1;1Hfirst\r${CSI}K${CSI}1Asecond\r${CSI}2Kthird`,
+  ],
+  [
     'shell session',
     `${CSI}1;32muser@host${CSI}0m:${CSI}1;34m~${CSI}0m$ ls\r\nREADME.md  src/\r\n${CSI}1;32muser@host${CSI}0m:${CSI}1;34m~${CSI}0m$ ${CSI}?2004h`,
   ],


### PR DESCRIPTION
A shell with a multi-line prompt was reprinting its whole prompt once per
keystroke, and the reprints marched down the screen instead of the line editor
updating in place.

## What it is

zsh's line editor reprints the entire prompt on every window change. Captured
off a real PTY, one keystroke at a time, with `PROMPT=$'\n... > '`:

| | bytes zsh emits per keystroke |
|---|---|
| no window change | `n`, then `\bnv`, ... -- the echoed character, nothing else |
| one window change per keystroke | `CR CR CUU  SGR-reset  ED  CR \n <the whole two-line prompt> <buffer>` |

So "one prompt per keystroke" is "one `SIGWINCH` per keystroke". The question
was only where the app was getting them from.

## Bisect: `7c214aa` (#23)

`git log -S` over the screen puts `bottomChrome`, `dockHeight` and
`useSettledHeight` all at `7c214aa`. Before it the grid was
`terminalGridFor({ height: viewport.height })` -- the dock sat in normal flow,
so the terminal's own box already excluded it and no dock measurement ever
reached the PTY. #23 made it `viewport.height - bottomChrome`, where
`bottomChrome` is the dock's *measured pixel height*. #31 kept that shape when
it moved the dock to an overlay.

The mechanism is that the measured height moves for reasons the terminal's size
has nothing to do with, and rows turn over roughly every 19pt of it, so plenty
of them cross a boundary. Measured on `muqun_android` against a real zsh over
real SSH, with the server logging every `window-change`:

| action | window changes sent, before |
|---|---|
| composer takes focus | 1 (33 -> 32 rows) |
| typing one long command as it wraps | 2 (32 -> 31 -> 30) |

Each of those is a full prompt reprint on the far side.

## Not the emulator

`terminal-core` folds that redraw correctly. I replayed the captured zsh bytes
through it with the emulator resized in lockstep with the PTY, and again with
it deliberately mismatched (PTY 24 rows, emulator 20/22/23): every run folds to
a single prompt. `CUU` clamps and never scrolls, `EL`/`ED` write in place, and
nothing moves a row into scrollback without a real scroll. None of #23/#24/#28/
#31 touched `src/terminal/` except #28, and only to add mouse-mode flags.

But nothing exercised the idiom, so the corpus grows it -- `CR CR CUU ED`,
reprint -- plus the single-line form, with goldens.

## The fix

One measurement, read two ways.

- **The canvas** keeps insetting by what covers the terminal *now*
  (`bottomChrome`, unchanged). It costs a redraw and nothing else, so it may
  follow the composer wrapping frame by frame.
- **The grid, and therefore the PTY**, reads `permanentChrome`: a height that
  only moves when the dock has genuinely become a different dock. That is what
  the code already claimed to be subtracting -- "what *permanently* covers the
  bottom of the terminal".

The shape is read off `dockPresentation` rather than off the facts behind it,
which is the difference between one window change per keyboard and two: opening
the app's keyboard stands the composer down, so `composerRevealed` falls a
render after `keyboardMode` rises, and only the dock's own rule knows the
composer was already gone. The safe area is deliberately excluded -- Android
hands the navigation bar's inset back while the system keyboard is up, and
sizing the PTY to the phone's keyboard is the one thing this screen already
promised never to do. A rotation still reaches the grid through `viewport`.

`useSettledHeight` is unchanged and still throttles (card #20); the new
`nextSteadyHeight` beside it returns the identical object when the shape holds,
so a re-measure stops at React.

## Verified on both, against a real zsh

Scratchpad build of `rnssh-testserver` running `/bin/zsh -i` on a real PTY with
the two-line prompt, logging every `window-change`.

| | before | after |
|---|---|---|
| 10 keystrokes on the app's keyboard, `muqun_android` | -- | **0** |
| 10 keystrokes on the app's keyboard, `muqun-ios` | -- | **0** |
| composer focus + one long wrapping command, `muqun_android` | **3** (33->32->31->30) | **0** |
| app keyboard open / close | 1 each (correct) | 1 each |

The terminal reads `osuki main > nvim nvim` on Android and
`osuki main > nvimnvim` on iOS -- one prompt, edited in place -- where the same
run before the fix walked the PTY down three rows.

## Nothing else moved

- **Gateway workspace: not affected.** It has no PTY to size -- there is no
  `resize` call anywhere in `server-terminal-workspace.tsx`, and its own
  `useSettledHeight` composer height only feeds `bottomInset` on the canvas.
  That is the model this change moves the SSH screen onto. Exercised live in
  the demo workspace on both platforms: panes, tabs, keyboard, rendering.
- **Gestures unchanged**, on `muqun_android`: one-finger pan, pinch, two-finger
  vertical scroll and two-finger horizontal tab swipe all still act. Two-finger
  tab swipe also re-checked on `muqun-ios`, keyboard up and down, both
  directions -- it works on both platforms and at every y position once the
  "while you were away" banner is dismissed; that banner covering the touch
  point was the only way I could make it miss.
- **Frame pacing unchanged.** Eight keyboard raise/dismiss cycles, same host
  load (~7): 52.63% janky / 23 missed vsyncs / p90 250ms with the fix against
  53.95% / 21 / p90 250ms on `origin/main`. Within noise; the absolute numbers
  are an emulator under load, not the app.

## Gates

```
npx tsc --noEmit     clean
bun run lint         clean (oxlint --deny-warnings)
bun run format:check All matched files use the correct format.
bun test src         2691 pass, 2 skip, 0 fail (2693 across 102 files)
```

## One thing I could not reproduce

The trailing composer-entry control (the pen) is **not** oversized on either
device. It measures 40x36pt on iOS and 105x95px on Android -- exactly
`styles.keyRowToggle`, and the same height as the `Enter`/`Esc`/`Tab`/`Ctrl C`
chips beside it (36pt / 95px). It is unchanged at font scale 1.3 as well. So I
have left it alone rather than change a size that is already correct here; if
it still looks wrong on the phone, a screenshot with the device's display-size
setting would pin what differs.

Likewise, the per-keystroke variant on the *virtual keyboard* never fired on the
emulator -- that dock height does not sit on a row boundary there. The composer
path above is the same defect through a trigger I could reproduce, and the fix
removes the class: the PTY size no longer follows the dock's pixels at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
