### PR TITLE
perf(terminal): a pane the reader has already seen paints from what it had

### DIFF
--- a/src/components/server-terminal-workspace.tsx
+++ b/src/components/server-terminal-workspace.tsx
@@ -71,7 +71,7 @@ import { useGatewayRecord } from '@/hooks/use-gateway-record';
 import { useGatewayTunnel } from '@/hooks/use-gateway-tunnel';
 import { usePaneApproval } from '@/hooks/use-pane-approval';
 import { usePaneEvents } from '@/hooks/use-pane-events';
-import { useLatestRef, useLazyRef } from '@/hooks/use-render-refs';
+import { useLatestRef, useLazyRef, useResetSignal } from '@/hooks/use-render-refs';
 import { useSettledHeight } from '@/hooks/use-settled-height';
 import { useTabSwipe } from '@/hooks/use-tab-swipe';
 import { usePaneViewMode } from '@/hooks/use-pane-view-mode';
@@ -129,6 +129,19 @@ import { field, numberField, panelTitle, statusColor } from '@/lib/herdr-entity'
 import type { GatewayRecord } from '@/lib/gateway-storage';
 import { sshHomeRows } from '@/lib/ssh-home';
 import type { PaneAddress } from '@/lib/pane-address';
+import {
+  emptyPaneCache,
+  foldPaneFrame,
+  notePaneRevision,
+  panePrefetchAccepted,
+  panePrefetchTargets,
+  paneReadIsCurrent,
+  recallPaneWindow,
+  rememberPaneWindow,
+  retainPanes,
+  type PaneCache,
+  type PaneWindow,
+} from '@/lib/pane-cache';
 import {
   hasEarlierPaneParts,
   hasEarlierPartsAfterPage,
@@ -316,6 +329,50 @@ const PANEL_PICK_RETRY_MS = 200;
  * position does not feel thrown away.
  */
 const PANE_SLIDE_DISTANCE = 36;
+
+/**
+ * How long a selection has to stand still before its neighbours are warmed.
+ *
+ * Long enough that a burst of swipes rearms the timer instead of firing per
+ * pane passed through, and long enough that the selected pane's own first read
+ * -- the one the reader is actually waiting on -- has the transport to itself.
+ * Short enough to have landed well inside the second the reader spends looking
+ * at the pane before deciding to move again.
+ */
+const PANE_PREFETCH_DELAY_MS = 400;
+
+/**
+ * How long a selection has to stand still before the event stream is re-opened
+ * against it.
+ *
+ * The pane whose output the gateway inlines is a query parameter on the SSE
+ * URL (`stream_pane`), so changing which pane that is means a new stream: a
+ * sealed request envelope, a fresh connection, and a full `refreshData` on the
+ * `onConnected` that follows. Paid on every pane switch that is a stop on the
+ * way somewhere else, that is the most expensive thing a swipe does and the
+ * least useful -- the stream is re-pointed at a pane the reader has already
+ * left by the time it opens.
+ *
+ * So the stream follows the selection at walking pace. Nothing is lost while
+ * it waits: the one-second refresh is already the safety net for exactly this
+ * (a missed event, a change that did not bump the revision), and the cache has
+ * meanwhile painted the pane the reader asked for. What is gained is that
+ * A -> B -> A, and a swipe through six panes, cost one re-open instead of one
+ * per pane.
+ */
+const PANE_STREAM_SETTLE_MS = 350;
+
+/**
+ * The shape every inlined frame arrives in, whatever pane it is for.
+ *
+ * `usePaneEvents` opens the stream with `stream_format=ansi` and
+ * `stream_source=recent-unwrapped` fixed, so a frame is always a window of
+ * that shape -- it does not follow the format the screen happens to be reading
+ * the selected pane under. Written down here because the cache has to match a
+ * frame against the shape of the window it would fold into, and guessing that
+ * from the selected pane's format would be right only by coincidence.
+ */
+const PANE_FRAME_SHAPE = 'ansi:recent-unwrapped';
 
 /**
  * Slack left around the active pane chip when scrolling it into view, so it
@@ -596,6 +653,32 @@ export function ServerTerminalWorkspace({
     contentKey: '',
   });
   const partsRequestIdRef = useRef(0);
+  /**
+   * The windows of the panes recently left, so coming back to one paints in
+   * the frame the tap happened in rather than after a round trip.
+   *
+   * A ref, not state: nothing renders from the cache itself -- what renders is
+   * the `output` the recall seeds -- and a cache that re-rendered the screen
+   * every time a neighbour's revision ticked would undo the very cost it is
+   * here to remove. The rules it obeys (the bounds, the revision ordering, the
+   * refusal of a reply overtaken in flight) are `lib/pane-cache`, tested
+   * without a screen.
+   */
+  const paneCacheRef = useRef<PaneCache>(emptyPaneCache);
+  /**
+   * Which pane the `output` on screen belongs to.
+   *
+   * Not the same question as `selection.paneId`: on the render that changes
+   * the selection, the window is still the outgoing pane's, and this is what
+   * says whose it is so it can be filed under the right name.
+   */
+  const paneWindowOwnerRef = useRef('');
+  /**
+   * Bumped on every selection change, and carried by each warming request, so
+   * a burst of swipes leaves exactly one useful warm-up behind it instead of
+   * one per pane passed through. See `panePrefetchAccepted`.
+   */
+  const prefetchGenerationRef = useRef(0);
   const refreshOutputRef = useRef<() => void>(() => {});
   const applyPaneOutputRef = useRef<
     (paneId: string, value: string, revision?: number, origin?: PaneReadOrigin) => void
@@ -732,6 +815,11 @@ export function ServerTerminalWorkspace({
   const resetSessionState = useCallback(() => {
     dataRequestIdRef.current += 1;
     outputRequestIdRef.current += 1;
+    // Every remembered window is a fact about the session being left, and pane
+    // ids are only unique within one -- so the cache goes with the output, for
+    // the same reason and in the same breath.
+    paneCacheRef.current = emptyPaneCache;
+    prefetchGenerationRef.current += 1;
     partsRequestIdRef.current += 1;
     readPartsKeyRef.current = { paneId: '', contentKey: '' };
     setPartsState(initialPartsState);
@@ -1525,6 +1613,11 @@ export function ServerTerminalWorkspace({
     : -1;
   const outputFormat = agentOutput ? 'text' : 'ansi';
   const outputSource: PaneOutputSource = fullScreenPane ? 'visible' : 'recent-unwrapped';
+  // The pair that says what a window is a window *of*. A pane can change shape
+  // while nobody is looking -- a shell hands its tty to nvim and the source it
+  // has to be read from turns with it -- so a remembered window is only handed
+  // back to a pane still being read the same way. See `PaneWindow.shape`.
+  const outputShape = `${outputFormat}:${outputSource}`;
   // Matches the terminal surface exactly, whichever pack is showing -- read
   // from the same palette the renderer draws with rather than restated, so the
   // chrome behind the grid can never be a shade off it.
@@ -1535,20 +1628,155 @@ export function ServerTerminalWorkspace({
   const chromeText = theme.colors.text;
   const chromeGlass = withAlpha(theme.colors.text, appChrome.opacity.chromeControl);
 
+  // The live values of everything the window is made of, so the pane being
+  // left can be remembered from a cleanup that closed over its id and nothing
+  // else. Refs rather than a dependency list on purpose: adding `output` to
+  // the switch effect's deps would re-run the switch on every fold.
+  const canLoadEarlierOutputRef = useLatestRef(canLoadEarlierOutput);
+  const paneRevisionRef = useLatestRef(paneRevision);
+  const outputShapeRef = useLatestRef(outputShape);
+  /**
+   * The shape the window *currently on screen* is made of -- which is not
+   * `outputShapeRef` at the moment a pane is left.
+   *
+   * `useLatestRef` is written during render, so on the render that changes the
+   * selection it already holds the incoming pane's shape, and the cleanup that
+   * remembers the outgoing pane's window runs after that render. Reading it
+   * there would file a shell's scrollback under an editor's screen.
+   *
+   * So this follows the reads instead of the render: it is set wherever a read
+   * is folded in, and wherever a window is restored, which by construction is
+   * every way the window can come to be. A shape that turns mid-pane -- a
+   * shell handing its tty to nvim -- is picked up on the first read after the
+   * turn, with no special case.
+   */
+  const heldShapeRef = useRef(outputShape);
+
+  /**
+   * The window exactly as it stands, in the one shape the cache stores.
+   *
+   * A callback rather than eight reads written out in the cleanup below, and
+   * not only for tidiness: the usual advice about refs in a cleanup -- copy
+   * `.current` into a variable on the way in -- is exactly wrong here. These
+   * are not nodes whose identity may have gone stale; they *are* the window's
+   * depth, and a copy taken when the effect ran would have missed every fold
+   * since. What is wanted is the value as of the last render of the pane being
+   * left, which is what these hold at the moment the cleanup runs.
+   */
+  /**
+   * Hand the pane being left over to the cache, and hand the pane arriving its
+   * window back -- both during the render that changes the selection.
+   *
+   * During render, and not from an effect, for exactly the reason
+   * `useCoalescedValue` adjusts its own state during render: the frame that
+   * carries the new pane's terminal id is the frame that must carry the new
+   * pane's window. The canvas throttles the snapshots it parses and records,
+   * and it flushes that throttle on the render the terminal id changes in --
+   * stamping a fresh window as it goes. A restore arriving one render later
+   * therefore lands *inside* a window it has to wait out, and the switch pays
+   * a full coalescing interval it was supposed to avoid. Measured on the
+   * loopback lab it was the difference between a first frame at 33 ms and one
+   * at 254 ms, on a switch that had the answer in hand the whole time.
+   *
+   * Both halves belong here, in this order, and not one here and one in an
+   * effect. The outgoing window has to be read while `output` and the depth
+   * refs still describe it, which is true on this render and false on the next
+   * one; and the recall has to see the cache the remember has already written
+   * to, or a switch straight back would miss what it had just put down.
+   *
+   * `useResetSignal` is what makes this run once per switch rather than every
+   * render -- see its docblock, which describes this case by name.
+   */
+  const paneSwitched = useResetSignal(selection.paneId);
+  /* oxlint-disable react/refs, react/purity -- deliberate, for this block only:
+     every ref touched here is the window's own bookkeeping, none of it is read
+     into what this render draws, and nothing but a switch writes any of it --
+     which is the render this is. The alternative is an effect, and an effect
+     is a coalescing interval late. See the docblock above and
+     `useCoalescedValue`, which adjusts its own state during render for the
+     same reason and with the same suppression. */
+  if (paneSwitched) {
+    const cache = paneCacheRef.current;
+    const leaving = paneWindowOwnerRef.current;
+    // A pane that never painted has nothing to hand back, and caching the
+    // blank would let the recall claim a hit that shows the reader nothing --
+    // worse than a miss, because a miss at least knows it is one.
+    //
+    // `output` is the render's own value, which on this render is still the
+    // outgoing pane's window; the depth beside it is read from the refs, which
+    // no post-commit write has reached yet either.
+    const held: PaneWindow | null =
+      leaving && output
+        ? {
+            shape: heldShapeRef.current,
+            output,
+            lineLimit: outputLineLimitRef.current,
+            revision: paneRevisionRef.current,
+            canLoadEarlier: canLoadEarlierOutputRef.current,
+            earlierRows: earlierOutputRowsRef.current,
+            rangeUnsupported: rangeUnsupportedRef.current,
+            lastRead: lastReadRef.current,
+          }
+        : null;
+    const remembered = held ? rememberPaneWindow(cache, leaving, held) : cache;
+    // What the window would have been if the pane had never been left: the
+    // folded string, and the four facts that say how deep it is. Restoring the
+    // depth alongside the text is not optional -- a window put back at the
+    // initial limit would have the next refresh ask for one page of a pane the
+    // reader had paged five back, and `foldPaneRead` would honour that answer.
+    const restored = recallPaneWindow(remembered, selection.paneId, outputShape);
+    paneCacheRef.current = remembered;
+    paneWindowOwnerRef.current = selection.paneId;
+    setOutput(restored?.output ?? '');
+    setCanLoadEarlierOutput(restored?.canLoadEarlier ?? false);
+    setPaneRevision(restored?.revision ?? -1);
+  }
+  /* oxlint-enable react/refs, react/purity */
+
   // Clearing belongs here rather than in the poller: opening a sheet over the
   // terminal unfocuses this screen, and blanking on every refocus made the
   // output flash even though the pane never changed.
-  useEffect(() => {
-    setOutput('');
+  //
+  // The window itself is no longer set here -- it is adjusted during the
+  // switch render above, where the canvas can see it on the same frame. What
+  // is left is everything that is only ever read after the commit: the request
+  // generations, the depth the next read asks at, and the transcript's own
+  // state. Restoring those here rather than during render keeps the render
+  // free of writes that a discarded render would have to undo.
+  //
+  // A *layout* effect rather than an ordinary one so the depth refs agree with
+  // the window before anything can read them -- the 1 s refresh and the event
+  // stream both fire after the commit, and an effect that ran after paint
+  // would leave a restored window paired with the previous pane's depth for
+  // one frame's worth of requests.
+  useLayoutEffect(() => {
+    const paneId = selection.paneId;
+    // The same recall the switch render made, against a cache nothing can have
+    // changed in between: no request can land between a render and its own
+    // layout effect. Asked again rather than carried across in a ref, which
+    // would be a render-time write for the sake of skipping a find over at
+    // most four entries.
+    const restored = recallPaneWindow(paneCacheRef.current, paneId, outputShapeRef.current);
+    heldShapeRef.current = outputShapeRef.current;
     outputRequestIdRef.current += 1;
-    outputLineLimitRef.current = INITIAL_PANE_OUTPUT_LINES;
-    earlierOutputRowsRef.current = 0;
-    lastReadRef.current = null;
-    rangeUnsupportedRef.current = false;
+    outputLineLimitRef.current = restored?.lineLimit ?? INITIAL_PANE_OUTPUT_LINES;
+    earlierOutputRowsRef.current = restored?.earlierRows ?? 0;
+    lastReadRef.current = restored?.lastRead ?? null;
+    rangeUnsupportedRef.current = restored?.rangeUnsupported ?? false;
     loadingEarlierOutputRef.current = false;
     setLoadingEarlierOutput(false);
-    setCanLoadEarlierOutput(false);
     setHistoryRevision(0);
+    // The revision the restored window was folded to, so the refresh that
+    // follows is a reconciliation rather than a repeat, and an event merely
+    // restating what is already on screen is ignored exactly as it would have
+    // been had the pane never been left.
+    readRevisionRef.current = { paneId, revision: restored?.revision ?? -1 };
+    // The transcript is deliberately not cached. A part is a claim about a
+    // span of source rows rather than a rectangle of them, so two reads of
+    // different windows cannot be stitched together (see `loadEarlierParts`),
+    // and a transcript restored under a window it was not read at would be a
+    // quiet lie about what the pane said. The chat view keeps the behaviour it
+    // has always had, whole.
     partsLineLimitRef.current = INITIAL_PANE_OUTPUT_LINES;
     earlierPartsRowsRef.current = 0;
     loadingEarlierPartsRef.current = false;
@@ -1556,9 +1784,8 @@ export function ServerTerminalWorkspace({
     setCanLoadEarlierParts(false);
     partsRequestIdRef.current += 1;
     readPartsKeyRef.current = { paneId: '', contentKey: '' };
-    setPaneRevision(-1);
     setPartsState(initialPartsState);
-  }, [selection.paneId]);
+  }, [outputShapeRef, selection.paneId]);
 
   useEffect(() => {
     if (!requestedPaneId || !data.health) return;
@@ -1662,6 +1889,9 @@ export function ServerTerminalWorkspace({
       };
       if (typeof revision === 'number') setPaneRevision(revision);
       const lineLimit = outputLineLimitRef.current;
+      // What this read was made under, so the window can only ever be handed
+      // back to a pane still being read the same way. See `heldShapeRef`.
+      heldShapeRef.current = outputShapeRef.current;
       // One door for every source, and the source says which it is rather than
       // the code guessing from a length. `foldPaneRead` places the read at the
       // seam its own head anchors and keeps whatever sits above it, so no
@@ -1688,7 +1918,7 @@ export function ServerTerminalWorkspace({
       }
       setError(null);
     },
-    [agentOutput]
+    [agentOutput, outputShapeRef]
   );
 
   const refreshOutput = useCallback(async () => {
@@ -1885,6 +2115,15 @@ export function ServerTerminalWorkspace({
 
   useEffect(() => {
     panesRef.current = data.panes;
+    // A closed pane's id can be reused by the next one Herdr opens, so a
+    // window is dropped when the session stops listing it rather than left to
+    // age out of the cache under a name that has since changed hands. The
+    // refreshed list is the reliable answer: the structural events say
+    // something closed, not always which.
+    paneCacheRef.current = retainPanes(
+      paneCacheRef.current,
+      data.panes.map((pane) => pane.id)
+    );
   }, [data.panes, t]);
 
   useEffect(() => {
@@ -1953,6 +2192,102 @@ export function ServerTerminalWorkspace({
     const timer = setInterval(() => void refreshOutput(), 1000);
     return () => clearInterval(timer);
   }, [connection.phase, ready, refreshOutput, selection.paneId]);
+
+  /**
+   * Warm the two panes a swipe can reach, so the switch onto them is a paint
+   * rather than a round trip.
+   *
+   * Deliberately late and deliberately quiet. It waits out
+   * `PANE_PREFETCH_DELAY_MS` so it never competes with the selected pane's own
+   * first read for the one transport the screen has -- the reader is looking
+   * at that pane, not at its neighbours -- and a burst of swipes rearms the
+   * timer rather than firing per pane passed through, so cycling a tab of six
+   * costs two reads at the end instead of twelve on the way.
+   *
+   * A neighbour whose cached window the stream has not overtaken is skipped
+   * entirely: there is no blank to remove there, and asking again would spend
+   * a round trip to be told what is already held.
+   *
+   * Everything it fetches goes into the cache and nothing else. It never
+   * touches `output`, `setPaneRevision` or any of the depth refs, so a warm-up
+   * landing at any moment cannot move what is on screen -- which is what makes
+   * it safe to run beside the reads that can. The only shape it fetches is the
+   * shape the *selected* pane is read under; a neighbour that turns out to be
+   * read another way (an agent as prose, an editor's screen) is refused by
+   * `recallPaneWindow` on arrival and costs nothing but the read.
+   */
+  useEffect(() => {
+    if (!ready || connection.phase !== 'connected' || !selection.paneId) return;
+    const generation = ++prefetchGenerationRef.current;
+    const requestServerId = serverId;
+    const targets = panePrefetchTargets(
+      tabPanes.map((pane) => pane.id),
+      selection.paneId,
+      paneCacheRef.current,
+      (paneId) => {
+        const revision = panesRef.current.find((pane) => pane.id === paneId)?.raw.revision;
+        return typeof revision === 'number' ? revision : -1;
+      }
+    );
+    if (targets.length === 0) return;
+
+    const timer = setTimeout(() => {
+      for (const paneId of targets) {
+        void readPaneTail(
+          data.sessionId,
+          paneId,
+          outputFormat,
+          INITIAL_PANE_OUTPUT_LINES,
+          outputSource
+        )
+          .then(({ output: value, read }) => {
+            // Three ways this answer can have been overtaken while it was on
+            // the wire, and all three end the same way -- drop it. The
+            // selection moved on (a stale generation); the server did; or the
+            // stream reported this pane past the revision the read was made
+            // at, which `paneReadIsCurrent` is exactly the check for.
+            if (!panePrefetchAccepted(generation, prefetchGenerationRef.current)) return;
+            if (activeServerRef.current !== requestServerId) return;
+            const paneRaw = panesRef.current.find((pane) => pane.id === paneId)?.raw.revision;
+            const revision = typeof paneRaw === 'number' ? paneRaw : -1;
+            if (!paneReadIsCurrent(paneCacheRef.current, paneId, revision)) return;
+            if (!value) return;
+            paneCacheRef.current = rememberPaneWindow(paneCacheRef.current, paneId, {
+              shape: `${outputFormat}:${outputSource}`,
+              output: value,
+              // A warm-up is always the first page. It is a seed for the
+              // switch, not a claim about depth -- the reader has never paged
+              // this pane in this visit, so there is nothing deeper to lose.
+              lineLimit: INITIAL_PANE_OUTPUT_LINES,
+              revision,
+              canLoadEarlier: hasEarlierTerminalOutput(
+                value,
+                INITIAL_PANE_OUTPUT_LINES,
+                MAX_PANE_OUTPUT_LINES,
+                panesRef.current.find((pane) => pane.id === paneId)?.raw.scroll
+              ),
+              earlierRows: terminalOutputLineCount(value),
+              rangeUnsupported: false,
+              lastRead: read,
+            });
+          })
+          // A warm-up nobody asked for is not news. The pane it failed for
+          // simply stays a miss, which is the behaviour every pane had before
+          // this existed.
+          .catch(() => {});
+      }
+    }, PANE_PREFETCH_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [
+    connection.phase,
+    data.sessionId,
+    outputFormat,
+    outputSource,
+    ready,
+    selection.paneId,
+    serverId,
+    tabPanes,
+  ]);
 
   // The permission menu this pane may be blocked on. Everything about it --
   // the read, the answer, the 409 retry rule -- lives in the hook; the screen
@@ -2024,6 +2359,26 @@ export function ServerTerminalWorkspace({
     if (dock.approvalOnly) Keyboard.dismiss();
   }, [dock.approvalOnly]);
 
+  // Which pane the stream is opened against, which trails the selection by
+  // `PANE_STREAM_SETTLE_MS`. See that constant for why it trails at all; the
+  // short version is that re-pointing the stream is a reconnect, and a pane
+  // passed through on the way somewhere else is not worth one.
+  //
+  const [streamPaneId, setStreamPaneId] = useState(selection.paneId);
+  useEffect(() => {
+    if (streamPaneId === selection.paneId) return;
+    // The first pane of a visit does not wait. There is no reconnect to avoid
+    // when there is no stream yet -- the selection arrives empty and is filled
+    // in once the gateway answers -- and making that one wait would delay the
+    // inline frames for the pane the reader actually arrived on.
+    if (!streamPaneId) {
+      setStreamPaneId(selection.paneId);
+      return;
+    }
+    const timer = setTimeout(() => setStreamPaneId(selection.paneId), PANE_STREAM_SETTLE_MS);
+    return () => clearTimeout(timer);
+  }, [selection.paneId, streamPaneId]);
+
   // The live event stream. `pane_updated` for the selected pane reads its
   // output; structural events refresh the navigator. A (re)connect forces a
   // full read, because the stream has no replay and anything during the gap is
@@ -2034,19 +2389,50 @@ export function ServerTerminalWorkspace({
     selectedServer ? tunnel.baseUrl : null,
     selectedServer ? (record?.token ?? null) : null,
     data.sessionId,
-    selectedServer ? selection.paneId || null : null,
+    // The settled pane, not the selected one -- see `streamPaneId` above. The
+    // structural and approval events this stream also carries are session-wide
+    // and unaffected by which pane it inlines.
+    selectedServer ? streamPaneId || null : null,
     ready && connection.phase === 'connected',
     retryNonce,
     useMemo(
       () => ({
         onPaneRevision: (paneId: string, revision: number) => {
-          if (paneId !== activePaneRef.current) return;
+          if (paneId !== activePaneRef.current) {
+            // The stream is session-wide, so this is how a pane nobody is
+            // looking at says it has moved on. Only its revision arrives --
+            // the gateway inlines the *text* for the one pane the stream was
+            // opened against (`stream_pane`) and no other -- and a revision is
+            // all that is needed here: it is what marks a remembered window as
+            // overtaken, so the switch back paints it at once and then
+            // reconciles, instead of trusting it forever. A pane the cache
+            // does not hold is not created by this.
+            paneCacheRef.current = notePaneRevision(paneCacheRef.current, paneId, revision);
+            return;
+          }
           const last = readRevisionRef.current;
           if (last.paneId === paneId && last.revision === revision) return;
           refreshOutputRef.current();
         },
         onPaneOutput: (paneId: string, revision: number, text: string) => {
-          if (paneId !== activePaneRef.current) return;
+          if (paneId !== activePaneRef.current) {
+            // For the short interval after a switch the stream is still
+            // inlining the pane just left -- the one pane other than the
+            // selected one whose text is ever on the wire (see
+            // `PANE_STREAM_SETTLE_MS`). Folded into that pane's remembered
+            // window through the same door its own frames went through, so
+            // switching straight back stays free even while it is printing.
+            // Everything else -- an uncached pane, a shape that has turned, a
+            // frame already overtaken -- leaves the cache exactly as it was.
+            paneCacheRef.current = foldPaneFrame(
+              notePaneRevision(paneCacheRef.current, paneId, revision),
+              paneId,
+              PANE_FRAME_SHAPE,
+              revision,
+              (held, lineLimit) => foldPaneRead(held, text, 'frame', lineLimit, false)
+            );
+            return;
+          }
           // Painted straight from the event -- no read round-trip.
           // Herdr can expose new text before its coalesced revision advances,
           // so inline output must not be discarded solely on revision equality.

--- a/src/lib/__tests__/pane-cache.test.ts
+++ b/src/lib/__tests__/pane-cache.test.ts
@@ -1,0 +1,341 @@
+// The rule these tests are a fence around: a cache may remove a blank, and it
+// may never invent a row.
+//
+// Everything the pane cache holds is a window `foldPaneRead` already folded,
+// so the way it can hurt is not by folding wrongly -- it never folds -- but by
+// handing back a window that is no longer true and saying nothing, or by
+// letting a reply that was overtaken in flight write itself in as the truth.
+// Both of those are revision arithmetic, and both are here. The bounds are the
+// third thing that can be wrong quietly: a cache that grows without one is a
+// leak nobody notices until a pane has been paged back two thousand lines.
+import { describe, expect, test } from 'bun:test';
+
+import {
+  type PaneCacheBounds,
+  type PaneWindow,
+  emptyPaneCache,
+  foldPaneFrame,
+  forgetPaneWindow,
+  notePaneRevision,
+  panePrefetchAccepted,
+  panePrefetchTargets,
+  paneReadIsCurrent,
+  paneWindowIsCurrent,
+  recallPaneWindow,
+  rememberPaneWindow,
+  retainPanes,
+} from '../pane-cache';
+
+/** The shape every window in these tests is of, unless one is being contrasted with another. */
+const ANSI = 'ansi:recent-unwrapped';
+
+function windowOf(output: string, revision = 1, extra: Partial<PaneWindow> = {}): PaneWindow {
+  return {
+    shape: ANSI,
+    output,
+    lineLimit: 240,
+    revision,
+    canLoadEarlier: false,
+    earlierRows: 12,
+    rangeUnsupported: false,
+    lastRead: null,
+    ...extra,
+  };
+}
+
+/** Small enough that eviction is reachable without building strings by the megabyte. */
+const BOUNDS: PaneCacheBounds = { panes: 3, characters: 100 };
+
+const paneIdsOf = (cache: { entries: readonly { paneId: string }[] }) =>
+  cache.entries.map((entry) => entry.paneId);
+
+describe('remembering and recalling', () => {
+  test('a window comes back exactly as it went in', () => {
+    const held = windowOf('rows', 7, { lineLimit: 720, canLoadEarlier: true, lastRead: { a: 1 } });
+    const cache = rememberPaneWindow(emptyPaneCache, 'p1', held);
+    expect(recallPaneWindow(cache, 'p1', ANSI)).toEqual(held);
+  });
+
+  test('a pane nobody remembers recalls as nothing, and so does the empty id', () => {
+    expect(recallPaneWindow(emptyPaneCache, 'p1', ANSI)).toBeNull();
+    expect(
+      recallPaneWindow(rememberPaneWindow(emptyPaneCache, 'p1', windowOf('a')), '', ANSI)
+    ).toBeNull();
+  });
+
+  test('remembering a pane twice replaces rather than duplicates it', () => {
+    let cache = rememberPaneWindow(emptyPaneCache, 'p1', windowOf('old', 1));
+    cache = rememberPaneWindow(cache, 'p1', windowOf('new', 2));
+    expect(cache.entries).toHaveLength(1);
+    expect(recallPaneWindow(cache, 'p1', ANSI)?.output).toBe('new');
+  });
+
+  // A pane can change shape while nobody is looking -- a shell hands its tty to
+  // an editor -- and a window restored across that change is escape sequences
+  // in a reading view.
+  test('a window of another shape is not handed back', () => {
+    const cache = rememberPaneWindow(emptyPaneCache, 'p1', windowOf('rows'));
+    expect(recallPaneWindow(cache, 'p1', 'text:visible')).toBeNull();
+    expect(recallPaneWindow(cache, 'p1', ANSI)?.output).toBe('rows');
+  });
+
+  test('a reshaped window replaces the one held under the old shape', () => {
+    let cache = rememberPaneWindow(emptyPaneCache, 'p1', windowOf('rows'));
+    cache = rememberPaneWindow(cache, 'p1', windowOf('screen', 1, { shape: 'text:visible' }));
+    expect(cache.entries).toHaveLength(1);
+    expect(recallPaneWindow(cache, 'p1', ANSI)).toBeNull();
+    expect(recallPaneWindow(cache, 'p1', 'text:visible')?.output).toBe('screen');
+  });
+
+  // Recall runs during the render that paints the switch, so it must not write.
+  test('recall does not reorder the cache', () => {
+    let cache = rememberPaneWindow(emptyPaneCache, 'p1', windowOf('a'));
+    cache = rememberPaneWindow(cache, 'p2', windowOf('b'));
+    recallPaneWindow(cache, 'p1', ANSI);
+    expect(paneIdsOf(cache)).toEqual(['p2', 'p1']);
+  });
+});
+
+describe('bounds', () => {
+  test('the least recently used pane is the one evicted by the count bound', () => {
+    let cache = emptyPaneCache;
+    for (const paneId of ['p1', 'p2', 'p3', 'p4']) {
+      cache = rememberPaneWindow(cache, paneId, windowOf(paneId), BOUNDS);
+    }
+    expect(paneIdsOf(cache)).toEqual(['p4', 'p3', 'p2']);
+    expect(recallPaneWindow(cache, 'p1', ANSI)).toBeNull();
+  });
+
+  test('re-remembering a pane moves it back to the front, so it survives the next eviction', () => {
+    let cache = emptyPaneCache;
+    for (const paneId of ['p1', 'p2', 'p3']) {
+      cache = rememberPaneWindow(cache, paneId, windowOf(paneId), BOUNDS);
+    }
+    cache = rememberPaneWindow(cache, 'p1', windowOf('p1 again'), BOUNDS);
+    cache = rememberPaneWindow(cache, 'p4', windowOf('p4'), BOUNDS);
+    expect(paneIdsOf(cache)).toEqual(['p4', 'p1', 'p3']);
+  });
+
+  test('the byte bound evicts even when the count bound is satisfied', () => {
+    let cache = rememberPaneWindow(emptyPaneCache, 'p1', windowOf('x'.repeat(60)), BOUNDS);
+    cache = rememberPaneWindow(cache, 'p2', windowOf('y'.repeat(60)), BOUNDS);
+    expect(paneIdsOf(cache)).toEqual(['p2']);
+  });
+
+  test('a window bigger than the whole budget is not stored, and takes the older copy with it', () => {
+    let cache = rememberPaneWindow(emptyPaneCache, 'p1', windowOf('small'), BOUNDS);
+    cache = rememberPaneWindow(cache, 'p2', windowOf('keep me'), BOUNDS);
+    cache = rememberPaneWindow(cache, 'p1', windowOf('x'.repeat(200)), BOUNDS);
+    expect(recallPaneWindow(cache, 'p1', ANSI)).toBeNull();
+    expect(recallPaneWindow(cache, 'p2', ANSI)?.output).toBe('keep me');
+  });
+
+  test('the pane just written always survives its own write', () => {
+    const cache = rememberPaneWindow(emptyPaneCache, 'p1', windowOf('x'.repeat(99)), BOUNDS);
+    expect(recallPaneWindow(cache, 'p1', ANSI)?.output).toHaveLength(99);
+  });
+
+  test('an empty pane id is not cacheable', () => {
+    expect(rememberPaneWindow(emptyPaneCache, '', windowOf('a'))).toBe(emptyPaneCache);
+  });
+});
+
+describe('revision ordering', () => {
+  // The defect this group is a fence around: one number cannot say both "the
+  // revision this window holds" and "the revision this pane has reached".
+  // While it tried to, news that a pane had printed while nobody was looking
+  // marked its stale window as the whole truth -- the exact opposite of what
+  // the news meant.
+  test('a stream revision marks the window overtaken without touching it', () => {
+    const cache = notePaneRevision(
+      rememberPaneWindow(emptyPaneCache, 'p1', windowOf('a', 3)),
+      'p1',
+      9
+    );
+    expect(recallPaneWindow(cache, 'p1', ANSI)).toMatchObject({ output: 'a', revision: 3 });
+    expect(paneWindowIsCurrent(cache, 'p1', 3)).toBe(false);
+  });
+
+  test('news never moves backwards, whatever order the events land in', () => {
+    let cache = rememberPaneWindow(emptyPaneCache, 'p1', windowOf('a', 9));
+    cache = notePaneRevision(cache, 'p1', 4);
+    expect(paneWindowIsCurrent(cache, 'p1', 9)).toBe(true);
+  });
+
+  test('a window written while news was in flight does not un-hear it', () => {
+    let cache = rememberPaneWindow(emptyPaneCache, 'p1', windowOf('a', 1));
+    cache = notePaneRevision(cache, 'p1', 7);
+    cache = rememberPaneWindow(cache, 'p1', windowOf('later', 4));
+    expect(paneWindowIsCurrent(cache, 'p1', 4)).toBe(false);
+    cache = rememberPaneWindow(cache, 'p1', windowOf('latest', 7));
+    expect(paneWindowIsCurrent(cache, 'p1', 7)).toBe(true);
+  });
+
+  test('a revision for an uncached pane creates nothing', () => {
+    expect(notePaneRevision(emptyPaneCache, 'p1', 9)).toBe(emptyPaneCache);
+  });
+
+  test('a window is current only up to the revision it was folded to', () => {
+    const cache = rememberPaneWindow(emptyPaneCache, 'p1', windowOf('a', 5));
+    expect(paneWindowIsCurrent(cache, 'p1', 5)).toBe(true);
+    expect(paneWindowIsCurrent(cache, 'p1', 4)).toBe(true);
+    expect(paneWindowIsCurrent(cache, 'p1', 6)).toBe(false);
+  });
+
+  // Guessing "current" with nothing to compare would leave stale output up for
+  // as long as the reader stayed away.
+  test('an unversioned pane on either side is never called current', () => {
+    expect(
+      paneWindowIsCurrent(rememberPaneWindow(emptyPaneCache, 'p1', windowOf('a', -1)), 'p1', 3)
+    ).toBe(false);
+    expect(
+      paneWindowIsCurrent(rememberPaneWindow(emptyPaneCache, 'p1', windowOf('a', 3)), 'p1', -1)
+    ).toBe(false);
+    expect(paneWindowIsCurrent(emptyPaneCache, 'p1', 3)).toBe(false);
+  });
+});
+
+describe('stale replies', () => {
+  // Measured against the window, not against the news: news carries no text,
+  // so refusing real text on the strength of it would leave the cache holding
+  // something older than the reply it just threw away.
+  test('a reply older than the window already held is refused', () => {
+    const cache = rememberPaneWindow(emptyPaneCache, 'p1', windowOf('a', 7));
+    expect(paneReadIsCurrent(cache, 'p1', 6)).toBe(false);
+    expect(paneReadIsCurrent(cache, 'p1', 7)).toBe(true);
+    expect(paneReadIsCurrent(cache, 'p1', 8)).toBe(true);
+  });
+
+  test('a reply for a pane nothing is held for is accepted', () => {
+    expect(paneReadIsCurrent(emptyPaneCache, 'p1', 2)).toBe(true);
+  });
+
+  test('a gateway that versions nothing is never refused', () => {
+    const cache = rememberPaneWindow(emptyPaneCache, 'p1', windowOf('a', 7));
+    expect(paneReadIsCurrent(cache, 'p1', -1)).toBe(true);
+  });
+});
+
+describe('frames for a pane nobody is looking at', () => {
+  // The caller's own fold, stubbed: this module supplies none and must not
+  // start having an opinion about what a folded window looks like.
+  const append = (text: string) => (held: string, lineLimit: number) =>
+    `${held}+${text}@${lineLimit}`;
+
+  test('a frame folds into the remembered window and carries its revision forward', () => {
+    const cache = rememberPaneWindow(emptyPaneCache, 'p1', windowOf('rows', 4, { lineLimit: 720 }));
+    const next = foldPaneFrame(notePaneRevision(cache, 'p1', 5), 'p1', ANSI, 5, append('more'));
+    expect(recallPaneWindow(next, 'p1', ANSI)).toMatchObject({
+      output: 'rows+more@720',
+      revision: 5,
+      lineLimit: 720,
+    });
+    // Folded, so the window is caught up again and the next switch back to it
+    // needs nothing from the network.
+    expect(paneWindowIsCurrent(next, 'p1', 5)).toBe(true);
+  });
+
+  // The other half of the same story: news the fold could not act on leaves the
+  // window honestly marked as behind, so the warm-up goes and gets it.
+  test('a frame refused for its shape leaves the window marked overtaken', () => {
+    const cache = notePaneRevision(
+      rememberPaneWindow(emptyPaneCache, 'p1', windowOf('rows', 4)),
+      'p1',
+      5
+    );
+    const next = foldPaneFrame(cache, 'p1', 'text:visible', 5, append('more'));
+    expect(recallPaneWindow(next, 'p1', ANSI)?.output).toBe('rows');
+    expect(paneWindowIsCurrent(next, 'p1', 5)).toBe(false);
+  });
+
+  test('a pane nothing is held for is not created by a frame', () => {
+    expect(foldPaneFrame(emptyPaneCache, 'p1', ANSI, 5, append('more'))).toBe(emptyPaneCache);
+  });
+
+  test('a frame of another shape is refused', () => {
+    const cache = rememberPaneWindow(emptyPaneCache, 'p1', windowOf('rows', 4));
+    expect(foldPaneFrame(cache, 'p1', 'text:visible', 5, append('more'))).toBe(cache);
+  });
+
+  test('a frame older than the window already held is refused', () => {
+    const cache = rememberPaneWindow(emptyPaneCache, 'p1', windowOf('rows', 9));
+    expect(foldPaneFrame(cache, 'p1', ANSI, 5, append('more'))).toBe(cache);
+  });
+
+  test('an unversioned frame folds without inventing a revision', () => {
+    const cache = rememberPaneWindow(emptyPaneCache, 'p1', windowOf('rows', 4));
+    const next = foldPaneFrame(cache, 'p1', ANSI, -1, append('more'));
+    expect(recallPaneWindow(next, 'p1', ANSI)).toMatchObject({
+      output: 'rows+more@240',
+      revision: 4,
+    });
+  });
+
+  test('a fold that changes nothing leaves the cache identical', () => {
+    const cache = rememberPaneWindow(emptyPaneCache, 'p1', windowOf('rows', 4));
+    expect(foldPaneFrame(cache, 'p1', ANSI, 4, (held) => held)).toBe(cache);
+  });
+
+  // A pane still printing while the reader is elsewhere is the case this whole
+  // path exists for, so its window must stay the most recently used one.
+  test('a folded pane moves to the front of the cache', () => {
+    let cache = rememberPaneWindow(emptyPaneCache, 'p1', windowOf('a', 1));
+    cache = rememberPaneWindow(cache, 'p2', windowOf('b', 1));
+    const next = foldPaneFrame(cache, 'p1', ANSI, 2, append('more'));
+    expect(paneIdsOf(next)).toEqual(['p1', 'p2']);
+  });
+});
+
+describe('a pane that goes away', () => {
+  test('forgetting drops it, and is a no-op for a pane not held', () => {
+    const cache = rememberPaneWindow(emptyPaneCache, 'p1', windowOf('a'));
+    expect(recallPaneWindow(forgetPaneWindow(cache, 'p1'), 'p1', ANSI)).toBeNull();
+    expect(forgetPaneWindow(cache, 'p2')).toBe(cache);
+  });
+
+  // A closed pane's id can be reused, so aging out is not good enough.
+  test('retaining keeps only the panes the session still lists', () => {
+    let cache = rememberPaneWindow(emptyPaneCache, 'p1', windowOf('a'));
+    cache = rememberPaneWindow(cache, 'p2', windowOf('b'));
+    cache = rememberPaneWindow(cache, 'p3', windowOf('c'));
+    const kept = retainPanes(cache, ['p3', 'p1']);
+    expect(paneIdsOf(kept)).toEqual(['p3', 'p1']);
+    expect(retainPanes(kept, ['p3', 'p1'])).toBe(kept);
+  });
+});
+
+describe('prefetch', () => {
+  const ring = ['p1', 'p2', 'p3', 'p4'];
+  const unversioned = () => -1;
+
+  test('both neighbours in the ring, wrapping at either end', () => {
+    expect(panePrefetchTargets(ring, 'p1', emptyPaneCache, unversioned)).toEqual(['p2', 'p4']);
+    expect(panePrefetchTargets(ring, 'p4', emptyPaneCache, unversioned)).toEqual(['p1', 'p3']);
+  });
+
+  test('a ring of two yields one neighbour rather than the same pane twice', () => {
+    expect(panePrefetchTargets(['p1', 'p2'], 'p1', emptyPaneCache, unversioned)).toEqual(['p2']);
+  });
+
+  test('a ring of one, and a selection the ring does not contain, warm nothing', () => {
+    expect(panePrefetchTargets(['p1'], 'p1', emptyPaneCache, unversioned)).toEqual([]);
+    expect(panePrefetchTargets(ring, 'gone', emptyPaneCache, unversioned)).toEqual([]);
+  });
+
+  test('a neighbour already current is not fetched again', () => {
+    const cache = rememberPaneWindow(emptyPaneCache, 'p2', windowOf('a', 5));
+    const revisions = (paneId: string) => (paneId === 'p2' ? 5 : -1);
+    expect(panePrefetchTargets(ring, 'p1', cache, revisions)).toEqual(['p4']);
+  });
+
+  test('a neighbour the stream has moved past is fetched again', () => {
+    const cache = rememberPaneWindow(emptyPaneCache, 'p2', windowOf('a', 5));
+    const revisions = (paneId: string) => (paneId === 'p2' ? 6 : -1);
+    expect(panePrefetchTargets(ring, 'p1', cache, revisions)).toEqual(['p2', 'p4']);
+  });
+
+  test('a prefetch is accepted only by the generation that issued it', () => {
+    expect(panePrefetchAccepted(3, 3)).toBe(true);
+    expect(panePrefetchAccepted(3, 4)).toBe(false);
+  });
+});

--- a/src/lib/pane-cache.ts
+++ b/src/lib/pane-cache.ts
@@ -1,0 +1,383 @@
+/**
+ * # What the reader already had, kept for the walk back
+ *
+ * Switching pane is the commonest thing anyone does on the terminal screen,
+ * and until this module existed it cost a blank. The screen blanked `output`
+ * on every `selection.paneId` change and then waited for `readPaneOutput` to
+ * come back over the encrypted transport before it had a single row to draw
+ * -- for a pane the reader had been looking at one second earlier, whose
+ * window was still sitting in memory when it was thrown away.
+ *
+ * Nothing here is new terminal logic. The window this module hands back is the
+ * exact string `foldPaneRead` had already folded (see the contract at the top
+ * of `src/terminal/history.ts`), together with the four things that describe
+ * *how deep* it is -- the line limit the reader paged to, the rows the last
+ * read reached, the read envelope a range page addresses from, and whether
+ * this gateway honoured a range at all. Put back together they restore the
+ * window to precisely the state the fold left it in, so the refresh that
+ * follows folds against it identically to the way it would have folded had
+ * the pane never been left. That is the whole safety argument: the cache does
+ * not merge, does not trim and does not decide anything about depth. It
+ * remembers, and the same one door that has always folded reads keeps folding
+ * them.
+ *
+ * ## Why the revision is kept beside it
+ *
+ * The event stream is session-wide -- `pane.updated` arrives for every pane --
+ * but the gateway only inlines the *text* for the one pane the stream was
+ * opened against (`stream_pane`), so there is no way to keep another pane's
+ * window genuinely warm off the wire. What does arrive for every pane is its
+ * revision, and that is enough to know whether what is remembered is still
+ * the whole truth. So a cached window is always painted -- a second-old
+ * window is a better answer than a blank one, and it is the only answer that
+ * can be given inside the frame the tap happened in -- and the revision says
+ * whether the read that follows is a reconciliation or a formality.
+ *
+ * A remembered revision never overwrites a newer one: {@link notePaneRevision}
+ * only moves it forward. That is what stops a late reply from a request issued
+ * before a switch from re-marking a pane as fresh at a revision the stream has
+ * already moved past.
+ *
+ * ## Bounds
+ *
+ * Two of them, because either on its own has a hole. A count bound alone lets
+ * four panes that have each been paged back to two thousand lines sit in
+ * memory at once; a byte bound alone lets a hundred one-line panes accumulate
+ * for no benefit, since only the handful either side of the selection are ever
+ * switched to. Both are enforced on every write, least-recently-used first.
+ *
+ * A single window larger than the whole byte budget is not cached at all,
+ * rather than cached by evicting everything else for it: it would empty the
+ * cache to hold one pane, and the read that would have to run anyway is the
+ * same read either way. Storing it is refused *and* any older copy of that
+ * pane is dropped, because a window that has since grown past the budget makes
+ * the copy underneath it stale.
+ */
+
+/** The window, and everything that says how deep it is. */
+export interface PaneWindow {
+  /**
+   * What this is a window *of*, in the caller's own terms -- the format and
+   * source the read was made under (`ansi`/`recent-unwrapped` for an ordinary
+   * pane, `text` for an agent being read as prose, `visible` for a program
+   * that draws its screen instead of printing).
+   *
+   * Opaque here on purpose: this module has no business knowing what an ANSI
+   * window is, only that two windows of different shapes are not
+   * interchangeable. It exists because a pane can change shape while nobody is
+   * looking -- a shell hands its tty to an editor and the source it must be
+   * read from turns with it -- and a window restored across that change would
+   * put escape sequences into a reading view, or a screen into a scrollback.
+   * {@link recallPaneWindow} refuses a shape it was not asked for, which turns
+   * that case back into the plain miss it was before this cache existed.
+   */
+  shape: string;
+  /** The folded window, exactly as `foldPaneRead` last left it. */
+  output: string;
+  /** How far back the reader had paged -- `outputLineLimitRef`. */
+  lineLimit: number;
+  /**
+   * The gateway revision this window was actually folded to; -1 when the
+   * gateway versions nothing.
+   *
+   * Kept apart from {@link PaneCacheEntry.seen} because one number cannot say
+   * both things. This one is a fact about the text held; `seen` is a fact
+   * about what the gateway has since said exists. Folding them into one field
+   * makes "this pane printed while you were away" indistinguishable from "this
+   * window contains what it printed", which is precisely backwards.
+   */
+  revision: number;
+  /** Whether the pull-down had anywhere left to go. */
+  canLoadEarlier: boolean;
+  /** Rows the last read reached, for the plateau check in `hasEarlierAfterPage`. */
+  earlierRows: number;
+  /** Whether this gateway was caught ignoring a `start`/`end` range. */
+  rangeUnsupported: boolean;
+  /** The last read's envelope, which `paneReadRange` addresses the next page from. */
+  lastRead: unknown;
+}
+
+export interface PaneCacheEntry extends PaneWindow {
+  paneId: string;
+  /**
+   * The newest revision the stream or the navigator has reported for this
+   * pane, folded in or not. Never below `revision`: a window cannot hold text
+   * from a revision nobody has heard of.
+   */
+  seen: number;
+}
+
+/** Most recently used first. Immutable: every operation returns a new cache. */
+export interface PaneCache {
+  readonly entries: readonly PaneCacheEntry[];
+}
+
+export interface PaneCacheBounds {
+  /** How many panes may be remembered at once. */
+  panes: number;
+  /** How many characters of window may be held across all of them. */
+  characters: number;
+}
+
+/**
+ * Four panes, because the ring the two-finger swipe walks is stepped one at a
+ * time and a reader browsing a tab of four panes should never meet a blank;
+ * beyond that the hit rate stops paying for the memory.
+ *
+ * A megabyte and a half, measured against the worst window the screen can
+ * hold: `MAX_PANE_OUTPUT_LINES` (2000) rows of ANSI at a phone's column count
+ * comes to a few hundred kilobytes, so the budget holds four ordinary panes
+ * comfortably and refuses to hold four pathological ones.
+ */
+export const PANE_CACHE_BOUNDS: PaneCacheBounds = { panes: 4, characters: 1_500_000 };
+
+export const emptyPaneCache: PaneCache = { entries: [] };
+
+function windowCharacters(entry: PaneWindow): number {
+  return entry.output.length;
+}
+
+/**
+ * Trim to both bounds, oldest first.
+ *
+ * The most recently used entry survives whatever the budget says, because it
+ * is the one the caller has just written and the one the next switch is most
+ * likely to ask for; the byte bound is what {@link rememberPaneWindow} has
+ * already refused an over-budget window against, so this can never be asked
+ * to keep something it cannot afford.
+ */
+function trim(entries: PaneCacheEntry[], bounds: PaneCacheBounds): PaneCacheEntry[] {
+  const kept = entries.slice(0, Math.max(1, bounds.panes));
+  let total = 0;
+  const affordable: PaneCacheEntry[] = [];
+  for (const entry of kept) {
+    const size = windowCharacters(entry);
+    if (affordable.length > 0 && total + size > bounds.characters) break;
+    total += size;
+    affordable.push(entry);
+  }
+  return affordable;
+}
+
+/**
+ * Put this pane's window at the front, replacing whatever was remembered of it.
+ *
+ * Called on the way out of a pane rather than on every read: what is worth
+ * remembering is the window as the reader last saw it, and writing on every
+ * fold would copy a string a second for a pane nobody is about to leave.
+ */
+export function rememberPaneWindow(
+  cache: PaneCache,
+  paneId: string,
+  window: PaneWindow,
+  bounds: PaneCacheBounds = PANE_CACHE_BOUNDS
+): PaneCache {
+  if (!paneId) return cache;
+  const others = cache.entries.filter((entry) => entry.paneId !== paneId);
+  // Over budget on its own: not stored, and the older copy goes with it -- see
+  // the bounds note in this file's docblock.
+  if (windowCharacters(window) > bounds.characters) {
+    return others.length === cache.entries.length ? cache : { entries: others };
+  }
+  const held = cache.entries.find((entry) => entry.paneId === paneId);
+  // A window just written is caught up with itself by definition, but it must
+  // not un-hear news that arrived while it was being fetched: a prefetch reply
+  // for revision 4, landing after the stream reported 7, is still a window at
+  // 4 and the pane is still known to have moved on.
+  const seen = Math.max(window.revision, held?.seen ?? -1);
+  return { entries: trim([{ ...window, paneId, seen }, ...others], bounds) };
+}
+
+/**
+ * What is remembered of this pane, or `null`.
+ *
+ * Deliberately does not reorder: recall happens during the render that paints
+ * the switch, and a lookup that rewrote the cache there would make painting a
+ * frame a side effect. {@link rememberPaneWindow} on the way out is the only
+ * thing that moves an entry to the front, and it is the honest signal anyway
+ * -- a pane that was actually read from is a pane that was actually used.
+ */
+export function recallPaneWindow(
+  cache: PaneCache,
+  paneId: string,
+  shape: string
+): PaneWindow | null {
+  if (!paneId) return null;
+  const found = cache.entries.find((entry) => entry.paneId === paneId);
+  if (!found || found.shape !== shape) return null;
+  const { paneId: _id, seen: _seen, ...window } = found;
+  return window;
+}
+
+/**
+ * A pane the session no longer has -- closed, or moved to another session --
+ * is dropped rather than left to age out, because its id can be reused.
+ */
+export function forgetPaneWindow(cache: PaneCache, paneId: string): PaneCache {
+  const entries = cache.entries.filter((entry) => entry.paneId !== paneId);
+  return entries.length === cache.entries.length ? cache : { entries };
+}
+
+/**
+ * Keep only the panes the session still lists.
+ *
+ * The structural events say a pane closed but not always which, and the
+ * navigator refresh that follows them is the reliable answer, so this is run
+ * against the refreshed pane list rather than against an event payload.
+ */
+export function retainPanes(cache: PaneCache, paneIds: readonly string[]): PaneCache {
+  const live = new Set(paneIds);
+  const entries = cache.entries.filter((entry) => live.has(entry.paneId));
+  return entries.length === cache.entries.length ? cache : { entries };
+}
+
+/**
+ * The stream said this pane printed.
+ *
+ * Only the revision moves, and only forward -- the window itself stays exactly
+ * as it was folded, because for a pane that is not the selected one the
+ * gateway sends no text to fold. What this buys is the difference between a
+ * cached window that is still the whole truth and one that has been overtaken,
+ * which is what {@link paneWindowIsCurrent} answers and what lets a switch
+ * back to an idle pane skip its read entirely.
+ *
+ * A pane that is not cached is not created here: remembering a revision for a
+ * window nobody holds would claim freshness for a blank.
+ */
+export function notePaneRevision(cache: PaneCache, paneId: string, revision: number): PaneCache {
+  let changed = false;
+  const entries = cache.entries.map((entry) => {
+    if (entry.paneId !== paneId || revision <= entry.seen) return entry;
+    changed = true;
+    // `seen` only. The window is untouched, because for a pane that is not the
+    // selected one there is no text on the wire to fold -- which is the whole
+    // point: this is the news that what is held has been overtaken, not a
+    // repair of it.
+    return { ...entry, seen: revision };
+  });
+  return changed ? { entries } : cache;
+}
+
+/**
+ * Fold a frame the stream delivered for a pane nobody is looking at into the
+ * window remembered for it.
+ *
+ * The one case where another pane's *text* is on the wire at all: for the
+ * short interval after a switch, before the stream has been re-opened against
+ * the new selection, the gateway is still inlining the pane just left. Folding
+ * those frames in rather than dropping them is what makes switching straight
+ * back free even while the pane is printing.
+ *
+ * `fold` is the caller's -- `foldPaneRead`, the same one door the selected
+ * pane's own frames go through, given the same `'frame'` origin and the same
+ * limit the window was read at. This module supplies no folding of its own and
+ * has no opinion about the result; it decides only *whether* there is a window
+ * to fold into (there is one, of the right shape, and this frame is not one
+ * the cache has already moved past) and then puts the answer back where it
+ * came from, revision and all.
+ *
+ * A pane that is not cached, one held under another shape, and a frame at a
+ * revision already overtaken all leave the cache untouched -- and untouched
+ * means a plain miss on the next switch, which is what every pane did before
+ * any of this existed.
+ */
+export function foldPaneFrame(
+  cache: PaneCache,
+  paneId: string,
+  shape: string,
+  revision: number,
+  fold: (held: string, lineLimit: number) => string,
+  bounds: PaneCacheBounds = PANE_CACHE_BOUNDS
+): PaneCache {
+  const found = cache.entries.find((entry) => entry.paneId === paneId);
+  if (!found || found.shape !== shape) return cache;
+  if (!paneReadIsCurrent(cache, paneId, revision)) return cache;
+  const output = fold(found.output, found.lineLimit);
+  const next = revision < 0 ? found.revision : Math.max(found.revision, revision);
+  if (output === found.output && next === found.revision) return cache;
+  const { paneId: _id, seen: _seen, ...window } = found;
+  // Through `rememberPaneWindow`, so the bounds are enforced on a window that
+  // has just grown and `seen` is reconciled in the one place that owns it.
+  return rememberPaneWindow(cache, paneId, { ...window, output, revision: next }, bounds);
+}
+
+/**
+ * Whether what is remembered of this pane is still everything the gateway has.
+ *
+ * `false` for a pane that is not cached, and for one whose remembered window
+ * predates a revision the navigator or the stream has since reported. A pane
+ * that never carried a revision (`-1` on either side) is never called current,
+ * because there is nothing to compare and guessing wrong here shows the reader
+ * stale output indefinitely.
+ */
+export function paneWindowIsCurrent(cache: PaneCache, paneId: string, revision: number): boolean {
+  const found = cache.entries.find((entry) => entry.paneId === paneId);
+  if (!found || found.revision < 0 || revision < 0) return false;
+  return found.revision >= Math.max(found.seen, revision);
+}
+
+/**
+ * Whether a read that has just landed still has anything to say about a
+ * cached pane.
+ *
+ * The screen's own `isCurrentRequest` already refuses a reply for a pane that
+ * is no longer selected; this is the same question for the panes nobody is
+ * looking at, where there is no selection to compare against. A reply is
+ * refused when the cache has moved past it -- a prefetch issued at revision 4
+ * landing after the stream reported 7 would otherwise write a window three
+ * revisions behind and mark it as the truth.
+ *
+ * An answer carrying no revision (`-1`) is accepted: a gateway that does not
+ * version its panes gives no grounds to refuse one, and the alternative is
+ * never caching anything on those gateways at all.
+ */
+export function paneReadIsCurrent(cache: PaneCache, paneId: string, revision: number): boolean {
+  if (revision < 0) return true;
+  const found = cache.entries.find((entry) => entry.paneId === paneId);
+  return !found || revision >= found.revision;
+}
+
+/**
+ * One warming request per neighbour, and only for neighbours worth warming.
+ *
+ * The ring is the tab's panes in the order the strip draws them, so the two
+ * neighbours are the two panes a swipe can reach in one gesture. A neighbour
+ * whose cached window is already current is skipped -- the point of the
+ * prefetch is to remove the blank, and there is no blank to remove there --
+ * and so is the selection itself, which the screen is already reading.
+ *
+ * The ring wraps, so a tab of two panes yields one neighbour rather than the
+ * same pane twice.
+ */
+export function panePrefetchTargets(
+  paneIds: readonly string[],
+  selectedPaneId: string,
+  cache: PaneCache,
+  revisionOf: (paneId: string) => number
+): string[] {
+  const index = paneIds.indexOf(selectedPaneId);
+  if (index < 0 || paneIds.length < 2) return [];
+  const size = paneIds.length;
+  const candidates = [paneIds[(index + 1) % size], paneIds[(index - 1 + size) % size]];
+  const targets: string[] = [];
+  for (const paneId of candidates) {
+    if (paneId === selectedPaneId || targets.includes(paneId)) continue;
+    if (paneWindowIsCurrent(cache, paneId, revisionOf(paneId))) continue;
+    targets.push(paneId);
+  }
+  return targets;
+}
+
+/**
+ * Whether a prefetch issued under `generation` may still be written.
+ *
+ * Prefetches are cancelled by being outrun rather than by an abort: the
+ * request is in flight over a transport that charges for the round trip
+ * whether or not anyone reads the answer, so tearing the socket down buys
+ * nothing a stale check does not. The screen bumps the generation on every
+ * selection change, which is what makes a burst of swipes cost one useful
+ * warm-up at the end rather than one per pane passed through.
+ */
+export function panePrefetchAccepted(generation: number, currentGeneration: number): boolean {
+  return generation === currentGeneration;
+}


### PR DESCRIPTION
Switching pane blanked the terminal and waited for a network read before it had a single row to draw — including on the walk straight back to a pane the reader had been looking at a second earlier. This keeps the window that pane already had and paints it in the frame the tap lands in.

Additive throughout. The fold is untouched, the canvas is untouched, and the gesture, dock and touch-layer paths from #20, #24, #28 and #31 are not in the diff at all — the whole change lives in the pane-selection and data path of `server-terminal-workspace.tsx` plus one new pure module.

## What the measurements found first

Two things in the report turned out not to be what they looked like.

**The canvas was never being remounted.** `TerminalBoundary`'s `resetKey` only clears the boundary's own `failed` state — it renders `this.props.children` directly, so changing the key does not unmount anything. `SkiaTerminal` sits under a constant `key="terminal"` with `terminalId` as an ordinary prop it handles itself (flushing its coalescer, restoring the pane's zoom, re-anchoring its history). The `key={selection.paneId}` in that JSX is on `PaneChatView`, the transcript view, where it is genuinely needed and is left alone. So there was no mount, no font-metric measure and no first layout to remove.

**But a switch really did reconnect something.** `usePaneEvents` takes the pane whose output the gateway should inline as a query parameter (`stream_pane`) and lists it in the effect's dependencies — so every pane switch tore down the SSE stream and opened a new sealed one, and the `onConnected` that followed forced a full `refreshOutput()` *and* a full `refreshData()` (workspaces, tabs, panes, agents). Paid on every pane merely passed through on the way somewhere else, and re-pointed at a pane the reader had already left by the time it opened.

**What `readPaneOutput` asks for.** A tail, not history:

```
GET /api/sessions/{session}/panes/{pane}/output?source=recent-unwrapped&lines=240&format=ansi
```

Decoded answer for a 49x19 tmux pane with a couple of minutes of scrollback: **4541 characters (~4.4 KB)**; the same pane paged back one page answered 6518. It is re-requested once a second for the selected pane, plus once per switch. So the cost of a switch was never bandwidth — it was the round trip's latency standing between the tap and the first row.

One more thing the wire decides: `usePaneEvents` opens the stream with `stream_format=ansi` and `stream_source=recent-unwrapped` fixed, and the gateway inlines **text** only for `stream_pane`. Every other pane's `pane.updated` carries a revision and nothing else. So "keep the cache warm from the session-wide stream" is only possible for one pane at a time — see below for what is done instead.

## Timings

iOS, `muqun-ios` (iOS 26.5 simulator), debug bundle over Metro, against my own gateway v0.8.0 on `:23961` with its own tmux socket — four panes each printing ~1.4 lines/s, and a second tab for the swipe. Host load average 8–13 for both arms; each arm measured back to back on the same lab.

Timeline points are timestamps in JS: **tap** is the press handler, **window in hand** is the moment the pane's window is in component state, **read** is `readPaneOutput` returning, and **first paint** is the first canvas frame whose text actually belongs to the pane tapped (each lab pane prints its own name, so a frame still carrying the outgoing pane's text is identified and rejected rather than counted).

**before** — `origin/main` @ 9a4c91f

| case | window in hand | read landed | first paint |
|---|---|---|---|
| never-seen pane | never (blank) | +120 ms | **+350 ms** |
| back to the pane just left | never (blank) | +131 / +148 / +130 ms | **+345 / +325 / +395 ms** |
| rapid A→B→A (alternating) | never (blank) | +143 / +134 / +153 ms | **+326 / +302 / +331 ms** |

**after**

| case | window in hand | read landed | first paint |
|---|---|---|---|
| never-seen pane | miss | +169 ms | **+336 ms** |
| back to the pane just left | hit at +9 / +1 / +1 / +16 ms | +207 / +166 / +166 / +258 ms | **+80 / +88 / +85 / +119 ms** |
| rapid A→B→A (alternating) | hit at +2 / +2 / +2 ms | +180 / +176 / +223 ms | **+86 / +87 / +90 ms** |

A pane the reader has already seen goes from a median **345 ms to 86 ms**, and a pane never seen is unchanged (350 → 336 ms, inside the noise).

**On the one-frame target, honestly.** The window is in hand within one frame — 1 to 16 ms — which is the part this change is responsible for, and the network round trip is no longer between the tap and the first row. The first *painted* frame is around 85 ms because of what is left once the data problem is solved: the workspace's own re-render plus the canvas parsing the snapshot and recording its SkPicture, in an unminified dev bundle with the React Compiler on, on a host under load 8–13. That residue is the terminal's existing cost and is identical in both arms; a release build was not measured.

**One measurement changed the design.** With the restore in a `useLayoutEffect`, a hit was in hand at +33 ms but did not paint until **+254 ms**. `useCoalescedValue` flushes and stamps a fresh throttle window on the render the `terminalId` changes in, so a window arriving one render later lands inside a window it has to wait out. Moving the restore into the switch render itself — the same adjust-state-during-render pattern `useCoalescedValue` uses, and the case `useResetSignal`'s docblock describes by name — is what took it to 80 ms.

## The cache

`src/lib/pane-cache.ts`, pure, with 37 tests and no knowledge of the terminal.

It stores the window `foldPaneRead` had already produced, plus the four facts that say how deep it is: the line limit the reader paged to, the rows the last read reached, the read envelope a range page addresses from, and whether this gateway was caught ignoring a range. Restored together they put the window back exactly as the fold left it, so the refresh that follows folds identically to the way it would have had the pane never been left. **The cache never folds, never trims and has no opinion about depth** — that is the whole safety argument, and it is why the "do not break the terminal" rule survives it.

- **Bounds, two of them**: 4 panes and 1.5 M characters, enforced on every write, least-recently-used first. Either bound alone has a hole — a count bound lets four panes paged back to two thousand lines sit in memory, a byte bound lets a hundred one-line panes accumulate for nothing. A single window larger than the whole budget is not stored at all, and takes any older copy of that pane with it.
- **Revision, split in two.** `revision` is what the window holds; `seen` is what the gateway has since said exists. One field could not say both, and while it tried, news that a pane had printed while nobody was looking marked its stale window as the whole truth — the exact opposite of what the news meant. Found by review, fixed, and fenced by tests.
- **Shape.** A window is only handed back to a pane still being read the same way (`ansi:recent-unwrapped`, `text`, `visible`). A shell that has handed its tty to an editor while nobody was looking is a plain miss rather than escape sequences in a reading view.
- **A pane the session stops listing is forgotten**, not aged out — tmux and Herdr both reuse pane ids. The whole cache goes with the session it belongs to.

Three things feed it:

1. **The switch itself**, during the switch render: the outgoing window is filed while `output` and the depth refs still describe it, then the arriving one is recalled from the cache that write just went into — so a switch straight back finds what the switch away put down.
2. **The event stream.** For the interval after a switch the gateway is still inlining the pane just left — the one pane other than the selected one whose text is ever on the wire — and those frames are folded into its remembered window through `foldPaneRead`, under the same `'frame'` origin, rather than dropped. Every other pane contributes its revision, which marks its window overtaken so the warm-up knows to go and get it.
3. **A warm-up of the two panes a swipe can reach**, 400 ms after the selection stands still so it never competes with the read the reader is actually waiting on. A burst of swipes rearms the timer rather than firing per pane passed through, and a neighbour whose window is already current is skipped. It writes only to the cache — never to `output`, the revision or any depth ref — so a warm-up landing at any moment cannot move what is on screen.

**And the stream now trails the selection by 350 ms**, so A→B→A and a swipe through six panes cost one re-open instead of one per pane. Nothing is lost in the gap: the one-second refresh is already the safety net for a missed event, and the cache has meanwhile painted the pane that was asked for. The first stream of a visit does not wait — there is no reconnect to avoid when there is no connection yet.

**Deliberately not cached: the transcript, and the reader's scroll offset.** A part is a claim about a span of source rows rather than a rectangle of them, so two reads of different windows cannot be stitched together and a transcript restored under a window it was not read at would be a quiet lie; the chat view keeps the behaviour it has, whole. The scroll offset is `SkiaTerminal`'s own per-pane anchoring, and moving it would mean touching the follow-position path that #24 and #28 stabilised — a switch still lands at the latest, exactly as it does today.

## Sanity set

Run on `muqun-ios` against the live lab, on this branch, after the change:

| | |
|---|---|
| pan / scrollback | history pulls up, the "Latest" pill appears when follow disengages |
| pinch out and back | zooms and restores; the grid is not disturbed |
| two-finger vertical | pages the window |
| two-finger horizontal tab swipe | moves `lab` → `lab2` and back; with a single tab in the ring it correctly does nothing rather than misfiring |
| keyboard raise / dismiss | the on-screen keyboard raises, the terminal insets above it, and dismissing restores the dock |
| typing in a pane after a switch | `echo switched-then-typed` typed after switching to `alpha3` arrived in `%2` and nowhere else |
| history paging after a switch | pull-down pages back, and switching away and back keeps the depth and the pull-down affordance |

**Android, measured after the emulator freed up.** `muqun_android` (Android 16, `sdk_gphone16k_arm64`), debug bundle over Metro, same gateway and same tmux lab, real IME (`com.google.android.inputmethod.latin`), host load average 9–14 across both arms. Same timeline points as the iOS table.

**before** — `origin/main` @ 9a4c91f

| case | window in hand | read landed | first paint |
|---|---|---|---|
| never-seen pane | never (blank) | +211 ms | **+417 ms** |
| back to the pane just left | never (blank) | +162 / +228 / +145 ms | **+398 / +419 / +385 ms** |
| rapid A→B→A (alternating) | never (blank) | +170 / +183 / +162 ms | **+408 / +431 / +440 ms** |

**after**

| case | window in hand | read landed | first paint |
|---|---|---|---|
| never-seen pane | miss | +186 / +208 ms | **+435 / +386 ms** |
| back to the pane just left | hit at +51 / +1 / +2 / +2 ms | +221 / +236 / +232 / +280 ms | **+139 / +123 / +112 / +100 ms** |
| rapid A→B→A (alternating) | hit at +12 / +3 / +5 ms | +202 / +233 / +188 ms | **+112 / +102 / +98 ms** |

A pane the reader has already seen goes from a median **398 ms to 112 ms**. A never-seen pane is unchanged: 417 ms before against 435 / 386 ms after — the two arms straddle each other, which is what "read-gated, and the read did not change" looks like. As on iOS the window itself is in hand within a frame or two (1–12 ms once warm), and the ~100 ms that remains before the first painted frame is the canvas's own parse-and-record on an emulator, identical in both arms.

## Android sanity set

Run on `muqun_android` on this branch, against the same live lab:

| | |
|---|---|
| pan / scrollback | history pulls up and holds |
| pinch out and back | zooms and restores; the grid is not disturbed |
| two-finger vertical | pages the window |
| two-finger horizontal tab swipe | `lab` → `lab2` on a leftward swipe and back on a rightward one; the pane strip reappears with all four chips |
| typing in a pane after a switch | `echo android-switch-then-type` sent after switching to `alpha2` arrived in `%1`, and in `%0`, `%2`, `%3` not at all |
| history paging across a cached switch | paged back, switched away and back, paged again — still reaches ~80 s of scrollback, and the pull-down affordance survives the restore |

**Keyboard raise/dismiss**, `dumpsys gfxinfo dev.osuki.muqun` reset before each run, three raise/dismiss cycles per run with the real IME:

| run | frames | janky | p50 | p90 | p95 | p99 |
|---|---|---|---|---|---|---|
| baseline 1 | 110 | 21.8% | 17 ms | 53 ms | 65 ms | 81 ms |
| baseline 2 | 113 | 20.4% | 17 ms | 48 ms | 65 ms | 81 ms |
| this branch 1 | 105 | 23.8% | 17 ms | 53 ms | 77 ms | 101 ms |
| this branch 2 | 115 | 22.6% | 23 ms | 53 ms | 65 ms | 81 ms |

Both arms sit at 20–24% janky with p50 at one frame and p90 at 48–53 ms; the tails cross over between runs (the worst p99 is on this branch in one run and identical to baseline in the other, and the worst p50 likewise). I am reporting both runs per arm rather than the flattering one: on a loaded emulator this is run-to-run noise, not a signal either way, and nothing here separates the two builds. The dock, gesture and inset paths are not in the diff.

Nothing in the Android run forced a code change; the commit is unchanged since the iOS arm.

## Gates

```
npx tsc --noEmit     clean
bun run lint         oxlint --deny-warnings, clean
bun run format:check All matched files use the correct format.
bun test src         2728 pass, 2 skip, 0 fail (103 files)
```

Rebased on `origin/main` after #32 merged; no file overlap with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

