### PR TITLE
perf(files): a big file is drawn a screenful at a time, not all at once

### DIFF
--- a/src/components/__tests__/code-view.test.ts
+++ b/src/components/__tests__/code-view.test.ts
@@ -1,0 +1,92 @@
+// The rule this file exists to keep: opening a file never builds a tree the
+// size of the file.
+//
+// Card #661 was a phone locking up for seconds on a 200 KB artifact. It was not
+// the download, not the AES-GCM unseal and not the tokenizer -- it was
+// `CodeView` mounting a `<Text>` per line, ten thousand of them, on the frame
+// the sheet opened. The fix is that only the rows on screen exist, and that the
+// tokenizer runs after the first paint rather than before it.
+//
+// Neither half can be checked by types, lint or a render test (this repo has no
+// renderer), and both are the kind of thing a later refactor undoes without
+// noticing: `<LegendList>` back to `<ScrollView>` reads like a simplification,
+// and a `useMemo` around `highlightFile` reads like an optimization. So the
+// scan reads the real TypeScript AST, scopes itself to `CodeView` by name, and
+// fails loudly if it is gone -- a rename is a finding here, not a silent pass.
+/// <reference types="node" />
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import ts from 'typescript';
+
+const VIEW = join(dirname(fileURLToPath(import.meta.url)), '..', 'code-view.tsx');
+const TEXT = readFileSync(VIEW, 'utf8');
+
+/** The source of one function in the file, by name. */
+function functionSource(name: string): string {
+  const source = ts.createSourceFile(VIEW, TEXT, ts.ScriptTarget.Latest, true);
+  let found: string | undefined;
+  const visit = (node: ts.Node) => {
+    if (
+      (ts.isFunctionDeclaration(node) || ts.isFunctionExpression(node)) &&
+      node.name?.text === name
+    ) {
+      found = node.getText(source);
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  if (found === undefined) {
+    throw new Error(`${name} is not a function of code-view.tsx any more`);
+  }
+  return found;
+}
+
+describe('a file is drawn a screenful at a time', () => {
+  const view = functionSource('CodeView');
+
+  test('the lines go through a virtualized list', () => {
+    expect(TEXT).toContain("from '@legendapp/list/react-native'");
+    expect(view).toContain('<LegendList');
+    expect(view).toContain('estimatedItemSize={LINE_HEIGHT}');
+  });
+
+  test('a row is exactly one line tall, so the estimate is never wrong', () => {
+    // A row that can wrap to two lines makes every offset the list has already
+    // computed wrong, and a virtualized list with wrong offsets scrolls to the
+    // wrong place and then jumps when it finds out.
+    const row = functionSource('CodeRow');
+    expect(row).toContain('numberOfLines={1}');
+    expect(TEXT).toContain('height: LINE_HEIGHT,');
+  });
+
+  test('the scrollable width is decided once, not by whichever rows are mounted', () => {
+    // A virtualized list only knows the rows it has, so letting the content
+    // size itself makes the horizontal extent move as the reader scrolls.
+    expect(view).toContain('longestLineOf(plain.lines)');
+    expect(view).toContain('const contentWidth = Math.max(');
+  });
+});
+
+describe('the tokenizer runs after the first paint', () => {
+  const view = functionSource('CodeView');
+
+  test('the first frame is the plain split', () => {
+    expect(view).toContain('plainFile(content)');
+    expect(view).toContain('const result = coloured ?? plain;');
+  });
+
+  test('highlighting is scheduled, never called while rendering', () => {
+    // One call site, and it is inside the callback. `highlightFile` on 64 KiB
+    // is tens of uninterruptible milliseconds on a phone; run from the render
+    // body it is tens of milliseconds the sheet spends unable to be closed.
+    const calls = TEXT.split('highlightFile(').length - 1;
+    expect(calls).toBe(1);
+    const scheduled = view.indexOf('InteractionManager.runAfterInteractions(');
+    expect(scheduled).toBeGreaterThan(-1);
+    expect(view.indexOf('highlightFile(')).toBeGreaterThan(scheduled);
+  });
+});

--- a/src/components/asset-viewer.tsx
+++ b/src/components/asset-viewer.tsx
@@ -1,8 +1,9 @@
+import * as Clipboard from 'expo-clipboard';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { Skeleton, Text, useThemeTokens } from '@osuki-dev/ui';
-import { X } from 'lucide-react-native';
+import { Check, Copy, X } from 'lucide-react-native';
 import { EnrichedMarkdownText } from 'react-native-enriched-markdown';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ActivityIndicator, Linking, Modal, ScrollView, StyleSheet, View } from 'react-native';
 import Animated from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -122,6 +123,37 @@ function EncryptedImageViewer({ asset, onClose }: { asset: SessionAsset; onClose
   );
 }
 
+/** How long the header's copy button stays a tick before it is a copy icon again. */
+const COPIED_FEEDBACK_MS = 1_600;
+
+/**
+ * Where a document stops being rendered as a document.
+ *
+ * `react-native-enriched-markdown` parses and lays out natively, which is why
+ * this sits far above the tokenizer's gate -- but the work still lands in one
+ * uninterruptible pass on the frame the text arrives, and past a point it stops
+ * being linear. Measured through the app, from the string being in hand to the
+ * renderer's first paint, warm (the very first markdown mount of a session
+ * costs an extra second on Android whatever the size, so only warm numbers say
+ * anything about size):
+ *
+ *   size        iOS simulator    Android emulator
+ *   20 KiB              18 ms              857 ms
+ *   60 KiB              18 ms            1_749 ms
+ *   200 KiB          5_023 ms            5_999 ms
+ *
+ * iOS is flat to 60 KiB and then falls off a cliff; Android is expensive
+ * throughout and ends in the same place. Five to six seconds is not a slow
+ * render, it is the phone not answering, and it is exactly what the report in
+ * card #661 described. 64 KiB is the last size measured on the flat part of the
+ * curve, and it is comfortably above every document an agent actually writes.
+ *
+ * Above it the file is shown as its own source through `CodeView`, which
+ * virtualizes its lines -- and, since anything over this is also over
+ * `HIGHLIGHT_MAX_BYTES`, says in its own caption that this is plain text.
+ */
+const MARKDOWN_MAX_BYTES = 64 * 1024;
+
 /** Everything that is not an image: a document, some text, or a file we can only describe. */
 function AssetSheet({ asset, onClose }: { asset: SessionAsset; onClose: () => void }) {
   // `t` from the hook, not the global `t` from `@lingui/core/macro`.
@@ -174,6 +206,26 @@ function AssetSheet({ asset, onClose }: { asset: SessionAsset; onClose: () => vo
     .filter(Boolean)
     .join(' · ');
 
+  /**
+   * The whole file, to the clipboard.
+   *
+   * The code viewer virtualizes its lines, so a drag selects within one line
+   * and not across the document -- which is the correct trade for a file that
+   * can be ten thousand lines long, but it does take away the only way there
+   * was to get the text out. This is that way, and it is a better one: nobody
+   * was dragging a selection over 200 KB.
+   */
+  const [copied, setCopied] = useState(false);
+  const copy = useCallback(() => {
+    if (content === null) return;
+    void Clipboard.setStringAsync(content).then(() => setCopied(true));
+  }, [content]);
+  useEffect(() => {
+    if (!copied) return;
+    const timer = setTimeout(() => setCopied(false), COPIED_FEEDBACK_MS);
+    return () => clearTimeout(timer);
+  }, [copied]);
+
   return (
     // `fade`, not `slide`: a document is opened, not pulled up. The slide read
     // as a half sheet that had stopped short even though the window was always
@@ -213,6 +265,18 @@ function AssetSheet({ asset, onClose }: { asset: SessionAsset; onClose: () => vo
                 {subtitle}
               </Text>
             </View>
+            {content ? (
+              <PressableScale
+                accessibilityLabel={t`Copy`}
+                onPress={copy}
+                style={[styles.close, { backgroundColor: theme.colors.surfaceRaised }]}>
+                {copied ? (
+                  <Check size={18} color={theme.colors.success} />
+                ) : (
+                  <Copy size={18} color={theme.colors.text} />
+                )}
+              </PressableScale>
+            ) : null}
             <PressableScale
               accessibilityLabel={t`Close file`}
               onPress={onClose}
@@ -329,7 +393,7 @@ function AssetBody({
     );
   }
 
-  if (asset.kind === 'markdown') {
+  if (asset.kind === 'markdown' && content.length <= MARKDOWN_MAX_BYTES) {
     return (
       <AssetBodyLayer id="markdown">
         <ScrollView

--- a/src/components/code-view.tsx
+++ b/src/components/code-view.tsx
@@ -1,26 +1,62 @@
+import { LegendList, type LegendListRenderItemProps } from '@legendapp/list/react-native';
 import { useLingui } from '@lingui/react/macro';
 import { Text as UIText, useThemeTokens } from '@osuki-dev/ui';
 import type { Colors } from '@osuki-dev/ui';
-import { useMemo } from 'react';
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  InteractionManager,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+  type LayoutChangeEvent,
+} from 'react-native';
 
-import { highlightFile, type CodeLine, type TokenRole } from '@/lib/code-highlight';
+import {
+  highlightFile,
+  plainFile,
+  type CodeLine,
+  type HighlightResult,
+  type TokenRole,
+} from '@/lib/code-highlight';
 
 /**
  * A source file or a diff, coloured, read-only.
  *
- * Two render paths, because the two have different units of meaning.
+ * This used to render the whole file in one go: a `<Text>` per line, with the
+ * coloured runs nested inside it, all under a single `<Text selectable>` in a
+ * plain `ScrollView`. The reasoning was that nested `<Text>` folds into ranges
+ * on one native attributed string rather than into views, so the spans are
+ * cheap -- which is true, and beside the point. The *lines* are not cheap. A
+ * 200 KB file is eight to ten thousand of them, and every one was an element to
+ * create, a shadow node to lay out and a range to measure, synchronously, on
+ * the frame the sheet opened. Card #661: opening a 200 KB artifact on a phone
+ * locked the whole app up for seconds -- not the download, not the decryption,
+ * not the tokenizer. The tree.
  *
- * **Syntax** is a property of runs of characters, so the whole file goes into
- * one `<Text>` with the coloured runs nested inside it. Nested `<Text>` does not
- * create views -- React Native folds it into ranges on a single native
- * attributed string -- which is why a file with nine thousand spans is
- * affordable at all.
+ * So the file is virtualized by line. Only the rows in the viewport exist, the
+ * work per frame is bounded by the screen rather than by the file, and the
+ * sheet can be scrolled and closed from the first frame at any size the reader
+ * is allowed to open.
  *
- * **A diff** is a property of whole lines, so each line needs its own `<View>`:
- * a background set on a text span paints only behind the glyphs, and a diff
- * whose tint stops at the end of the text does not read as a diff. That is the
- * expensive path, and it is what `HIGHLIGHT_MAX_LINES` protects.
+ * Three things follow from that, and each costs something here:
+ *
+ * **Colour arrives a frame late.** Splitting on newlines is a couple of
+ * milliseconds at 200 KB; tokenizing is hundreds, uninterruptible, on the JS
+ * thread (see `HIGHLIGHT_MAX_BYTES` for what that measured out to). So the
+ * first paint is plain and `highlightFile` runs after the interaction settles,
+ * then swaps in.
+ *
+ * **The scrollable width has to be decided up front.** A virtualized list only
+ * knows the rows it has mounted, so letting the content size itself would make
+ * the horizontal extent jump as the reader scrolled. The longest line is
+ * measured once, off screen, and every row is cut to that width.
+ *
+ * **Selection is per line.** One `<Text>` spanning the document is exactly the
+ * thing that cannot be virtualized, so a drag no longer runs past the end of a
+ * line. The viewer's header carries a copy action for the whole file instead,
+ * which is what a selection across ten thousand lines was being used for
+ * anyway.
  *
  * Neither path wraps, and both scroll horizontally. A re-wrapped line loses the
  * column alignment that is the entire reason for reading a log or a diff in a
@@ -29,13 +65,56 @@ import { highlightFile, type CodeLine, type TokenRole } from '@/lib/code-highlig
 export function CodeView({ name, content }: { name: string; content: string }) {
   const { t } = useLingui();
   const theme = useThemeTokens();
-  const result = useMemo(() => highlightFile(name, content), [content, name]);
-  const roleColors = useMemo(() => roleColorMap(theme.colors), [theme.colors]);
 
+  // What the first frame draws. `plainFile` is one `split('\n')`.
+  const plain = useMemo(() => plainFile(content), [content]);
+  const [coloured, setColoured] = useState<HighlightResult | null>(null);
+
+  useEffect(() => {
+    setColoured(null);
+    // `runAfterInteractions`, not a bare timeout: the sheet is opening with a
+    // fade as this mounts, and the tokenizer is the one thing here long enough
+    // to be seen dropping frames out of it.
+    const task = InteractionManager.runAfterInteractions(() => {
+      setColoured(highlightFile(name, content));
+    });
+    return () => task.cancel();
+  }, [content, name]);
+
+  const result = coloured ?? plain;
+  const roleColors = useMemo(() => roleColorMap(theme.colors), [theme.colors]);
   const isDiff = result.language === 'diff';
 
+  // Measured from the plain split rather than from `result`, so the scrollable
+  // width is settled before colour lands and does not move when it does.
+  const longestLine = useMemo(() => longestLineOf(plain.lines), [plain]);
+  const [longestWidth, setLongestWidth] = useState(0);
+  const [viewport, setViewport] = useState({ width: 0, height: 0 });
+
+  const contentWidth = Math.max(viewport.width, longestWidth + CONTENT_PADDING * 2);
+
+  const renderItem = useCallback(
+    ({ item }: LegendListRenderItemProps<CodeLine>) => (
+      <CodeRow
+        line={item}
+        isDiff={isDiff}
+        colors={theme.colors}
+        roleColors={roleColors}
+        width={contentWidth}
+      />
+    ),
+    [contentWidth, isDiff, roleColors, theme.colors]
+  );
+
+  const onArea = useCallback((event: LayoutChangeEvent) => {
+    const { width, height } = event.nativeEvent.layout;
+    setViewport((previous) =>
+      previous.width === width && previous.height === height ? previous : { width, height }
+    );
+  }, []);
+
   return (
-    <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
+    <View style={styles.body}>
       {result.skipped ? (
         <UIText variant="caption" color={theme.colors.textMuted} style={styles.notice}>
           {result.skipped === 'size'
@@ -43,44 +122,127 @@ export function CodeView({ name, content }: { name: string; content: string }) {
             : t`Too many lines to colour. Shown as plain text.`}
         </UIText>
       ) : null}
-      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-        {isDiff ? (
-          <View>
-            {result.lines.map((line, index) => (
-              <View
-                // Lines have no identity of their own; position is what they are.
-                key={index}
-                style={[styles.diffRow, { backgroundColor: diffBackground(line, theme.colors) }]}>
-                <Text
-                  selectable
-                  style={[styles.code, { color: diffColor(line, theme.colors, roleColors) }]}>
-                  {line.spans.length > 0 ? line.spans.map((span) => span.text).join('') : ' '}
-                </Text>
-              </View>
-            ))}
-          </View>
-        ) : (
-          <Text selectable style={[styles.code, { color: theme.colors.text }]}>
-            {result.lines.map((line, lineIndex) => (
-              <Text key={lineIndex}>
-                {line.spans.map((span, spanIndex) => (
-                  <Text
-                    key={spanIndex}
-                    style={[
-                      { color: roleColors[span.role] },
-                      span.role === 'comment' ? styles.comment : null,
-                    ]}>
-                    {span.text}
-                  </Text>
-                ))}
-                {lineIndex < result.lines.length - 1 ? '\n' : ''}
-              </Text>
-            ))}
-          </Text>
-        )}
-      </ScrollView>
-    </ScrollView>
+
+      {/* The width probe. It sits in a container far wider than any screen so
+          the text lays out at its natural width instead of being wrapped or
+          clipped to the viewport, which is the only way to learn how wide the
+          file actually is without mounting all of it. One text node, one
+          layout pass, and it never draws. */}
+      <View style={styles.probe} pointerEvents="none">
+        <Text
+          style={[styles.code, styles.probeLine]}
+          numberOfLines={1}
+          onLayout={(event) => setLongestWidth(event.nativeEvent.layout.width)}>
+          {longestLine}
+        </Text>
+      </View>
+
+      <View style={styles.area} onLayout={onArea}>
+        {viewport.height > 0 ? (
+          <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+            {/* A vertical list inside a horizontal scroller: different axes, so
+                this is not the nesting React Native warns about. The height is
+                the measured one rather than `flex: 1` -- a child of a
+                horizontal `ScrollView` is sized by its content on the cross
+                axis too, and a list that sizes itself to its content is a list
+                that is not virtualizing. */}
+            <LegendList
+              data={result.lines}
+              renderItem={renderItem}
+              keyExtractor={keyOfLine}
+              estimatedItemSize={LINE_HEIGHT}
+              recycleItems
+              showsVerticalScrollIndicator={false}
+              style={{ width: contentWidth, height: viewport.height }}
+              contentContainerStyle={styles.listContent}
+            />
+          </ScrollView>
+        ) : null}
+      </View>
+    </View>
   );
+}
+
+/**
+ * One line.
+ *
+ * Fixed height, and `numberOfLines={1}` under it: a row that can grow to two
+ * lines makes every offset the list has already computed wrong, and the whole
+ * point of not wrapping is that it never should.
+ */
+const CodeRow = memo(function CodeRow({
+  line,
+  isDiff,
+  colors,
+  roleColors,
+  width,
+}: {
+  line: CodeLine;
+  isDiff: boolean;
+  colors: Colors;
+  roleColors: Record<TokenRole, string>;
+  width: number;
+}) {
+  if (isDiff) {
+    // The tint is the line's verdict, so it runs the whole row rather than
+    // stopping where the text does -- which is why a diff is a `View` per line
+    // and not a background on a text span.
+    return (
+      <View style={[styles.row, { width, backgroundColor: diffBackground(line, colors) }]}>
+        <Text
+          selectable
+          numberOfLines={1}
+          style={[styles.code, { color: diffColor(line, colors, roleColors) }]}>
+          {textOf(line)}
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.row, { width }]}>
+      <Text selectable numberOfLines={1} style={[styles.code, { color: colors.text }]}>
+        {line.spans.map((span, index) => (
+          <Text
+            key={index}
+            style={[
+              { color: roleColors[span.role] },
+              span.role === 'comment' ? styles.comment : null,
+            ]}>
+            {span.text}
+          </Text>
+        ))}
+      </Text>
+    </View>
+  );
+});
+
+/** Lines have no identity of their own; position is what they are. */
+function keyOfLine(_line: CodeLine, index: number): string {
+  return String(index);
+}
+
+function textOf(line: CodeLine): string {
+  return line.spans.map((span) => span.text).join('');
+}
+
+/**
+ * The line the scrollable width is measured from.
+ *
+ * By character count, which is not the same as by rendered width for a face
+ * that has any double-width glyph in it -- but the result is only ever used as
+ * `Math.max` against the viewport, and being a few points short on a file of
+ * CJK is a line that ends at the edge rather than a broken viewer. Counting
+ * columns properly means walking every character of the file, which is the kind
+ * of whole-input pass this change exists to remove.
+ */
+function longestLineOf(lines: CodeLine[]): string {
+  let longest = '';
+  for (const line of lines) {
+    const text = line.spans.length > 0 ? line.spans[0].text : '';
+    if (text.length > longest.length) longest = text;
+  }
+  return longest;
 }
 
 /**
@@ -150,29 +312,58 @@ export function withAlpha(color: string, alpha: number): string {
   return `rgba(${red}, ${green}, ${blue}, ${alpha})`;
 }
 
+/** One row, exactly. The list's item size is this and never has to be measured. */
+const LINE_HEIGHT = 18;
+const CONTENT_PADDING = 16;
+
+/**
+ * The width the off-screen probe lays out on. Wide enough that no real line of
+ * code reaches the end of it, so the measurement is the line's own width and
+ * not this number.
+ */
+const PROBE_CANVAS_WIDTH = 100_000;
+
 const styles = StyleSheet.create({
-  scroll: {
+  body: {
     flex: 1,
   },
-  content: {
-    padding: 16,
-    paddingBottom: 40,
+  area: {
+    flex: 1,
   },
   notice: {
-    marginBottom: 10,
+    paddingHorizontal: CONTENT_PADDING,
+    paddingTop: 12,
+    paddingBottom: 6,
+  },
+  // Off screen and unclipped: `left` puts it beyond any viewport and the width
+  // is a canvas the longest line can lay out on without being wrapped.
+  probe: {
+    position: 'absolute',
+    left: -PROBE_CANVAS_WIDTH,
+    top: 0,
+    width: PROBE_CANVAS_WIDTH,
+    opacity: 0,
+  },
+  // Without this the probe stretches to its container the way a `Text` in a
+  // `View` always does, and the measurement comes back as the canvas width
+  // rather than the line's.
+  probeLine: {
+    alignSelf: 'flex-start',
+  },
+  listContent: {
+    paddingVertical: CONTENT_PADDING,
+  },
+  row: {
+    height: LINE_HEIGHT,
+    justifyContent: 'center',
+    paddingHorizontal: CONTENT_PADDING,
   },
   code: {
     fontFamily: 'monospace',
     fontSize: 12.5,
-    lineHeight: 18,
+    lineHeight: LINE_HEIGHT,
   },
   comment: {
     fontStyle: 'italic',
-  },
-  diffRow: {
-    // The tint is the line's verdict, so it runs the whole row rather than
-    // stopping where the text does.
-    minWidth: '100%',
-    paddingHorizontal: 4,
   },
 });

--- a/src/lib/__tests__/code-highlight.test.ts
+++ b/src/lib/__tests__/code-highlight.test.ts
@@ -7,6 +7,7 @@ import {
   highlightFile,
   isDiffFile,
   languageForFile,
+  plainFile,
   spansFromHighlightHtml,
   type CodeLine,
 } from '@/lib/code-highlight';
@@ -252,5 +253,42 @@ describe('highlightDiff', () => {
     const { language, skipped } = highlightFile('big.diff', big);
     expect(skipped).toBeNull();
     expect(language).toBe('diff');
+  });
+});
+
+describe('plainFile', () => {
+  // What the viewer paints on the frame the sheet opens, before the tokenizer
+  // has run. It has to agree with the fallback `highlightFile` produces, or the
+  // swap to colour would move every line.
+  it('is line for line what the size fallback produces', () => {
+    const big = `const x = ${'1 + '.repeat(HIGHLIGHT_MAX_BYTES / 4)}0;`;
+    expect(plainFile(big).lines.map(textOf)).toEqual(
+      highlightFile('big.ts', big).lines.map(textOf)
+    );
+  });
+
+  it('claims no language and reports no fallback of its own', () => {
+    const { language, skipped } = plainFile('a\nb');
+    expect(language).toBeNull();
+    expect(skipped).toBeNull();
+  });
+
+  it('gives an empty file one empty line, the way every other path does', () => {
+    expect(plainFile('').lines).toEqual([{ spans: [] }]);
+  });
+
+  it('costs one split, whatever the file is', () => {
+    // The whole reason this exists: it runs on the frame the sheet opens, at
+    // sizes where `highlightFile` is tens of milliseconds. 200 KB is the size
+    // from the report in card #661.
+    const text = Array.from(
+      { length: 8_000 },
+      (_, index) => `line ${index} of a file the size of the one in the report`
+    ).join('\n');
+    expect(text.length).toBeGreaterThan(200 * 1024);
+    const started = performance.now();
+    const { lines } = plainFile(text);
+    expect(performance.now() - started).toBeLessThan(50);
+    expect(lines).toHaveLength(8_000);
   });
 });

--- a/src/lib/code-highlight.ts
+++ b/src/lib/code-highlight.ts
@@ -95,43 +95,57 @@ export interface HighlightResult {
 /**
  * Where highlighting gives up.
  *
- * Two gates because bytes alone are the wrong measure. Tokenizing is linear in
- * characters; *rendering* is linear in spans, and React Native's cost per
- * nested `<Text>` dwarfs highlight.js's cost per character. A minified bundle
- * is 500 long lines -- slow to tokenize, cheap to render. A build log is 20,000
- * short ones -- the reverse. Either gate trips the fallback.
+ * Two gates, and card #661 changed what both of them are protecting and what
+ * one of them is worth.
  *
- * Measured with `bun run scripts/bench-highlight.ts` on this machine (bun 1.4,
- * Apple Silicon):
+ * The viewer used to mount the whole file at once, so the count that hurt was
+ * the *span* count -- every coloured run was a node in one enormous tree, built
+ * and laid out synchronously on the frame the sheet opened. `CodeView`
+ * virtualizes lines now, so render cost is bounded by the viewport rather than
+ * by the file, and what is left is the work that is still linear in the whole
+ * input:
  *
- *   input                      chars     time    spans    lines
- *   demo theme.diff              368  0.02 ms        9        9   (diff path)
- *   demo coverage.json            55  0.07 ms       22        1
- *   16 KiB TypeScript         16_384  5.90 ms    2_324      472
- *   64 KiB TypeScript         65_536 27.61 ms    9_303    1_874
- *   128 KiB TypeScript       131_072 43.89 ms   18_608    3_749
- *   64 KiB diff               65_536  0.16 ms    1_599    1_599
- *   40_000-line log        2_759_999  2.12 ms   40_000   40_000   (unmapped ext)
+ *   * the byte gate is tokenizing time. highlight.js is a regex machine, it
+ *     runs on the JS thread, and it cannot be interrupted part way.
+ *   * the line gate is the arrays. Every line is a `CodeLine` in the JS heap
+ *     whether or not it is on screen.
  *
- * Tokenizing is linear at roughly 0.35 ms/KiB here. Bun's JSC is well ahead of
- * Hermes, so 64 KiB -- 27.6 ms on this machine -- is about as much as a phone
- * can absorb in one shot without the sheet visibly stalling as it opens, and it
- * covers essentially every artifact an agent actually writes. 128 KiB was
- * measured and rejected: 43.9 ms here extrapolates past 150 ms on device.
+ * The byte gate was 64 KiB, set from `scripts/bench-highlight.ts`: 27.6 ms for
+ * 64 KiB of TypeScript, on bun's JSC, on an Apple Silicon desktop. The note
+ * said Hermes would be slower. It is not slower, it is a different order --
+ * measured through the app on an Android emulator, one file at a time, warm:
  *
- * The line gate protects a different thing. Syntax spans cost little to render
- * -- nested `<Text>` inside one parent `<Text>` collapses to ranges on a single
- * native attributed string, not to views. Diff lines cannot: a full-width row
- * tint needs a real `<View>` per line, because a background on a text span only
- * paints behind the glyphs. 2_000 rows is already more than a mounted
- * `ScrollView` should carry, and it is far more diff than anyone reads on a
- * phone.
+ *   input                    bun/JSC     Hermes    ratio
+ *   20 KiB TypeScript        14.1 ms     447 ms      32x
+ *   60 KiB TypeScript        24.9 ms   1_906 ms      77x   (includes grammar
+ *                                                           registration)
+ *   20 KiB Rust               6.9 ms     142 ms      21x
+ *   60 KiB Rust              11.8 ms     147 ms      12x
+ *   60 KiB plain log          0.0 ms      10 ms       --   (no grammar)
  *
- * `readAssetText` refuses anything over 512 KiB outright, so both sit under a
- * ceiling that already exists.
+ * Hermes has its own regex engine and it is where the whole difference lives.
+ * So the desktop benchmark was reading a machine nobody runs the app on, and
+ * 64 KiB of TypeScript is not "about as much as a phone can absorb" -- it is
+ * close to two seconds of a thread that cannot answer a touch.
+ *
+ * 16 KiB is what the same measurement supports: roughly 350 ms for the most
+ * expensive grammar registered here, and well under a tenth of that for the
+ * cheap ones, on a file bigger than almost everything an agent writes. It is
+ * spent after the first paint rather than before it (see `CodeView`), so it is
+ * colour arriving late on a page already being read -- but it is still a block,
+ * and the number is chosen so it is a short one. Anything above the gate is
+ * plain text with a caption saying so, which is what shipped before colour
+ * existed at all.
+ *
+ * The line gate rose from 2_000 to 20_000 with the same change. 2_000 was the
+ * point past which a mounted `View` per diff row stopped being affordable, and
+ * there is no longer a `View` per row -- only the rows on screen exist. 20_000
+ * is where the `CodeLine` array itself starts to be the expensive part, and
+ * `readAssetText` refuses anything over 512 KiB outright, so both gates sit
+ * under a ceiling that already exists.
  */
-export const HIGHLIGHT_MAX_BYTES = 64 * 1024;
-export const HIGHLIGHT_MAX_LINES = 2_000;
+export const HIGHLIGHT_MAX_BYTES = 16 * 1024;
+export const HIGHLIGHT_MAX_LINES = 20_000;
 
 /**
  * Extension to language. Explicit, and no auto-detection: `highlightAuto` runs
@@ -442,6 +456,18 @@ export function highlightFile(name: string, text: string): HighlightResult {
     return { lines: plainLines(text), language: null, skipped: 'lines' };
   }
   return { lines, language, skipped: null };
+}
+
+/**
+ * The same result the fallbacks produce, with nothing coloured.
+ *
+ * Exported because `CodeView` paints this on the frame the sheet opens and
+ * swaps the coloured result in afterwards: splitting on newlines is a fraction
+ * of a millisecond even at 200 KB, where tokenizing is tens of milliseconds and
+ * the reader is looking at an empty screen for every one of them.
+ */
+export function plainFile(text: string): HighlightResult {
+  return { lines: plainLines(text), language: null, skipped: null };
 }
 
 function plainLines(text: string): CodeLine[] {


### PR DESCRIPTION
Opening an artifact of tens of KB to ~200 KB from the files sheet locked the whole app up.

## Is it the decryption?

No. It is not the transport, not the cipher, not any base64 or UTF-8 conversion around them, and not the tokenizer either. It is the view.

Instrumented one open of a 60 KB Rust source file, end to end, on Android, on the code as it stands on `main`:

| stage | ms |
| --- | ---: |
| request start -> response received | 25.3 |
| envelope `JSON.parse` | 0.3 |
| AES-256-GCM unseal + inner `JSON.parse` | 35.8 |
| body base64 decode | 21.0 |
| UTF-8 decode | 3.9 |
| **text in hand** | **86.2** |
| `highlightFile` | 142.4 |
| React render + commit of the code view | **974,563.4** |
| first frame after that | 18,588.9 |
| **total** | **993,388** |

`react-native-quick-crypto` is native and behaves like it: 200 KB unseals plus its inner `JSON.parse` in 92 to 97 ms on iOS and 449 to 536 ms on Android, and the base64 goes through `QuickCrypto.Buffer` rather than any JS-side loop. Decryption is about 4 thousandths of one percent of that 993-second wait, and about 2% of the wall clock on the worst case that still finished (200 KB markdown on iOS: 228 ms to have the string, then 5,023 ms in the renderer).

The 522,769 ms in that trace is one uninterruptible block on the JS thread, measured by the drift of a 16 ms heartbeat. `dumpsys gfxinfo` over the same window recorded 163 frames in total, three of them in the 4,950 ms clamp bucket, with `Number High input latency: 221`. The phone is not slow during this. It is not there.

## What it actually was

`CodeView` rendered the whole file in one go: a `<Text>` per line, with the coloured runs nested inside it, all under a single `<Text selectable>` in a plain `ScrollView`. The comment on it argued that nested `<Text>` folds into ranges on one native attributed string rather than into views, so the spans are cheap. That is true, and beside the point -- the *lines* are not cheap. A 200 KB file is 4,000 to 10,000 of them, and every one was an element to create, a shadow node to lay out and a range to measure, synchronously, on the frame the sheet opened. The plain path does it too, so the existing 64 KiB fallback did not help: it only removed the colour.

## The fix

**Virtualize the lines.** The file is drawn through Legend List, which this app already uses for the artifacts list and the chat transcript. Only the rows in the viewport exist. Each row is one line, fixed height, `numberOfLines={1}`, so the item size is exact and never has to be measured.

Three things follow, and each is paid for explicitly:

- **Colour arrives a frame late.** The first paint is `plainFile(content)` -- one `split('\n')`, about 2 ms at 200 KB -- and `highlightFile` runs under `InteractionManager.runAfterInteractions`, then swaps in.
- **The scrollable width is decided up front.** A virtualized list only knows the rows it has mounted, so letting the content size itself made the horizontal extent move as the reader scrolled. The longest line is measured once by an off-screen probe laid out on a canvas wider than any screen, and every row is cut to that width.
- **Selection is per line.** One `<Text>` spanning the document is exactly the thing that cannot be virtualized. I took the trade deliberately: rows stay `selectable` so a drag still works within a line, and the viewer's header gains a copy action for the whole file, which is what a selection across ten thousand lines was standing in for. It reuses the existing `Copy` message, so no catalogs move.

**Two gates were wrong, and only measuring on a device showed it.**

`HIGHLIGHT_MAX_BYTES` was 64 KiB, set from `scripts/bench-highlight.ts` on bun's JSC on a desktop. Hermes has its own regex engine and runs the same tokenizer 20 to 70 times slower:

| input | bun/JSC | Hermes | ratio |
| --- | ---: | ---: | ---: |
| 20 KiB TypeScript | 14.1 ms | 447 ms | 32x |
| 60 KiB TypeScript | 24.9 ms | 1,906 ms | 77x |
| 20 KiB Rust | 6.9 ms | 142 ms | 21x |
| 60 KiB Rust | 11.8 ms | 147 ms | 12x |

So 64 KiB of TypeScript was not "about as much as a phone can absorb" -- it was close to two seconds of a thread that cannot answer a touch. It is 16 KiB now, which the same measurement puts at roughly 350 ms for the most expensive grammar registered and a small fraction of that for the cheap ones. Above the gate the file is plain text with the caption that already existed.

Markdown had no gate at all. `react-native-enriched-markdown` parses and lays out natively, but the work still lands in one pass, and past a point it stops being linear:

| size | iOS | Android |
| --- | ---: | ---: |
| 20 KiB | 18 ms | 857 ms |
| 60 KiB | 18 ms | 1,749 ms |
| 200 KiB | 5,023 ms | 5,999 ms |

`MARKDOWN_MAX_BYTES` is 64 KiB, the last size on the flat part of the iOS curve and comfortably above every document an agent writes. Above it a document is shown as its own source through the now-virtualized code view -- which, being also over the highlight gate, says in its own caption that this is plain text.

`HIGHLIGHT_MAX_LINES` went the other way, 2,000 to 20,000. It existed because a diff needs a real `<View>` per row for the full-width tint, and there is no longer a `<View>` per row -- only the rows on screen. A 200 KB diff is tinted again.

The fix from #25 is untouched: one sheet, one `openAsset`, and the read still aborts on close and on moving to another file.

## Measurements

Debug bundles over Metro, on a simulator and an emulator, not release builds on the maintainer's phone -- absolute numbers are inflated and the ratios are the finding. "First paint" is the request starting to the viewer's first committed frame; "longest block" is the worst 16 ms-heartbeat drift over the same window. Files are synthetic samples of each size served by a v0.8.0 gateway of my own on port 23901 over the encrypted transport, from a tmux session rooted in a directory of those files.

### iOS simulator (muqun-ios), warm, one size group at a time

| type | size | before: first paint | before: longest block | after: first paint | after: longest block |
| --- | ---: | ---: | ---: | ---: | ---: |
| .txt | 20 KB | 150 | 150 | 209 | 209 |
| .ts | 20 KB | 859 | 859 | 230 | 230 |
| .rs | 20 KB | 870 | 870 | 292 | 237 |
| .md | 20 KB | 53 | 53 | 97 | 50 |
| .txt | 60 KB | 376 | 375 | 256 | 256 |
| .ts | 60 KB | 2,113 | 2,112 | 283 | 282 |
| .rs | 60 KB | 1,105 | 1,081 | 416 | 416 |
| .md | 60 KB | 114 | 68 | 86 | 86 |
| .txt | 200 KB | 1,126 | 1,125 | 417 | 417 |
| .ts | 200 KB | 1,491 | 1,490 | 593 | 574 |
| .rs | 200 KB | 2,743 | 2,743 | 634 | 634 |
| .md | 200 KB | 5,257 | 5,236 | 763 | 763 |

The two rows that got worse are the two smallest, by 60 to 150 ms: that is Legend List's setup, and it buys the other ten. The 20 KB markdown row does not touch this code at all and is run-to-run noise.

### Android emulator (muqun_android, API 36)

Before, the harness got exactly one file:

| type | size | before: first paint | before: longest block |
| --- | ---: | ---: | ---: |
| .rs | 60 KB | 993,388 | 522,769 |

It then opened the 60 KB TypeScript file and was still wedged 25 minutes later at 1.4 GB RSS, so the run was abandoned. That is the report, reproduced: 60 KB, not 200.

After (this column predates the two gate changes -- the emulator was taken by another job before a second pass was possible, so the highlight column here still shows work the 16 KiB gate now skips):

| type | size | after: first paint | after: longest block | note |
| --- | ---: | ---: | --- | --- |
| .txt | 20 KB | 1,769 | 1,008 | |
| .ts | 20 KB | 3,093 | 1,871 | 447 ms of it the tokenizer, now gated |
| .rs | 20 KB | 2,783 | 1,697 | 142 ms tokenizer, now gated |
| .md | 20 KB | 1,233 | 852 | |
| .txt | 60 KB | 2,486 | 1,144 | |
| .ts | 60 KB | 3,324 | 1,955 | 1,906 ms tokenizer, now gated |
| .rs | 60 KB | 464 | 336 | |
| .md | 60 KB | 3,776 | 1,842 | |
| .txt | 200 KB | 1,767 | 813 | |
| .ts | 200 KB | 3,605 | 1,948 | |
| .rs | 200 KB | 1,916 | 1,049 | |
| .md | 200 KB | 9,146 | 6,003 | now goes through the code view instead |

The emulator was shared with other jobs at load average 8 to 20 throughout, so treat these as an order of magnitude rather than a stopwatch. iOS is the clean set. Both agree on the shape: everything that was seconds-to-never is now sub-second to low-seconds on a debug build, and the sheet scrolls and closes from the first frame at every size.

## Gates

```
npx tsc --noEmit      clean
bun run lint          clean (oxlint --deny-warnings)
bun run format:check  clean
bun test src          2742 pass, 2 skip, 0 fail, 15041 expect() across 104 files
```

`bash scripts/e2e.sh` on the Android emulator, and the same suite run on this branch's merge base on the same emulator in the same session, for attribution:

| flow | merge base | this branch |
| --- | --- | --- |
| demo-tour | pass | pass |
| pairing-manual | pass | pass |
| terminal-interactions | FAIL `Switch to zsh` | FAIL `Switch to zsh` |
| ssh | FAIL `Open Demo shell` | FAIL `Open Demo shell` |
| file-mentions | FAIL `Type into this editor` | FAIL `Type into this editor` |
| attachments-ui | pass | pass |
| **artifacts** | **pass** | **pass** |
| settings | FAIL `Contact us.*` | FAIL `Contact us.*` |
| away-digest | pass | pass |
| pad-workspace | FAIL `Type into this editor` | FAIL `Type into this editor` |
| slash-commands | pass | FAIL under load, passes on its own |

Five flows fail identically with and without this change, so they are the state of that emulator rather than anything here -- it was shared with several other jobs at load average 8 to 20 for the whole session, and `slash-commands`, the longest flow, failed once on this branch and passes when run on its own. `artifacts` is the flow that opens the files sheet and the asset viewer, and it passes on both, before and after the change; it was also re-run on its own on this branch to be sure.

The suite is not green on this machine today, and it is not green on `main` either. I did not chase the five: none of them touch the code viewer, the markdown viewer, or the asset read.

New coverage: `plainFile` against the fallback `highlightFile` produces, and a source scan in `src/components/__tests__/code-view.test.ts` that fails if the list stops being virtualized, if a row stops being one line tall, or if `highlightFile` moves back into the render body -- the three things a later refactor would undo without noticing.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
