### PR TITLE
fix(gateway): a key the reader presses is a keystroke, not a paste

### DIFF
--- a/src/components/server-terminal-workspace.tsx
+++ b/src/components/server-terminal-workspace.tsx
@@ -64,6 +64,12 @@ import { VirtualKeyboard } from '@/components/virtual-keyboard';
 import { WorkspaceTitleSwitcher } from '@/components/workspace-title-switcher';
 import { appChrome } from '@/constants/appearance';
 import { KEY_ROW_HEIGHT } from '@/constants/key-row';
+import {
+  isSendableAsKeystrokes,
+  paneInputDelivery,
+  paneKeystrokes,
+  type PaneInputSource,
+} from '@/lib/pane-input';
 import { NAV_HEADER_TOP_GAP } from '@/constants/nav-header';
 import { useAttachmentUploads } from '@/hooks/use-attachment-uploads';
 import { useAwayDigest } from '@/hooks/use-away-digest';
@@ -2740,19 +2746,15 @@ export function ServerTerminalWorkspace({
       if (selectedAgent) {
         await sendAgentText(data.sessionId, requestPaneId, value);
       } else {
-        await sendPaneText(data.sessionId, requestPaneId, value);
-        if (
-          activeServerRef.current !== requestServerId ||
-          activePaneRef.current !== requestPaneId
-        ) {
-          return;
-        }
         // A shell needs Enter to run what was typed. An editor does not: Enter
         // there is a newline in the buffer, so it belongs on the key row where
         // it can be pressed deliberately.
-        if (!fullScreenPane) {
-          await sendPaneKeys(data.sessionId, requestPaneId, ['enter']);
-        }
+        //
+        // A composed line stays a paste, and that is not an oversight: it is
+        // what keeps a two-line message one message instead of two Enters, and
+        // the only channel by which an agent recognises an attachment path as
+        // an image.
+        await sendPaneCharacters(requestPaneId, value, 'composer', !fullScreenPane);
       }
       if (activeServerRef.current !== requestServerId || activePaneRef.current !== requestPaneId) {
         return;
@@ -2772,6 +2774,33 @@ export function ServerTerminalWorkspace({
     }
   }
 
+  /**
+   * Characters into a pane, by the one rule that decides how they travel.
+   *
+   * `send-text` is a *paste* -- the gateway loads a tmux buffer and pastes it
+   * bracketed -- and a full-screen program reads a bracketed paste as content
+   * rather than as keys. So a keypress that went out this way did not press
+   * anything: `i` typed the letter into the file instead of entering insert
+   * mode, and on nvim's dashboard or a file tree, where the buffer cannot be
+   * written, it did nothing at all. `lib/pane-input` is the rule and the
+   * reason; this is the only place on this screen that acts on it.
+   */
+  function sendPaneCharacters(
+    paneId: string,
+    text: string,
+    source: PaneInputSource,
+    submit = false
+  ): Promise<unknown> {
+    if (paneInputDelivery(source) === 'keystrokes' && isSendableAsKeystrokes(text)) {
+      // The submit rides in the same request, so an Enter cannot land between
+      // two halves of a command line.
+      return sendPaneKeys(data.sessionId, paneId, paneKeystrokes(text, { submit }));
+    }
+    return sendPaneText(data.sessionId, paneId, text).then(() =>
+      submit ? sendPaneKeys(data.sessionId, paneId, ['enter']) : undefined
+    );
+  }
+
   // The virtual keyboard fires a key per tap, so it skips the spinner state the
   // row uses and just sends. An immediate read keeps the caret responsive
   // without waiting on the event stream.
@@ -2786,7 +2815,7 @@ export function ServerTerminalWorkspace({
   function typeText(text: string) {
     const requestPaneId = selection.paneId;
     if (connection.phase !== 'connected' || !ready || !requestPaneId) return;
-    void sendPaneText(data.sessionId, requestPaneId, text)
+    void sendPaneCharacters(requestPaneId, text, 'virtual-key')
       .then(() => refreshOutputRef.current())
       .catch(() => {});
   }
@@ -2802,13 +2831,15 @@ export function ServerTerminalWorkspace({
       if (item.text === undefined) {
         await sendPaneKeys(data.sessionId, requestPaneId, [item.key]);
       } else {
-        // An editor command is characters, not a key name -- the gateway
-        // validates key names and `:` is not one -- so it goes out the way the
-        // composer sends a line, and a `:` command line is run the same way too.
-        await sendPaneText(data.sessionId, requestPaneId, item.text);
-        if (item.submit) {
-          await sendPaneKeys(data.sessionId, requestPaneId, ['enter']);
-        }
+        // A cap made of characters is still a key the reader pressed, so it
+        // goes as keys: `:` has to open nvim's command line rather than arrive
+        // in the buffer, and `dd` has to delete a line rather than type two.
+        //
+        // The note that used to be here said the gateway rejects `:` as a key
+        // name. It does not -- `tmux_key` takes any single non-control
+        // character verbatim -- and sending these as text is what made every
+        // editor key on this screen do nothing.
+        await sendPaneCharacters(requestPaneId, item.text, 'terminal-key', item.submit);
       }
       setTimeout(() => void refreshOutput(), 80);
     } catch (failure) {

--- a/src/lib/__tests__/pane-input.test.ts
+++ b/src/lib/__tests__/pane-input.test.ts
@@ -1,0 +1,113 @@
+/**
+ * A keypress is a keystroke, and only a composed line is a paste.
+ *
+ * The defect this pins: every character the app's own keyboard put into a
+ * gateway pane went out as `send-text`, which the gateway pastes with tmux's
+ * `-p`, which is a bracketed paste, which nvim hands to its paste handler
+ * instead of its keymap. `i` did not enter insert mode -- it typed the letter
+ * into the file, and on a buffer that cannot be written (nvim's dashboard, a
+ * file tree) it did nothing whatsoever.
+ *
+ * The table is the fix, so the table is the test.
+ */
+import { describe, expect, test } from 'bun:test';
+
+import {
+  isSendableAsKeystrokes,
+  paneInputDelivery,
+  paneKeystrokes,
+  type PaneInputSource,
+} from '@/lib/pane-input';
+
+const EVERY_SOURCE: PaneInputSource[] = ['virtual-key', 'terminal-key', 'composer'];
+
+describe('what is a keystroke and what is a paste', () => {
+  test('a key press is keys, on either keyboard the app draws', () => {
+    // The QWERTY and the terminal key row are both keyboards: the reader
+    // pressed a key and the program is waiting for a key.
+    expect(paneInputDelivery('virtual-key')).toBe('keystrokes');
+    expect(paneInputDelivery('terminal-key')).toBe('keystrokes');
+  });
+
+  test('a line the reader assembled and sent is a paste', () => {
+    // Not a length rule. The paste is what keeps a two-line message one
+    // message rather than two Enters, and it is the only channel by which an
+    // agent recognises an attachment path as an image.
+    expect(paneInputDelivery('composer')).toBe('paste');
+  });
+
+  test('every source has an answer and it is one of the two', () => {
+    for (const source of EVERY_SOURCE) {
+      expect(['keystrokes', 'paste']).toContain(paneInputDelivery(source));
+    }
+  });
+});
+
+describe('what one press of a character-capped key is worth', () => {
+  test('a single letter is a single key', () => {
+    expect(paneKeystrokes('i')).toEqual(['i']);
+  });
+
+  test('a two-letter vim command is two keys, not a two-character paste', () => {
+    // `dd` pasted is the string "dd" in the buffer; `dd` typed deletes a line.
+    expect(paneKeystrokes('dd')).toEqual(['d', 'd']);
+    expect(paneKeystrokes('gg')).toEqual(['g', 'g']);
+  });
+
+  test('a colon command carries its Enter in the same request', () => {
+    // One request, so the Enter cannot interleave with the next press and run
+    // a half-typed command line.
+    expect(paneKeystrokes(':w', { submit: true })).toEqual([':', 'w', 'enter']);
+    expect(paneKeystrokes(':wq', { submit: true })).toEqual([':', 'w', 'q', 'enter']);
+  });
+
+  test('a command that is not submitted does not grow an Enter', () => {
+    // `/` and `:` open a line the reader then types into; sending Enter would
+    // run the empty one.
+    expect(paneKeystrokes('/')).toEqual(['/']);
+    expect(paneKeystrokes(':')).toEqual([':']);
+  });
+});
+
+describe('what cannot go as keys falls back rather than failing', () => {
+  test('the printable characters the app can type are all sendable', () => {
+    // Everything on the app's keyboard: the letters, the digits, and both
+    // symbol pages -- including the semicolon, which the gateway escapes for
+    // tmux and which arrives as a character.
+    const typable =
+      'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789' +
+      ' -/:;()$&@".,?!\'~|_\\=+[]{}#%<>`^*';
+    for (const character of typable) {
+      expect(isSendableAsKeystrokes(character)).toBe(true);
+    }
+  });
+
+  test('a newline is not a key, because as a key it is Enter', () => {
+    // The one that would do damage: a two-line payload split into keys submits
+    // halfway through.
+    expect(isSendableAsKeystrokes('one\ntwo')).toBe(false);
+    expect(isSendableAsKeystrokes('\n')).toBe(false);
+    expect(isSendableAsKeystrokes('\r')).toBe(false);
+    // Tab has a key name of its own; as a character it is a control.
+    expect(isSendableAsKeystrokes('\t')).toBe(false);
+    // C1 as well, which is what the gateway's `char::is_control` covers.
+    expect(isSendableAsKeystrokes('\u0085')).toBe(false);
+  });
+
+  test('the two sides split a string on the same boundary', () => {
+    // Rust's `char` is a Unicode scalar value and so is what `Array.from`
+    // yields, so an astral character is one key on both sides and needs no
+    // special case. Asserted rather than assumed, because if the two ever
+    // disagreed the failure would be a 400 on a keypress.
+    expect(isSendableAsKeystrokes('\u{1F600}')).toBe(true);
+    expect(paneKeystrokes('\u{1F600}')).toEqual(['\u{1F600}']);
+    // A decomposed accent is genuinely two scalars, so it is genuinely two
+    // keys -- and typing both in order puts the same character on screen.
+    expect(paneKeystrokes('e\u0301')).toEqual(['e', '\u0301']);
+    expect(paneKeystrokes('\u00e9')).toEqual(['\u00e9']);
+  });
+
+  test('nothing at all is not a keystroke', () => {
+    expect(isSendableAsKeystrokes('')).toBe(false);
+  });
+});

--- a/src/lib/pane-input.ts
+++ b/src/lib/pane-input.ts
@@ -1,0 +1,103 @@
+/**
+ * Whether what the reader just did is a keystroke or a paste, and how the two
+ * reach a gateway pane.
+ *
+ * The gateway offers two ways to put characters into a pane and they are not
+ * interchangeable:
+ *
+ * - `send-keys` is a keystroke. tmux delivers each key to the pane's tty as
+ *   the program would have received it from a real keyboard.
+ * - `send-text` is a **paste**. tmux loads the text into a buffer and pastes
+ *   it with `-p`, which wraps it in the bracketed-paste markers for any
+ *   program that asked for them.
+ *
+ * A full-screen program asks for them. nvim, on receiving a bracketed paste,
+ * runs its paste handler rather than its keymap: the payload is *content*, and
+ * content is inserted into the buffer rather than obeyed. So `i` sent as text
+ * does not enter insert mode -- it puts the letter `i` in the file. On a buffer
+ * that cannot be written -- nvim's dashboard, a file tree, `:help` -- the paste
+ * is refused with `E21: Cannot make changes, 'modifiable' is off` and nothing
+ * happens at all, which is what the reader sees when they press the app's
+ * keyboard on an editor pane and the file does not move.
+ *
+ * This is the one place the gateway path had drifted from the SSH path, where
+ * the same keypress is written to the PTY as bytes and has always been a
+ * keystroke. Both screens now agree: what the reader produced one key at a
+ * time is keys, and only a line they composed and submitted is a paste.
+ *
+ * The paste is not a mistake in its own place. It is what lets a multi-line
+ * message arrive as one message rather than as one Enter per line, and it is
+ * the only channel by which an agent can recognise an attachment path as an
+ * image. So the rule is about the *source* of the text, not about its length.
+ *
+ * Kept pure and free of React so the rule is one table in one test rather than
+ * a decision repeated at every call site.
+ */
+
+/** How the characters reach the pane. */
+export type PaneInputDelivery = 'keystrokes' | 'paste';
+
+/** What the reader did to produce them. */
+export type PaneInputSource =
+  /** One press of the app's on-screen keyboard. */
+  | 'virtual-key'
+  /** One press of a terminal key-row chip whose cap is characters (`:w`, `gg`). */
+  | 'terminal-key'
+  /** A line typed into the composer and submitted. */
+  | 'composer';
+
+/**
+ * The rule, in one table.
+ *
+ * The two keystroke sources are the two surfaces that are a keyboard: a key
+ * press produced each of them, and a key press is what the program is waiting
+ * for. The composer is the one where the reader assembled something first and
+ * then said "send it". (The quick-actions sheet sends a saved command the same
+ * way, from `app/commands.tsx`, and for the same reason.)
+ */
+export function paneInputDelivery(source: PaneInputSource): PaneInputDelivery {
+  switch (source) {
+    case 'virtual-key':
+    case 'terminal-key':
+      return 'keystrokes';
+    case 'composer':
+      return 'paste';
+  }
+}
+
+/** C0 and C1, which is what Rust's `char::is_control` covers. */
+const CONTROL = /[\u0000-\u001f\u007f-\u009f]/;
+
+/**
+ * Whether every character of this text can be sent as a key.
+ *
+ * The gateway's key names are either one of its own words (`enter`, `escape`,
+ * `ctrl+c`) or exactly one non-control character, and it rejects the *whole*
+ * request if any one key fails that -- so a payload that cannot go as keys has
+ * to fall back to a paste rather than turn one keypress into a 400.
+ *
+ * Only one thing fails it, and it is the one that would do damage: a control
+ * character. The newline is why this function exists -- sent as a key it is
+ * Enter, so a two-line payload split into keys would submit halfway through.
+ *
+ * Everything else passes, astral characters included. The unit on both sides
+ * is the Unicode scalar value: Rust's `char` is one, `chars().count() == 1` is
+ * the gateway's own test, and `Array.from` splits on the same boundary -- so an
+ * emoji is one key here and one key there.
+ */
+export function isSendableAsKeystrokes(text: string): boolean {
+  if (text.length === 0) return false;
+  return !CONTROL.test(text);
+}
+
+/**
+ * The keys one press of a character-capped control is worth.
+ *
+ * Split by code point, because that is the unit the gateway accepts, and with
+ * the submit -- the Enter that runs a `:w` -- in the same list, so the whole
+ * chord is one request and cannot interleave with the next press.
+ */
+export function paneKeystrokes(text: string, options: { submit?: boolean } = {}): string[] {
+  const keys = Array.from(text);
+  return options.submit ? [...keys, 'enter'] : keys;
+}


### PR DESCRIPTION
Pressing anything on the app's own keyboard did nothing in nvim over the gateway. Not the QWERTY, not `i`, not `:w` — to answer the question directly: **none of the editor-mode keys worked at all on that path**, while the same keys on the SSH screen always had.

It is not the gateway version. His binary is `a4f063d0…`, which is v0.8.0, and v0.8.0 has the `;` fix from gateway PR #4. Upgrading him would have changed nothing.

## Root cause

The two ways to put characters into a gateway pane are not interchangeable.

- **`send-keys` is a keystroke.** tmux delivers each key to the pane's tty as a real keyboard would.
- **`send-text` is a paste.** The gateway loads a tmux buffer and pastes it with `-p` (`src/backend/tmux.rs`, unchanged between v0.8.0 and today):

```rust
fn paste_buffer_args<'a>(buffer: &'a str, pane_id: &'a str) -> [&'a str; 7] {
    ["paste-buffer", "-b", buffer, "-t", pane_id, "-d", "-p"]
}
```

`-p` wraps the payload in the bracketed-paste markers for any program that asked for them. A full-screen program asks for them, and on receiving a bracketed paste nvim runs its **paste handler** rather than its keymap: the payload is *content*, and content is inserted rather than obeyed.

Every character the app's keyboard produced went out as `send-text` (`typeText` → `sendPaneText`), and so did every editor key-row cap — `i`, `v`, `dd`, `gg`, `:w`, `:wq` — because `sendTerminalKey` sent `item.text` the same way. The comment that justified it was wrong:

> An editor command is characters, not a key name -- the gateway validates key names and `:` is not one

It is one. `tmux_key` takes any single non-control character verbatim:

```rust
_ if value.chars().count() == 1 && !value.chars().any(char::is_control) => value.to_owned(),
```

The SSH screen never had the bug because there `typeText` writes the bytes straight to the PTY. This was the one place the two paths had drifted.

## Evidence: a real nvim, in tmux, through a real gateway

My own gateway instance (his exact binary, isolated config/state, port 23901, its own tmux socket — his install on `:23847` untouched), driving the same HTTP requests the app makes, with `tmux capture-pane` after each.

**A — what the app did:**

```
$ curl -X POST .../panes/tp0/send-text -d '{"text":"i"}'
   http 200
$ tmux capture-pane -p -t %0 | head -1
ailpha bravo
```

200, and the letter `i` landed **in the file**. nvim never entered insert mode.

**B — what the fix does:**

```
$ curl -X POST .../panes/tp0/send-keys -d '{"keys":["i"]}'
   http 200
$ tmux capture-pane -p -t %0 | tail -1
-- INSERT --
```

**The maintainer's exact sequence — press `i`, type a word, `Esc`, `:w`:**

```
   send-keys ["i"]                http 200
   send-keys ["h","e","l","l","o"] http 200
   send-keys ["escape"]           http 200
   send-keys [":","w","enter"]    http 200

$ tmux capture-pane -p -t %0 | head -1
helloalpha bravo
$ tmux capture-pane -p -t %0 | tail -1
"/private/tmp/mq-keys-file.txt" 3L, 44B written
$ head -1 /tmp/mq-keys-file.txt
helloalpha bravo
```

Each key landed, and the file changed **on disk**.

**Why he saw "nothing", not a stray letter.** His screenshot is nvim's dashboard and a file tree — both `nomodifiable`. A bracketed paste into one of those is refused outright:

```
$ curl -X POST .../send-text -d '{"text":"i"}'     # a nomodifiable buffer
   http 200
$ tmux capture-pane -p -t %0 | tail -1
Press ENTER or type command to continue            # E21, nothing typed
```

That is the whole symptom: 200 from the gateway, nothing on screen.

## The fix

The rule is now the **source** of the text rather than its length, in `src/lib/pane-input.ts`:

```ts
export function paneInputDelivery(source: PaneInputSource): PaneInputDelivery {
  switch (source) {
    case 'virtual-key':
    case 'terminal-key':
      return 'keystrokes';
    case 'composer':
      return 'paste';
  }
}
```

One seam acts on it in `server-terminal-workspace.tsx`, and the three call sites name their source. A `:w` goes as `[':', 'w', 'enter']` — one request, so the Enter cannot land between two halves of a command line.

**The composer keeps the paste, deliberately.** It is what keeps a two-line message one message instead of one Enter per line, and it is the only channel by which an agent recognises an attachment path as an image. That is why this is a rule about the source and not "short things are keys".

**The fallback matters.** The gateway rejects the *whole* request if any one key is invalid, so anything containing a control character pastes instead — the newline above all, because as a key it is Enter and would submit a two-line payload halfway through.

Nothing on the gateway needs to change and nothing needs upgrading.

## Wiring and target pane, checked as asked

- The `VirtualKeyboard` inside `EditorControls` receives the **same** `onText`/`onKey` as the ordinary dock's keyboard — one pair of functions, two mount points.
- `disabled` and `dockPresentation` were not swallowing anything: `typeText`/`typeKey` guard only on `connection.phase`, `ready` and a pane id.
- The send reads `selection.paneId` **fresh at call time**, so it is the current pane, not a cached one.

## Tests

`src/lib/__tests__/pane-input.test.ts` — 11 tests: the table, `:w` → `[':','w','enter']`, `dd` → two keys, every character the app's keyboard can produce is sendable, and the control-character fallback. Astral characters are asserted to be one key on **both** sides (Rust's `char` and `Array.from` split on the same boundary), because a disagreement there would be a 400 on a keypress.

## Separately: main-screen scrollback above the alternate screen

His second observation is real and is **not** fixed here — it is a different defect in a different layer, and fixing it means changing what the canvas may scroll to, so it wants its own change.

Measured on the same nvim pane, with six `echo` lines of main-screen scrollback behind it:

```
pane scroll: {"alternate_on": true, "max_offset_from_bottom": 2, "viewport_rows": 24}
pane read:   26 lines returned for a 24-row pane
  first two:  ''  and  '➜  muqun-gateway'      <- main screen, above nvim
```

**Exactly two rows above the alternate screen — which is what he saw.** The gateway returns history plus the current screen, and the app draws all of it: `screenRows` reaches `skia-terminal.tsx` but is only used to anchor the rest position —

```ts
const historyHeight =
  screenRows > 0 ? Math.max(0, frame.lines.length - screenRows) * lineHeight : 0;
```

— so those rows are still drawn and still scrollable. The SSH path does not have this: its emulator keeps a real alternate buffer.

The natural seam is a pure `altScreenOutput(output, { ownsScreen, screenRows })` applied where `TerminalPanel` hands `output` to `SkiaTerminal`, and the app has already decided an editor has no earlier output (`canLoadEarlier={fullScreenPane ? false : …}`) — so trimming agrees with a decision it already makes. Left out of this PR because it is not a one-liner and it touches the scroll and history arithmetic the terminal depends on.

## Devices

Not verified through the app's own UI, and I would rather say so than imply otherwise. `muqun-ios` was held by another agent's live session (`foldshot`) for the whole window, and on `muqun_android` the accessibility snapshot helper failed for this build (`Android snapshot helper output could not be parsed`), leaving coordinate-only driving for a multi-step pairing flow.

What is verified is the layer the defect lives in and where the evidence is stronger than a screenshot: the real gateway's HTTP API — byte for byte the request the app issues — against a real nvim in tmux, with `capture-pane` after every call, shown above.

## Gates

```
$ npx tsc --noEmit
(exit 0)

$ bun run lint
$ oxlint --deny-warnings

$ bun run format:check
All matched files use the correct format.
Finished in 315ms on 441 files using 12 threads.

$ bun test src
 2753 pass
 2 skip
 0 fail
 15159 expect() calls
Ran 2755 tests across 105 files. [8.56s]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
