### PR TITLE
fix(terminal): the phone's scrollback is the desktop's scrollback again

### DIFF
--- a/src/components/server-terminal-workspace.tsx
+++ b/src/components/server-terminal-workspace.tsx
@@ -145,6 +145,7 @@ import {
   recallPaneWindow,
   rememberPaneWindow,
   retainPanes,
+  warmPaneWindow,
   type PaneCache,
   type PaneWindow,
 } from '@/lib/pane-cache';
@@ -2258,12 +2259,13 @@ export function ServerTerminalWorkspace({
             const revision = typeof paneRaw === 'number' ? paneRaw : -1;
             if (!paneReadIsCurrent(paneCacheRef.current, paneId, revision)) return;
             if (!value) return;
-            paneCacheRef.current = rememberPaneWindow(paneCacheRef.current, paneId, {
+            paneCacheRef.current = warmPaneWindow(paneCacheRef.current, paneId, {
               shape: `${outputFormat}:${outputSource}`,
               output: value,
-              // A warm-up is always the first page. It is a seed for the
-              // switch, not a claim about depth -- the reader has never paged
-              // this pane in this visit, so there is nothing deeper to lose.
+              // A warm-up is always the first page -- a seed for the switch,
+              // never a claim about depth. `warmPaneWindow`, not
+              // `rememberPaneWindow`, is what stops that seed being written
+              // over a window the reader had already paged deeper and left.
               lineLimit: INITIAL_PANE_OUTPUT_LINES,
               revision,
               canLoadEarlier: hasEarlierTerminalOutput(

--- a/src/components/server-terminal-workspace.tsx
+++ b/src/components/server-terminal-workspace.tsx
@@ -643,6 +643,9 @@ export function ServerTerminalWorkspace({
   // honour it rather than on every pull, and `loadEarlierOutput` falls back to
   // widening the tail -- exactly what every pane did before this feature
   // existed -- for the rest of the session.
+  // TEMPORARY measurement scaffold, not for merge: forces the widening-tail
+  // paging path that herdr panes always take (herdr ignores start/end), which
+  // the tmux backend would otherwise avoid by serving a real range page.
   const rangeUnsupportedRef = useRef(false);
   const earlierPartsRowsRef = useRef(0);
   const loadingEarlierPartsRef = useRef(false);
@@ -1419,6 +1422,20 @@ export function ServerTerminalWorkspace({
   useLayoutEffect(() => {
     fullScreenPaneRef.current = fullScreenPane;
   }, [fullScreenPane]);
+  /**
+   * What the fold is told about the pane, as opposed to about the program.
+   *
+   * `alternate_on` and the command heuristic disagree, and the disagreement is
+   * the defect: a real nvim pane reported `alternate_on: true` while
+   * `isFullScreenTuiPane` did not recognise it, so its read was folded into
+   * scrollback as if the pane were printing -- putting the shell prompt it was
+   * launched from above nvim's own first line. What is *drawn* is a fact about
+   * the pane, so the fold reads these; the chrome (the key row, the editor
+   * controls, the surface) keeps following the editor predicate, because that
+   * is a question about what the reader is driving.
+   */
+  const paneOwnsScreenRef = useRef(false);
+  const paneScreenRowsRef = useRef(0);
   // The pane's own viewport, off the scroll metric every pane entity carries.
   // This is what separates the ring-buffer history in the served window from
   // the live screen at its tail: a full-screen program repaints exactly its
@@ -1618,13 +1635,26 @@ export function ServerTerminalWorkspace({
   const previewIndex = previewAttachmentId
     ? previewImages.findIndex((item) => item.id === previewAttachmentId)
     : -1;
+  useLayoutEffect(() => {
+    paneOwnsScreenRef.current = paneOwnsScreen;
+    paneScreenRowsRef.current = selectedPaneScreenRows;
+  }, [paneOwnsScreen, selectedPaneScreenRows]);
+
   const outputFormat = agentOutput ? 'text' : 'ansi';
   const outputSource: PaneOutputSource = fullScreenPane ? 'visible' : 'recent-unwrapped';
   // The pair that says what a window is a window *of*. A pane can change shape
   // while nobody is looking -- a shell hands its tty to nvim and the source it
   // has to be read from turns with it -- so a remembered window is only handed
   // back to a pane still being read the same way. See `PaneWindow.shape`.
-  const outputShape = `${outputFormat}:${outputSource}`;
+  //
+  // It also records whether the pane owns the screen. Entering and leaving an
+  // alternate screen is a change of picture, not of depth: nvim's frame and the
+  // shell's scrollback are two windows of one pane, and folding either into the
+  // other is what put a prompt above nvim's first line. Carried here, the
+  // boundary is crossed the way a pane switch is -- the main-screen window is
+  // filed on the way in and handed back whole on the way out, which is the
+  // reader's history surviving the editor.
+  const outputShape = `${outputFormat}:${outputSource}:${paneOwnsScreen ? 'alt' : 'main'}`;
   // Matches the terminal surface exactly, whichever pack is showing -- read
   // from the same palette the renderer draws with rather than restated, so the
   // chrome behind the grid can never be a shade off it.
@@ -1694,7 +1724,7 @@ export function ServerTerminalWorkspace({
    * `useResetSignal` is what makes this run once per switch rather than every
    * render -- see its docblock, which describes this case by name.
    */
-  const paneSwitched = useResetSignal(selection.paneId);
+  const paneSwitched = useResetSignal(`${selection.paneId}|${outputShape}`);
   /* oxlint-disable react/refs, react/purity -- deliberate, for this block only:
      every ref touched here is the window's own bookkeeping, none of it is read
      into what this render draws, and nothing but a switch writes any of it --
@@ -1792,7 +1822,7 @@ export function ServerTerminalWorkspace({
     partsRequestIdRef.current += 1;
     readPartsKeyRef.current = { paneId: '', contentKey: '' };
     setPartsState(initialPartsState);
-  }, [outputShapeRef, selection.paneId]);
+  }, [outputShape, outputShapeRef, selection.paneId]);
 
   useEffect(() => {
     if (!requestedPaneId || !data.health) return;
@@ -1908,19 +1938,33 @@ export function ServerTerminalWorkspace({
       // replacing a window it is not as deep as) all died here.
       setOutput((current) => {
         if (agentOutput) return mergeTerminalWindow(current, value, MAX_PANE_OUTPUT_LINES);
-        // `fullScreenPaneRef.current`, not the closed-over `fullScreenPane`:
-        // an editor's read is the whole of its current screen, not a tail of
-        // a growing log, so it replaces rather than folds against the
-        // placement heuristics built for the latter (card #795, defect 2 --
-        // see `foldPaneRead`'s own doc on `ownsScreen`, and the ref's own doc
-        // above for why this reads a ref instead of the render-time value).
-        return foldPaneRead(current, value, origin, lineLimit, fullScreenPaneRef.current);
+        // A screen-owning pane's read is the whole of its current screen, not
+        // a tail of a growing log, so it replaces rather than folds against
+        // the placement heuristics built for the latter (card #795, defect 2
+        // -- see `foldPaneRead`'s own doc on `ownsScreen`). Read off the
+        // pane's own `alternate_on` rather than the command heuristic, and
+        // paired with the pane's height so only the rows the program drew are
+        // drawn; see `paneOwnsScreenRef`. Refs rather than the render-time
+        // values because this updater is built once.
+        return foldPaneRead(
+          current,
+          value,
+          origin,
+          lineLimit,
+          paneOwnsScreenRef.current,
+          paneScreenRowsRef.current
+        );
       });
       if (lineLimit === INITIAL_PANE_OUTPUT_LINES) {
         const scroll = panesRef.current.find((pane) => pane.id === requestPaneId)?.raw.scroll;
         earlierOutputRowsRef.current = terminalOutputLineCount(value);
+        // Nothing to page while the program owns the screen: its frame has no
+        // history beneath it, and the scrollback the pane had before it started
+        // is not this window's to widen into. It comes back whole when the
+        // program exits -- see `outputShape`.
         setCanLoadEarlierOutput(
-          hasEarlierTerminalOutput(value, lineLimit, MAX_PANE_OUTPUT_LINES, scroll)
+          !paneOwnsScreenRef.current &&
+            hasEarlierTerminalOutput(value, lineLimit, MAX_PANE_OUTPUT_LINES, scroll)
         );
       }
       setError(null);
@@ -2089,9 +2133,17 @@ export function ServerTerminalWorkspace({
       // its own `'rangePage'` origin rather than `'page'`: the two may look
       // alike at this call site, but only a genuine range read may be believed
       // with zero overlap. See the origin's own doc in `history.ts`.
-      setOutput((current) =>
-        foldPaneRead(current, value, origin, nextLimit, fullScreenPaneRef.current)
-      );
+      setOutput((current) => {
+        const next = foldPaneRead(
+          current,
+          value,
+          origin,
+          nextLimit,
+          paneOwnsScreenRef.current,
+          paneScreenRowsRef.current
+        );
+        return next;
+      });
       const scroll = panesRef.current.find((pane) => pane.id === requestPaneId)?.raw.scroll;
       const reachedRows = earlierOutputRowsRef.current;
       earlierOutputRowsRef.current = terminalOutputLineCount(value);

--- a/src/lib/__tests__/pane-cache.test.ts
+++ b/src/lib/__tests__/pane-cache.test.ts
@@ -15,6 +15,7 @@ import {
   type PaneWindow,
   emptyPaneCache,
   foldPaneFrame,
+  warmPaneWindow,
   forgetPaneWindow,
   notePaneRevision,
   panePrefetchAccepted,
@@ -283,6 +284,42 @@ describe('frames for a pane nobody is looking at', () => {
     cache = rememberPaneWindow(cache, 'p2', windowOf('b', 1));
     const next = foldPaneFrame(cache, 'p1', ANSI, 2, append('more'));
     expect(paneIdsOf(next)).toEqual(['p1', 'p2']);
+  });
+});
+
+describe('warming a pane the reader has already paged', () => {
+  // The defect: the warm-up wrote its first page over whatever was remembered,
+  // so a pane the reader had paged five pages back and then left came back at
+  // one page and their paging was silently undone. A warm-up exists to remove a
+  // blank, and there is no blank behind a window that is already deeper.
+  test('a warm-up does not shallow out a deeper window', () => {
+    const deep = windowOf('paged', 4, { lineLimit: 1200, canLoadEarlier: true });
+    const cache = rememberPaneWindow(emptyPaneCache, 'p1', deep);
+    const warmed = warmPaneWindow(cache, 'p1', windowOf('one page', 9, { lineLimit: 240 }));
+    expect(recallPaneWindow(warmed, 'p1', ANSI)).toMatchObject({
+      output: 'paged',
+      lineLimit: 1200,
+    });
+  });
+
+  test('a warm-up still fills a pane nothing is held for', () => {
+    const warmed = warmPaneWindow(emptyPaneCache, 'p1', windowOf('one page', 2));
+    expect(recallPaneWindow(warmed, 'p1', ANSI)?.output).toBe('one page');
+  });
+
+  test('a warm-up refreshes a window no deeper than itself', () => {
+    const cache = rememberPaneWindow(emptyPaneCache, 'p1', windowOf('stale', 2));
+    const warmed = warmPaneWindow(cache, 'p1', windowOf('fresh', 5));
+    expect(recallPaneWindow(warmed, 'p1', ANSI)).toMatchObject({ output: 'fresh', revision: 5 });
+  });
+
+  // A window of another shape is not a deeper reading of this one, so it is no
+  // reason to refuse the warm-up.
+  test('depth held under another shape does not block a warm-up', () => {
+    const other = windowOf('screen', 4, { lineLimit: 1200, shape: 'text:visible' });
+    const cache = rememberPaneWindow(emptyPaneCache, 'p1', other);
+    const warmed = warmPaneWindow(cache, 'p1', windowOf('one page', 5, { lineLimit: 240 }));
+    expect(recallPaneWindow(warmed, 'p1', ANSI)?.output).toBe('one page');
   });
 });
 

--- a/src/lib/pane-cache.ts
+++ b/src/lib/pane-cache.ts
@@ -189,6 +189,32 @@ export function rememberPaneWindow(
 }
 
 /**
+ * Store a window fetched to warm a pane nobody has asked for yet.
+ *
+ * {@link rememberPaneWindow} with the one rule a warm-up has and a real read
+ * does not: it may not make what is held shallower. A warm-up is always the
+ * first page, and it exists to remove a blank -- so behind a window the reader
+ * has already paged deeper there is no blank to remove, and writing over it
+ * would undo their paging in a way nothing on screen explains. That was the
+ * defect: page a pane five pages back, leave it, come back, and it was at one
+ * page again.
+ *
+ * The depth held is only a reason to refuse when it is depth in *this* reading
+ * of the pane; a window of another shape is a different picture, not a deeper
+ * one, and does not stand in the way.
+ */
+export function warmPaneWindow(
+  cache: PaneCache,
+  paneId: string,
+  window: PaneWindow,
+  bounds: PaneCacheBounds = PANE_CACHE_BOUNDS
+): PaneCache {
+  const held = cache.entries.find((entry) => entry.paneId === paneId);
+  if (held && held.shape === window.shape && held.lineLimit > window.lineLimit) return cache;
+  return rememberPaneWindow(cache, paneId, window, bounds);
+}
+
+/**
  * What is remembered of this pane, or `null`.
  *
  * Deliberately does not reorder: recall happens during the render that paints

--- a/src/terminal/__tests__/history-invariants.test.ts
+++ b/src/terminal/__tests__/history-invariants.test.ts
@@ -346,6 +346,60 @@ describe('(a) the window is a supersequence of what arrived, in arrival order', 
 });
 
 // ---------------------------------------------------------------------------
+// (e) a pane that owns the screen draws its screen and nothing else
+// ---------------------------------------------------------------------------
+
+describe('(e) an alternate-screen pane draws its own frame and nothing above it', () => {
+  // Measured through the gateway against a real nvim pane on 2026-09-05:
+  // `viewport_rows: 24`, `alternate_on: true`, and a `recent-unwrapped` read
+  // that comes back **26** rows -- the 24 the program drew, with two rows of
+  // the shell it was launched from still sitting on top (a blank and the
+  // prompt). The app drew all 26 and let the reader scroll those two above
+  // nvim's own first line.
+  //
+  // The rule: while a pane owns the screen, the frame is the screen. Its height
+  // is a fact about the pane, not about how many rows a read happened to carry,
+  // so the fold takes the screen's own rows off the end of the read rather than
+  // believing its length.
+  const frame = (rows: number, mark: string) =>
+    Array.from({ length: rows }, (_, index) => `${mark} nvim row ${index}`);
+  const shellAbove = ['', '> muqun-gateway'];
+
+  test('a read carrying main-screen rows above the frame draws only the frame', () => {
+    const read = [...shellAbove, ...frame(24, 'a')].join('\n');
+    const held = ['history one', 'history two'].join('\n');
+    const drawn = rows(foldPaneRead(held, read, 'refresh', MAXIMUM, true, 24));
+    expect(drawn).toHaveLength(24);
+    expect(drawn[0]).toBe('a nvim row 0');
+    expect(drawn.at(-1)).toBe('a nvim row 23');
+    expect(drawn.some((row) => row.includes('muqun-gateway'))).toBe(false);
+  });
+
+  test('a redraw replaces the frame rather than stacking under it', () => {
+    const first = [...shellAbove, ...frame(24, 'a')].join('\n');
+    const second = [...shellAbove, ...frame(24, 'b')].join('\n');
+    let window = foldPaneRead('', first, 'refresh', MAXIMUM, true, 24);
+    window = foldPaneRead(window, second, 'frame', MAXIMUM, true, 24);
+    const drawn = rows(window);
+    expect(drawn).toHaveLength(24);
+    expect(drawn.every((row) => row.startsWith('b '))).toBe(true);
+  });
+
+  test('a read shorter than the screen is drawn whole rather than padded away', () => {
+    // A frame caught mid-redraw is short. Taking "the last 24" of 10 rows must
+    // not invent rows or drop the ones there are.
+    const read = frame(10, 'a').join('\n');
+    expect(rows(foldPaneRead('', read, 'refresh', MAXIMUM, true, 24))).toHaveLength(10);
+  });
+
+  test('a pane whose height the gateway did not report keeps the old behaviour', () => {
+    // `screenRows` of 0 is "not reported", not "draw nothing".
+    const read = [...shellAbove, ...frame(24, 'a')].join('\n');
+    expect(rows(foldPaneRead('', read, 'refresh', MAXIMUM, true, 0))).toHaveLength(26);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // (b) a refresh never shrinks what the reader paged to
 // ---------------------------------------------------------------------------
 

--- a/src/terminal/__tests__/history-invariants.test.ts
+++ b/src/terminal/__tests__/history-invariants.test.ts
@@ -87,6 +87,47 @@ class Pane {
 }
 
 /**
+ * The same pane, with the pinned box the real Claude Code TUI actually draws.
+ *
+ * Two differences from {@link Pane}, and both of them are the defect: the box
+ * carries a status row that changes on every frame, and it **changes height**
+ * as background agents come and go. `Pane` pins a box of a fixed height whose
+ * every row but the timer is constant, which is a composer standing still --
+ * and standing still is exactly the case a page read could already handle.
+ *
+ * A read of this pane is the tail of the transcript that fits above the box,
+ * then the box, which is what both a tail read and a deeper page return.
+ */
+class AgentPane {
+  readonly transcript: string[] = [];
+  private tick = 0;
+  agents = 2;
+
+  emit(count: number): void {
+    for (let step = 0; step < count; step += 1) {
+      this.transcript.push(`row ${this.transcript.length} of the session`);
+    }
+  }
+
+  private box(): string[] {
+    this.tick += 1;
+    const agents = Array.from({ length: this.agents }, (_, index) => `  L Agent ${index} running`);
+    return [
+      '-'.repeat(20),
+      '> ',
+      ...agents,
+      `  bypass permissions on - ${this.agents} shell - ${this.tick}m ${this.tick % 60}s`,
+    ];
+  }
+
+  /** A read of `lines` rows: the transcript tail that fits, then the box. */
+  read(lines: number): string {
+    const box = this.box();
+    return [...this.transcript.slice(-Math.max(0, lines - box.length)), ...box].join('\n');
+  }
+}
+
+/**
  * Whether `part` appears inside `whole` in order, allowing gaps.
  *
  * The machine form of invariant (a): a window that is a subsequence of the true
@@ -200,6 +241,88 @@ describe('(a) the window is a supersequence of what arrived, in arrival order', 
     const rewrapped = rows(foldPaneRead(window, pane.screen(), 'frame', MAXIMUM));
     expect(rewrapped.length).toBeLessThan(deep);
     expect(adjacentRepeat(rewrapped)).toBeNull();
+  });
+
+  test('paging a pane with a pinned box that changes height keeps the order', () => {
+    // The defect from the maintainer's phone: the live bottom of the screen --
+    // the prompt, the status row, the agents list -- sat in the MIDDLE of the
+    // window, with older transcript below it. An earlier page had been appended
+    // under the live screen instead of being recognised as the deeper read it
+    // was.
+    //
+    // Why it survived every test here until now: the paging tests above use a
+    // fixture with no pinned box at all, and the composer tests never page. The
+    // deepening check demands the window agree with the deeper read EXACTLY,
+    // row for row -- so one ticking status row, or one agent appearing, is
+    // enough to refuse it, and the read then falls through to the
+    // newest-thing-on-top fallback and lands under the transcript it contains.
+    //
+    // The sequence is the one a reader actually performs: read, page, let the
+    // poll land, leave the pane and come back to the cached window, page again.
+    const pane = new AgentPane();
+    pane.emit(900);
+
+    let window = foldPaneRead('', pane.read(240), 'refresh', MAXIMUM);
+    pane.agents = 3;
+    window = foldPaneRead(window, pane.read(480), 'page', MAXIMUM);
+    window = foldPaneRead(window, pane.read(480), 'refresh', MAXIMUM);
+    // Leaving the pane and coming back: the cache hands the window straight
+    // back (#33) and the reconcile read folds against it at the paged depth.
+    const restored = window;
+    window = foldPaneRead(restored, pane.read(480), 'refresh', MAXIMUM);
+    pane.agents = 1;
+    window = foldPaneRead(window, pane.read(720), 'page', MAXIMUM);
+
+    const held = rows(window);
+    // (a) itself: every transcript row the window holds, in the session's order.
+    const body = held.filter((row) => row.startsWith('row '));
+    expect(isSubsequenceOf(body, pane.transcript)).toBe(-1);
+    // And the reading of it the screenshot showed: the live box is the bottom
+    // of the pane, so nothing may sit under it.
+    const status = held.findIndex((row) => row.includes('bypass permissions on'));
+    expect(status).toBeGreaterThanOrEqual(0);
+    expect(held.slice(status + 1).filter((row) => row.startsWith('row '))).toEqual([]);
+    // One live box, not one per read folded in.
+    expect(held.filter((row) => row.includes('bypass permissions on'))).toHaveLength(1);
+    expect(adjacentRepeat(held)).toBeNull();
+  });
+
+  test('one ticking row in the pinned box does not cost a page its depth', () => {
+    // The minimal form of the same fault, isolated: the box stands still except
+    // for its status row. Every other comparison in `history.ts` scores its
+    // agreement for exactly this reason -- "a composer is not a still image" --
+    // and the deepening check was the one that still demanded a photograph.
+    const older = Array.from({ length: 477 }, (_, index) => `row ${index + 423}`);
+    const newer = older.slice(-237);
+    const held = [...newer, '-'.repeat(20), '> ', 'status 1m 1s'].join('\n');
+    const page = [...older, '-'.repeat(20), '> ', 'status 2m 2s'].join('\n');
+    const folded = rows(foldPaneRead(held, page, 'page', MAXIMUM));
+    expect(folded[0]).toBe('row 423');
+    expect(folded.at(-1)).toBe('status 2m 2s');
+    expect(folded.filter((row) => row === '> ')).toHaveLength(1);
+  });
+
+  test('a pinned box taller than the deepening slack costs depth, never order', () => {
+    // The structural half of the same rule, and the reason it is not left to a
+    // constant being big enough. A box deeper than the slack defeats the
+    // deepening check whatever its value -- so the question is what the fold
+    // does *then*. Appending was a scrambled transcript; declining is a pull
+    // that brought nothing back, which the next pull retries.
+    const older = Array.from({ length: 400 }, (_, index) => `row ${index}`);
+    const box = (n: number) => Array.from({ length: n }, (_, index) => `box row ${index} at ${n}`);
+    const held = [...older.slice(-120), ...box(40)].join('\n');
+    const page = [...older, ...box(64)].join('\n');
+    const folded = rows(foldPaneRead(held, page, 'page', MAXIMUM));
+    // Nothing older was written underneath the box the window already ends on.
+    const body = folded.filter((row) => row.startsWith('row '));
+    expect(isSubsequenceOf(body, older)).toBe(-1);
+    const lastBody = folded
+      .map((row, at) => (row.startsWith('row ') ? at : -1))
+      .filter((at) => at >= 0)
+      .pop();
+    const firstBox = folded.findIndex((row) => row.startsWith('box row '));
+    expect(lastBody).toBeLessThan(firstBox);
+    expect(adjacentRepeat(folded)).toBeNull();
   });
 
   test('a fold only ever drops from the tail and appends', () => {

--- a/src/terminal/history.ts
+++ b/src/terminal/history.ts
@@ -294,6 +294,25 @@ const FURNITURE_MIN_ROWS = 2;
 const FURNITURE_VOLATILE_ROWS = 1;
 
 /**
+ * How much of the window's own tail a deeper read is allowed to disagree with
+ * and still be recognised as reaching further back.
+ *
+ * The window ends with the pinned box as the last frame drew it; a read taken
+ * later ends with the box as it is now. Those are the same pane, not two
+ * different transcripts -- but they are not the same rows. Claude Code's box is
+ * the case that broke: a prompt, a status row whose timer ticks every frame,
+ * and a list of background agents that appears, grows and empties, so the box
+ * changes *height* as well as content. The transcript above it is identical
+ * either way, which is the part that decides whether one read contains the
+ * other.
+ *
+ * Generous enough for a composer, a status row and a handful of agents; far
+ * short of anything that could pass an unrelated read off as a superset, since
+ * every row above the slack must still agree verbatim, in order, contiguously.
+ */
+const DEEPENING_FURNITURE_ROWS = 24;
+
+/**
  * Fold one read of a pane into the window the reader already has.
  *
  * The one door. See the contract at the top of this file for which source may
@@ -406,6 +425,26 @@ export function foldPaneRead(
     if (overlap === 0 && origin === 'rangePage') {
       return trimTerminalWindow(collapseRepeat([...latest, ...held]).join('\n'), maximumLines);
     }
+    // A widening tail that could not be placed, but which demonstrably re-sends
+    // history the window is already holding, is refused rather than appended.
+    //
+    // The distinction this draws is the one the origin alone cannot. A `'page'`
+    // that shares nothing with the window is the case the branch below is
+    // written for and keeps: a burst outran what one read can follow, the read
+    // is the newest thing there is, and it goes on top. But a `'page'` is the
+    // same tail asked for again at a greater depth, so when it still carries
+    // rows the window holds, it is a superset that failed to place -- and there
+    // is no arrangement in which putting a superset *under* the window is
+    // right. Everything it adds is older than everything the window has.
+    //
+    // This is what makes invariant (a) hold across paging by construction
+    // rather than because {@link DEEPENING_FURNITURE_ROWS} happens to be large
+    // enough for the pinned box in front of us. A box taller than that slack
+    // costs a page its depth -- the reader pulls and gets nothing new, and the
+    // next pull tries again -- where appending was a scrambled transcript.
+    if (overlap === 0 && origin === 'page' && sharesHistory(placed, latest)) {
+      return trimTerminalWindow(currentOutput, maximumLines);
+    }
     // Whatever the placement decided, rows the window verbatim already ends
     // with are not written down a second time. This is the last guard and it is
     // unconditional: appending rows that are already there, already in this
@@ -491,18 +530,20 @@ function staleRead(held: string[], incoming: string[]): boolean {
  */
 function deepeningSeam(held: string[], incoming: string[]): boolean {
   if (incoming.length <= held.length) return false;
-  const probe = held.slice(0, Math.min(held.length, incoming.length));
-  for (let offset = 1; offset + held.length <= incoming.length; offset += 1) {
+  // The window's tail is furniture, not transcript, and the deeper read redrew
+  // it. Everything above that has to agree verbatim; the box at the bottom is
+  // allowed to have moved on -- see {@link DEEPENING_FURNITURE_ROWS}, and the
+  // defect it exists for.
+  const slack = Math.min(DEEPENING_FURNITURE_ROWS, Math.max(0, held.length - SCREEN_ANCHOR_ROWS));
+  const needed = held.length - slack;
+  for (let offset = 1; offset + needed <= incoming.length; offset += 1) {
     let carried = 0;
-    let agreed = true;
-    for (let row = 0; row < probe.length; row += 1) {
-      if (incoming[offset + row] !== probe[row]) {
-        agreed = false;
-        break;
-      }
-      if (probe[row].trim() !== '') carried += 1;
+    let row = 0;
+    for (; row < held.length && offset + row < incoming.length; row += 1) {
+      if (incoming[offset + row] !== held[row]) break;
+      if (held[row].trim() !== '') carried += 1;
     }
-    if (agreed && carried >= SCREEN_ANCHOR_ROWS) return true;
+    if (row >= needed && carried >= SCREEN_ANCHOR_ROWS) return true;
   }
   return false;
 }
@@ -699,6 +740,35 @@ function anchoredPlacement(held: string[], incoming: string[]): number {
 }
 
 /** How much of the read the window already ends with, exactly. */
+/**
+ * Whether the incoming read still carries history the window is holding.
+ *
+ * A foothold, not a placement: {@link SCREEN_ANCHOR_ROWS} rows of the window
+ * carrying text, consecutive in the window, all present somewhere in the read.
+ * That is enough to say the read is a re-send of ground the window already
+ * covers rather than the next thing the pane printed, which is the only
+ * question its caller asks.
+ *
+ * Deliberately weaker than {@link deepeningSeam}, which has to prove the read
+ * is a superset before it may drop rows. Nothing is dropped on the strength of
+ * this one -- it only ever declines to append -- so a foothold is the right
+ * price.
+ */
+function sharesHistory(held: string[], incoming: string[]): boolean {
+  const present = new Set(incoming);
+  let run = 0;
+  for (const row of held) {
+    if (row.trim() === '') continue;
+    if (!present.has(row)) {
+      run = 0;
+      continue;
+    }
+    run += 1;
+    if (run >= SCREEN_ANCHOR_ROWS) return true;
+  }
+  return false;
+}
+
 function alreadyHeld(held: string[], incoming: string[]): number {
   const widest = Math.min(held.length, incoming.length);
   for (let count = widest; count >= 1; count -= 1) {

--- a/src/terminal/history.ts
+++ b/src/terminal/history.ts
@@ -328,7 +328,8 @@ export function foldPaneRead(
   latestOutput: string,
   origin: PaneReadOrigin,
   maximumLines: number,
-  ownsScreen = false
+  ownsScreen = false,
+  screenRows = 0
 ): string {
   const incoming = sanitizePaneRead(latestOutput);
   if (!currentOutput) return trimTerminalWindow(incoming, maximumLines);
@@ -347,7 +348,14 @@ export function foldPaneRead(
   // exactly the two-stacked-frames bug the card reported. A screen-owning read
   // replaces outright -- there is nothing above it this pane is responsible
   // for keeping.
-  if (ownsScreen) return trimTerminalWindow(incoming, maximumLines);
+  //
+  // And it replaces with the SCREEN, not with the read. Measured through the
+  // gateway against a real nvim pane: `viewport_rows: 24`, `alternate_on:
+  // true`, and a `recent-unwrapped` read 26 rows long -- the 24 the program
+  // drew, with two rows of the shell it was launched from still on top. A read
+  // is not authoritative about how tall the screen is; the pane is. See
+  // {@link altScreenFrame}.
+  if (ownsScreen) return altScreenFrame(incoming, screenRows);
 
   // A fold failure must degrade to showing the fresh read, never to killing the
   // app: in a release build an exception escaping a state updater is fatal, and
@@ -458,6 +466,31 @@ export function foldPaneRead(
 }
 
 /**
+ * The rows an alternate-screen pane actually drew, taken off the end of a read
+ * that may carry more than them.
+ *
+ * A program that owns the screen draws exactly the pane's height, every frame.
+ * A read of it can still be longer: asked for scrollback rather than the
+ * visible screen, the gateway answers with the rows above the alternate buffer
+ * too -- the shell the program was launched from, still sitting where it was.
+ * Those rows are not this pane's history and not part of its frame; drawn, they
+ * appear above the program's own first line and scroll with it, which is the
+ * defect this exists for.
+ *
+ * The screen's height is the authority, so the frame is its last `screenRows`
+ * rows. Two deliberate non-cases: a read SHORTER than the screen is a frame
+ * caught mid-redraw and is drawn whole rather than padded, and a pane whose
+ * height the gateway never reported (`0`) keeps the read intact, which is
+ * exactly what every such pane did before this existed.
+ */
+export function altScreenFrame(output: string, screenRows: number): string {
+  if (screenRows <= 0) return output;
+  const rows = terminalLines(output);
+  if (rows.length <= screenRows) return output;
+  return rows.slice(rows.length - screenRows).join('\n');
+}
+
+/**
  * Fold an SSE inline frame. {@link foldPaneRead} with the source it can only
  * ever have; kept as its own name because that is what the stream handler has.
  */
@@ -465,9 +498,10 @@ export function applyTerminalFrame(
   currentOutput: string,
   latestOutput: string,
   maximumLines: number,
-  ownsScreen = false
+  ownsScreen = false,
+  screenRows = 0
 ): string {
-  return foldPaneRead(currentOutput, latestOutput, 'frame', maximumLines, ownsScreen);
+  return foldPaneRead(currentOutput, latestOutput, 'frame', maximumLines, ownsScreen, screenRows);
 }
 
 /**


### PR DESCRIPTION
The window on the phone did not match the desktop scrollback. Two separate faults in the same seam, plus a smaller one of my own from #33.

## 1. A deeper page was written under the live screen

**Symptom.** The prompt, the status row and the agents list sat in the middle of the window, and below them the phone showed paragraphs that on the Mac sit above.

**Root cause.** `deepeningSeam` is the only licence in `history.ts` to drop rows above a seam, so it demanded the window appear inside the deeper read *exactly*, row for row. Every other comparison in the file scores its agreement instead, and says why: a composer is not a still image. Claude Code's pinned box collects the whole bill — a status row whose timer ticks every frame, and a list of background agents that appears, grows and empties, so the box changes **height** as well as content. One such row refuses the deepening; the read then falls through to the newest-thing-on-top fallback and lands under the transcript it contains.

**Evidence.** Folding the reads the screen actually makes — tail, page, poll, page, leave and come back, page — against a live tmux pane through my own gateway, comparing only transcript rows against `tmux capture-pane -p -S -`:

| | before | after |
|---|---|---|
| first page (240 -> 480) | **720 rows** (appended) | 480 rows |
| final window | **2000 rows** (hit the cap) | 960 rows |
| transcript order | **breaks at index 274** | no violation |
| duplicated rows | **975** | 0 |
| copies of the live box in the window | **3**, at rows 295 / 1039 / 1999 | 1, at the bottom |
| transcript rows below the live status row | **1605** | 0 |

Reproducible across runs; the before arm broke every time, the after arm was clean every time.

It is the **widening-tail** read that breaks, which is the read herdr panes always make — herdr ignores `start`/`end`, so it pages by widening the tail. The tmux backend serves ranges (verified: `range: {start: 100, end: 140, total: 4416}`) and pages by range, which prepends and was never affected. That is why this reached a phone on a Claude Code pane and not on an ordinary tmux one.

**Fix**, two parts, and the second is why it cannot come back the moment a box grows past a constant:

- The deepening check now allows the window's own tail to have moved on, bounded by `DEEPENING_FURNITURE_ROWS`. Everything above that must still agree verbatim, in order, contiguously, so a read that merely looks long still cannot claim depth — card #712's guard is untouched, as is the origin gate that keeps frames out of the branch entirely.
- A widening tail that could not be placed **and still carries rows the window is holding** is declined rather than appended. A superset that failed to place has nothing to add below the window by construction. A page that shares nothing with the window is untouched: that is a burst outrunning the read, it is the newest thing there is, and it still goes on top — the boundary a review pinned deliberately, and its test still passes.

So a pinned box taller than the slack now costs a page its depth — the pull brings nothing back and the next one tries again — where before it scrambled the transcript.

**On device**, with the widening-tail path forced (tmux would otherwise page by range), the before build wrote the pinned box into the head of the window (`status=2@0,479`) on exactly the input where the window was not a verbatim subset of the read; the after build, given the same input, produced one box at the bottom and nothing else.

## 2. An alternate-screen pane drew rows that were not its frame

**Symptom.** The shell the program was launched from sat above its first line and scrolled with it.

**Root cause.** Two things, both measured through the gateway:

- A read is not authoritative about how tall the screen is. A 24-row nvim pane (`viewport_rows: 24`, `alternate_on: true`) answered a `recent-unwrapped` read with **26 rows** — the 24 drawn, plus a blank and the prompt. For `less` the same read came back **52 rows**.
- The fold was told whether a pane owns the screen by the *name of the command in it* (`isFullScreenTuiPane`, matching `n?vim|nvi|helix|hx|emacs|nano`), not by the pane's own `alternate_on`. `less` holds the alternate screen and is not in that list, so its read was folded into scrollback as if the pane were printing.

**Fix.** `altScreenFrame` takes the screen's own rows off the end of the read rather than believing its length; the fold reads `alternate_on` and `viewport_rows` from the pane; paging is switched off while the program owns the screen. The command heuristic still decides the chrome, because that is a question about what the reader is driving, not about what is drawn.

**History comes back.** Whether a pane owns the screen is now part of the window's shape, so crossing the boundary files the main-screen window and hands it back whole on the way out — the same cache and rule that already carry a window across a pane switch.

**Before/after on device**, same `less` pane: before, three rows of prompt history above the frame; after, the frame starts at row 0 with nothing above it. Same for nvim.

## 3. A warm-up undid the reader's paging (from #33, mine)

The neighbour warm-up wrote its first page over whatever was remembered, so a pane the reader had paged deep and then left came back at one page. `warmPaneWindow` is `rememberPaneWindow` with the one rule a warm-up has: it may not make what is held shallower.

## Tests

Invariant-first, red before each fix and green after. The suite was missing the fixture that would have caught the first fault: its pane pins a box of fixed height whose every row but the timer is constant, and its paging tests use a fixture with no box at all — the two halves were never in the same test. Added:

- `AgentPane`, a box that changes height and content, folded through the reader's real sequence (tail, page, poll, page, cache restore, page), asserting invariant (a) across **paging and cache restore** rather than only across streamed frames.
- The minimal form: one ticking row must not cost a page its depth.
- The structural guarantee: a pinned box taller than the slack costs depth, never order.
- A new group (e) for alternate-screen panes: a read carrying main-screen rows draws only the frame; a redraw replaces rather than stacks; a short read is drawn whole; an unreported height keeps the old behaviour.

## Gates

```
tsc --noEmit      clean
oxlint            --deny-warnings, clean
oxfmt --check     All matched files use the correct format.
bun test src      2764 pass, 2 skip, 0 fail
```

Rebased on `origin/main` @ bf37224.

## The light-theme report is not in this PR, and nothing was changed for it

The black bands and the line fragments are the same area, and I looked at both. Neither is fixed here, for different reasons.

**The bands.** I could not reproduce them from a real Claude Code pane. Claude Code's blocks only get their background once it is running tools, which needs a live session, and the screen it draws before that -- the folder-trust prompt, captured with `tmux capture-pane -e` -- carries foreground colours only (`38;5;246`, `38;5;220`, `38;5;153`), no background sequences at all. What I have is a mechanism that fits the report exactly but was measured on a synthetic pane rather than on his: index 234 of the 256-colour ramp is `rgb(28, 28, 28)`, which against the dark pack's `#08111B` is the faint chrome the program meant and against the light pack's `#F7F3EC` is a black bar, because `terminalIndexedColor` maps the 232..255 ramp absolutely. That is a hypothesis with arithmetic behind it, not a reproduction, so nothing in this PR acts on it.

**The fragments.** One hypothesis is eliminated with evidence: the gateway is not handing back lines wrapped at a stale width. Asked for `recent-unwrapped` on a 359-column pane holding a 720-character logical line, it returned that line whole at 720 characters, byte-identical to `tmux capture-pane -J -p`. So the wrapping the reader sees is the app's own, done at `paneColumns`. The tails he photographed -- `ounts.` / `nts.` / `ts.` -- shorten by two characters each, which is the signature of one logical line wrapped at three widths one column apart; that points at the width used for layout drifting rather than at the read. Not chased further, and nothing changed.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

