### PR TITLE
feat(terminal): a pane the phone cannot show whole opens where the work is

### DIFF
--- a/src/components/server-terminal-workspace.tsx
+++ b/src/components/server-terminal-workspace.tsx
@@ -131,7 +131,13 @@ import { asAgentWidgetStatus, syncAgentWidget } from '@/lib/agent-widget';
 import { describeGatewayFailure, type GatewayFailure } from '@/lib/network-error';
 import { DEMO_SERVER_ID, demoRecord, isDemoRecord } from '@/lib/demo-gateway';
 import { demoSshHost } from '@/lib/demo-ssh';
-import { field, numberField, panelTitle, statusColor } from '@/lib/herdr-entity';
+import {
+  field,
+  numberField,
+  optionalNumberField,
+  panelTitle,
+  statusColor,
+} from '@/lib/herdr-entity';
 import type { GatewayRecord } from '@/lib/gateway-storage';
 import { sshHomeRows } from '@/lib/ssh-home';
 import type { PaneAddress } from '@/lib/pane-address';
@@ -1464,6 +1470,25 @@ export function ServerTerminalWorkspace({
   const selectedPaneColumns = selectedPane
     ? numberField(selectedPane, 'width') || undefined
     : undefined;
+  // The other axis of the same report, and read for the same reason: the pane's
+  // own grid is what the snapshot should be laid out on, rather than however
+  // many lines the read happened to return. `undefined` for a gateway that did
+  // not say -- every herdr pane today reports neither -- which leaves the
+  // parser's own measurement in charge exactly as it is now.
+  const selectedPaneRows = selectedPane
+    ? numberField(selectedPane, 'height') || undefined
+    : undefined;
+  // Where the program is actually working, when the gateway knows. Nothing
+  // sends these yet; they are read as optional so a gateway that starts sending
+  // them needs no app change, and their absence is a documented case of
+  // `terminalOpenView` rather than a hole in it.
+  // `optionalNumberField`, not `numberField`: a cursor's 0 is the first column,
+  // so the "absent" answer has to be distinguishable from it. Read through
+  // `numberField` instead, every pane on today's gateway -- which sends neither
+  // field -- would claim a cursor in its top-left corner and be placed there,
+  // which is the exact position this change exists to stop.
+  const selectedPaneCursorColumn = optionalNumberField(selectedPane, 'cursor_x');
+  const selectedPaneCursorRow = optionalNumberField(selectedPane, 'cursor_y');
 
   // nvim's own mode, read off the screen it just painted rather than asked
   // for -- tmux's formats carry nothing about it (`#{pane_mode}` is empty for
@@ -3634,6 +3659,9 @@ export function ServerTerminalWorkspace({
                       onTwoFingerSwipe={tabSwipe.onSwipe}
                       screenFocused={isFocused}
                       paneColumns={selectedPaneColumns}
+                      paneRows={selectedPaneRows}
+                      paneCursorColumn={selectedPaneCursorColumn}
+                      paneCursorRow={selectedPaneCursorRow}
                     />
                   </TerminalBoundary>
                 )}

--- a/src/components/skia-terminal.tsx
+++ b/src/components/skia-terminal.tsx
@@ -55,7 +55,7 @@ import { scheduleOnRN } from 'react-native-worklets';
 import { PressableScale } from '@/components/pressable-scale';
 import { useCoalescedValue } from '@/hooks/use-coalesced-value';
 import { useFreezeGate, useFrozenValue } from '@/hooks/use-frozen-value';
-import { useLatestRef } from '@/hooks/use-render-refs';
+import { useLatestRef, useResetSignal } from '@/hooks/use-render-refs';
 import { latestPillVisible } from '@/lib/dock-presentation';
 import { feedback } from '@/lib/feedback';
 import { fadeOut, timing, zoomIn, zoomOut } from '@/lib/motion';
@@ -67,10 +67,14 @@ import {
   type TwoFingerFrame,
 } from '@/lib/tab-swipe';
 import { createMMKV } from 'react-native-mmkv';
+import { terminalGridFor } from '@/lib/ssh-grid-metrics';
 import {
   pinchedTerminalScale,
+  terminalFitToWidthScale,
   terminalFontSize,
-  terminalScaleOnPaneOpen,
+  terminalOpenScale,
+  terminalOpenView,
+  terminalPanMinX,
   terminalScaleOnScreenLeave,
   type TerminalPaneScales,
   type TerminalPinchPhase,
@@ -318,6 +322,9 @@ export function SkiaTerminal({
   onTwoFingerSwipe,
   screenFocused = true,
   paneColumns,
+  paneRows,
+  paneCursorColumn,
+  paneCursorRow,
   touchInput,
 }: {
   /**
@@ -423,6 +430,17 @@ export function SkiaTerminal({
    * leaves the parser on that inference exactly as before.
    */
   paneColumns?: number;
+  /**
+   * The pane's own height, as the gateway reports it. Used for two things and
+   * only for a pane that owns the screen: it floors the parsed frame so an
+   * editor's grid is the pane's rather than the read's line count, and it is
+   * one input to where the pane opens (`terminalOpenView`). Absent on a gateway
+   * that does not report it, which is every herdr pane today.
+   */
+  paneRows?: number;
+  /** The program's cursor, when the gateway reports one. Both or neither. */
+  paneCursorColumn?: number;
+  paneCursorRow?: number;
   /**
    * The far side's input channel, for a pane whose program has asked to hear
    * about the pointer. Left out by a caller that has no such channel -- the
@@ -552,8 +570,22 @@ export function SkiaTerminal({
   // rather than here, so the cells hold the text the agent printed -- which is
   // what the clipboard has to be given.
   const frame = useMemo(
-    () => appliedFrame ?? parseTerminalSnapshot(coalescedOutput, terminalTheme, paneColumns),
-    [appliedFrame, coalescedOutput, terminalTheme, paneColumns]
+    () =>
+      appliedFrame ??
+      // The pane's rows are handed to the parse only for a program that owns
+      // the screen. An editor's frame IS its grid, so a read one line short of
+      // the pane would otherwise put the pane's last row somewhere it is not.
+      // A shell's frame is a tail of a stream and has no height to be wrong
+      // about, so it keeps the arithmetic it has always had. Rows are a floor
+      // rather than a size (see `parseTerminalSnapshot`), so the scrollback a
+      // read carries above the screen still arrives whole.
+      parseTerminalSnapshot(
+        coalescedOutput,
+        terminalTheme,
+        paneColumns,
+        ownsScreen ? paneRows : undefined
+      ),
+    [appliedFrame, coalescedOutput, terminalTheme, paneColumns, paneRows, ownsScreen]
   );
   // The pane's own colours, which are the app's unless the frame says the
   // program owns the screen and is painting in colours we never named. The
@@ -588,7 +620,17 @@ export function SkiaTerminal({
   useEffect(() => {
     onCellMetrics?.({ cellWidth, lineHeight });
   }, [cellWidth, lineHeight, onCellMetrics]);
-  const contentWidth = Math.max(viewport.width, frame.columns * cellWidth + horizontalPadding * 2);
+  // The pane's own drawn width: its columns, plus the padding the grid keeps at
+  // each edge. Kept beside `contentWidth` rather than folded into it, because
+  // the two are wanted for different things. `contentWidth` is this floored at
+  // the viewport, so a pane narrower than the screen still records and draws
+  // onto a full-width surface; the pan wants the unfloored number, or a pane
+  // scaled up to fit could be dragged sideways past the end of its own text
+  // (see `terminalPanMinX`). For every pane at least as wide as the viewport --
+  // which is every pane the fit does not touch -- they are the same number and
+  // nothing downstream can tell them apart.
+  const textWidth = frame.columns * cellWidth + horizontalPadding * 2;
+  const contentWidth = Math.max(viewport.width, textWidth);
   const contentWidthRef = useRef(contentWidth);
   // `terminalContentRows`, not `frame.lines.length`: a freshly opened pane's
   // frame is one prompt line and the rest of the pane's rows blank beneath it
@@ -806,6 +848,39 @@ export function SkiaTerminal({
   // bottom instantly instead of animating up from the top, which read as the
   // terminal "filling in from the top" on every switch.
   const snapToBottomNext = useSharedValue(false);
+  // How many rows below the pane's resting anchor the first frame after a
+  // switch should be placed at, from `terminalOpenView`. A one-shot for the
+  // same reason `snapToBottomNext` is one: the placement is an opening
+  // position, not a rule the pane is held to, so it is spent on the frame it
+  // applies to and never argues with a reader who has since panned. 0 -- every
+  // pane that is not a full-screen program bigger than this phone -- leaves
+  // that frame exactly where it lands today.
+  /**
+   * Whether this opening of the pane still owes a placement.
+   *
+   * Not a shared-value one-shot, which is what this was first: armed in the
+   * switch render and cleared by whichever applied frame got there first, it
+   * lost races that only a device showed. Measured on a 359-column pane armed
+   * at column 158 -- the arm ran, the frame that consumed it read 0, and the
+   * pane opened at column 1 anyway.
+   *
+   * `null` means armed. The switch render arms it -- that render happens
+   * exactly once per opening, which is exactly how often a pane should be
+   * placed -- and the first frame that belongs to this pane spends it and
+   * writes the key back. Every frame after that leaves the transform alone, so
+   * a reader who pans is never argued with.
+   *
+   * Keying it on the pane alone was not enough: a reader who leaves a pane and
+   * comes back gets the same key, and the placement would be skipped for a
+   * pane whose pan the switch render had just reset to the left edge. Measured:
+   * the 359-column pane placed correctly on first open and at column 1 on every
+   * return to it.
+   *
+   * Written during render, like the reset signal it follows and for the same
+   * reason: an effect would arm it a commit late, after the frame that should
+   * have spent it.
+   */
+  const placedOpenKeyRef = useRef<string | null>(null);
   const pullDistance = useSharedValue(0);
   const fallbackKeyboardOffset = useSharedValue(0);
   const activeKeyboardOffset = keyboardOffset ?? fallbackKeyboardOffset;
@@ -1016,17 +1091,111 @@ export function SkiaTerminal({
     clearSelection();
   }, [clearSelection, followOutput, pullDistance, snapToBottomNext, terminalId, translateY]);
 
-  // Opening a pane starts at the size the Text size setting names, unless this
-  // exact pane has a remembered pinch (see `terminalScaleOnPaneOpen`), in which
-  // case that is what it opens at instead. No fit to the pane's own width --
-  // lines are never wrapped, and a table wider than the phone is read by
-  // panning across it rather than by shrinking every other pane's text to
-  // match.
-  useEffect(() => {
-    if (viewport.width <= 0 || viewport.height <= 0) return;
-    scale.value = terminalScaleOnPaneOpen(terminalId, loadPaneScales());
+  // How many columns this phone would draw into this viewport at this font --
+  // the same function, on the same constants, that sizes an SSH PTY to this
+  // canvas, so the two cannot drift. The measured cell advance is passed in, so
+  // the answer is the grid actually being drawn rather than an estimate of it.
+  const phoneGrid = terminalGridFor({
+    width: viewport.width,
+    height: viewport.height,
+    fontSize,
+    cellWidth,
+    lineHeight,
+  });
+  const phoneColumns = phoneGrid.cols;
+  // The size this pane rests at with nothing remembered for it: 1 for every
+  // pane as wide as the phone or wider, and for every pane whose width the
+  // gateway did not report -- which is every SSH shell, whose grid *is* the
+  // PTY and can never differ from this one. Only a pane narrower than the grid
+  // above gets anything else. See `terminalFitToWidthScale`.
+  const paneRestingScale = terminalFitToWidthScale(phoneColumns, paneColumns);
+  // The size this pane is about to open at -- the remembered pinch if it has
+  // one, the fit otherwise. Computed here rather than inside the switch render
+  // below because the placement needs it too: how many of the pane's cells are
+  // on the glass is `phoneColumns / scale`, and a remembered 1.44 turns 52
+  // columns into 36. Getting that wrong does not nudge the placement, it moves
+  // it by a third of a screen -- measured on Android, where a stale entry for a
+  // reused pane id had this pane at 1.44 while the placement still counted at
+  // 1:1. `loadPaneScales` is a plain object after its first read (see it), so
+  // asking every render costs a lookup.
+  const paneOpenScale = terminalOpenScale({
+    paneId: terminalId,
+    remembered: loadPaneScales(),
+    phoneColumns,
+    paneColumns,
+  });
+  // Which cell of the pane the reader is put in front of. `{ 0, 0 }` for every
+  // pane that is not a full-screen program bigger than this phone's grid, which
+  // is every pane that opens correctly today. See `terminalOpenView`.
+  const openView = terminalOpenView({
+    paneColumns,
+    paneRows,
+    phoneColumns,
+    phoneRows: phoneGrid.rows,
+    // The scale it is about to be drawn at, so the placement counts the cells
+    // that will actually be on the glass rather than the ones that would be at
+    // 1:1 -- the remembered pinch included, not just the fit.
+    scale: paneOpenScale,
+    cursorColumn: paneCursorColumn,
+    cursorRow: paneCursorRow,
+    ownsScreen,
+  });
+
+  /*
+   * Opening a pane starts at the size the Text size setting names, unless this
+   * exact pane has a remembered pinch -- or unless it is narrower than the grid
+   * this phone would otherwise draw, in which case it opens scaled up until its
+   * columns reach the edge. `terminalOpenScale` is the whole rule and this is
+   * its only call site.
+   *
+   * During the render the pane changes on, not in an effect after it. The scale
+   * is a transform on the recorded picture rather than an input to it -- nothing
+   * here re-parses, re-records or re-measures -- so the cost is a shared-value
+   * write, and the reason it is here is timing rather than cost: an effect runs
+   * after the commit it belongs to has been painted, so a fitted pane would
+   * show one frame of its text at 1:1 hugging the left of the screen and then
+   * jump. #33 measured that shape of mistake from the other end and moved its
+   * own restore into the switch render for the same reason; `useResetSignal`'s
+   * docblock describes this case by name.
+   *
+   * The key is the pane *and* the geometry, which is exactly the set of
+   * dependencies the effect this replaces re-ran on, plus the pane's own column
+   * count -- so a viewport that changes still re-applies, and a pane tmux
+   * re-splits under the reader is re-fitted to the width it has now. The
+   * remembered table is read here rather than in an effect for the same timing
+   * reason; after the first read it is a plain object held for the process
+   * (see `loadPaneScales`).
+   *
+   * A reset signal is false on the render it is first called on, which would
+   * matter if a mount could arrive with a viewport already measured. It cannot:
+   * `viewport` is this component's own state, seeded `{ width: 0, height: 0 }`
+   * on every mount, so the first geometry worth acting on is always a later
+   * render and always a change from the zero this saw first.
+   */
+  const paneOpenKey = `${terminalId}:${viewport.width}x${viewport.height}:${paneColumns ?? 0}x${paneRows ?? 0}:${ownsScreen ? 1 : 0}`;
+  const paneOpened = useResetSignal(paneOpenKey);
+  if (paneOpened && viewport.width > 0 && viewport.height > 0) {
+    // A shared value, not React state: nothing in this render reads it back, so
+    // there is no torn render to have. This is the adjust-during-render pattern
+    // `useResetSignal` exists for, and an effect here is a painted frame late.
+    scale.value = paneOpenScale;
+    // The pan goes back to the left edge, as it always has on open.
     translateX.value = 0;
-  }, [scale, terminalId, translateX, viewport.height, viewport.width]);
+    // The placement itself is applied on the first frame of the new pane rather
+    // than here. This render still describes the outgoing pane -- its content
+    // height, which the resting anchor is made of, and its text width, which
+    // both pan clamps are made of -- so a position applied here is clamped
+    // against the wrong pane and lost. All this render does is say one is owed.
+    // oxlint-disable-next-line react/refs -- deliberate: nothing renders from this ref; it is the arm half of the adjust-during-render pattern above, and an effect would set it a commit too late. See its doc comment.
+    placedOpenKeyRef.current = null;
+  }
+
+  // What the placement needs, read from the one frame that can honour it. Both
+  // are mailboxes rather than dependencies so the applied-frame effect below is
+  // not restarted by a cursor that moved; the key beside them is what decides
+  // whether it is time to act at all.
+  const openViewRef = useLatestRef(openView);
+  const paneOpenKeyRef = useLatestRef(paneOpenKey);
 
   // Leaving the service screen remembers the pinch this pane is showing, keyed
   // on its id (see `terminalScaleOnScreenLeave`), rather than resetting it.
@@ -1038,9 +1207,11 @@ export function SkiaTerminal({
   useEffect(() => {
     if (screenFocused) return;
     if (viewport.width <= 0) return;
-    savePaneScales(terminalScaleOnScreenLeave(terminalId, scale.value, loadPaneScales()));
+    savePaneScales(
+      terminalScaleOnScreenLeave(terminalId, scale.value, loadPaneScales(), paneRestingScale)
+    );
     translateX.value = 0;
-  }, [scale, screenFocused, terminalId, translateX, viewport.width]);
+  }, [paneRestingScale, scale, screenFocused, terminalId, translateX, viewport.width]);
 
   // The other half of the write above, for the one path that never renders
   // `screenFocused: false` at all.
@@ -1061,13 +1232,24 @@ export function SkiaTerminal({
   // are read only from this cleanup, never from render.
   const unmountTerminalIdRef = useLatestRef(terminalId);
   const unmountViewportWidthRef = useLatestRef(viewport.width);
+  // The size this pane would have opened at anyway, so the write below can tell
+  // a scale the reader chose from one the fit handed them (see
+  // `terminalScaleOnScreenLeave`). Same mailbox pattern as the two above, and
+  // read from the same one place.
+  const unmountRestingScaleRef = useLatestRef(paneRestingScale);
   useEffect(() => {
     return () => {
       // oxlint-disable-next-line react/exhaustive-deps -- deliberate: `useLatestRef` (see its own doc comment) exists exactly so a callback outside render can read the current value; this is that read, at the one moment -- unmount -- render can no longer reach.
       if (unmountViewportWidthRef.current <= 0) return;
       savePaneScales(
-        // oxlint-disable-next-line react/exhaustive-deps -- deliberate: same as above.
-        terminalScaleOnScreenLeave(unmountTerminalIdRef.current, scale.value, loadPaneScales())
+        terminalScaleOnScreenLeave(
+          // oxlint-disable-next-line react/exhaustive-deps -- deliberate: same as above.
+          unmountTerminalIdRef.current,
+          scale.value,
+          loadPaneScales(),
+          // oxlint-disable-next-line react/exhaustive-deps -- deliberate: same as above.
+          unmountRestingScaleRef.current
+        )
       );
     };
     // oxlint-disable-next-line react/exhaustive-deps -- deliberate: unmount only, see comment above. `scale` and the two refs are stable identities, so listing them would not change when this runs.
@@ -1078,9 +1260,9 @@ export function SkiaTerminal({
   useEffect(() => {
     contentWidthRef.current = contentWidth;
     if (viewport.width <= 0) return;
-    const minX = Math.min(0, viewport.width - contentWidth * scale.value);
+    const minX = terminalPanMinX(viewport.width, textWidth, scale.value);
     translateX.value = Math.max(minX, Math.min(0, translateX.value));
-  }, [contentWidth, scale, translateX, viewport.width]);
+  }, [contentWidth, scale, textWidth, translateX, viewport.width]);
 
   // Everything that has to happen when a frame is *applied* -- which, with the
   // freeze above, is no longer once per snapshot but once per gesture-free
@@ -1188,6 +1370,69 @@ export function SkiaTerminal({
     );
     const debt = owesFreezeDebt.current;
     owesFreezeDebt.current = false;
+    const frameRows = frame.lines.length;
+
+    // The placement, applied on the first frame that can actually carry it.
+    //
+    // Kept ahead of the snap below and armed independently of it, because the
+    // two do not always get the same frame. A switch into a pane the cache
+    // already had lands its window on the switch render itself (#33), so both
+    // fire together; a switch into a pane the cache missed renders once with no
+    // output at all, and a placement spent on that empty frame would put the
+    // pane 55 rows down a one-line canvas, clamp it straight back to the
+    // anchor, and be gone before the real frame arrived. So the placement waits
+    // for a frame with the rows to hold it, and `snapToBottomNext` keeps its
+    // own behaviour exactly.
+    // Read from mailboxes, not from dependencies: `useLatestRef` is what lets
+    // this see the current placement without the effect restarting every time
+    // a cursor moves, which is the one thing it must not chase. The refs
+    // themselves are stable identities, so listing them below changes nothing
+    // about when this runs.
+    const placement = openViewRef.current;
+    const placedRows = placement.row;
+    const placedColumns = placement.column;
+    if (
+      placedOpenKeyRef.current === null &&
+      (placedRows > 0 || placedColumns > 0) &&
+      // The frame has to be this pane's, not the one being left. A switch into
+      // a pane the cache missed renders once with the outgoing pane's window
+      // still in hand, and a placement spent on it would be spent on the wrong
+      // grid. A placement only exists when the gateway reported a height, so
+      // that height is always available to check against -- and since #39 an
+      // alternate-screen frame is exactly the pane's rows, never fewer.
+      frameRows >= (paneRows ?? 0) &&
+      frameRows > placedRows
+    ) {
+      placedOpenKeyRef.current = paneOpenKeyRef.current;
+      cancelAnimation(translateY);
+      catchingUp.value = false;
+      // `bottom` is the pane's resting offset, which for a full-screen program
+      // is its FIRST row under the header rather than its last (see
+      // `terminalRestOffset`), so a placement is always a move downward into
+      // the pane and the clamp is what stops it at the real end of the content.
+      translateY.value = clampScrollOffset(
+        bottom - placedRows * lineHeight * scale.value,
+        animatedVisibleHeight.value - contentHeight * scale.value,
+        animatedTopInset.value,
+        historyHeight * scale.value
+      );
+      // The horizontal half, measured against this frame's own width so the
+      // clamp is the one the finger would meet rather than the outgoing pane's.
+      translateX.value = Math.max(
+        terminalPanMinX(viewport.width, textWidth, scale.value),
+        Math.min(0, -placedColumns * cellWidth * scale.value)
+      );
+      // A pane placed downward is deliberately not at its anchor, so follow is
+      // released -- otherwise the next frame's reaction would rest it straight
+      // back to the top and the placement would last exactly one frame. This is
+      // the same state a reader who scrolls up puts the pane in, so the Latest
+      // pill, the clamps and the re-engagement on scrolling back all behave as
+      // they already do. A pane placed only sideways keeps following, because
+      // sideways is not what follow is about.
+      if (placedRows > 0) followOutput.value = false;
+      snapToBottomNext.value = false;
+      return;
+    }
 
     if (snapToBottomNext.value) {
       // First output after a pane switch: jump to the bottom with no animation,
@@ -1232,8 +1477,16 @@ export function SkiaTerminal({
     catchingUp,
     contentHeight,
     followOutput,
+    cellWidth,
+    frame.lines.length,
+    openViewRef,
+    paneOpenKeyRef,
+    paneRows,
     gate.frozen,
     historyHeight,
+    textWidth,
+    translateX,
+    viewport.width,
     appliedContent,
     lineHeight,
     scale,
@@ -1832,7 +2085,7 @@ export function SkiaTerminal({
         }
       }
 
-      const minX = Math.min(0, viewport.width - contentWidth * scale.value);
+      const minX = terminalPanMinX(viewport.width, textWidth, scale.value);
       if (panAxis.value !== AXIS_VERTICAL) {
         translateX.value = Math.max(minX, Math.min(0, gestureStartX.value + event.translationX));
       }
@@ -1890,7 +2143,7 @@ export function SkiaTerminal({
         }
         return;
       }
-      const minX = Math.min(0, viewport.width - contentWidth * scale.value);
+      const minX = terminalPanMinX(viewport.width, textWidth, scale.value);
       const minY = animatedVisibleHeight.value - contentHeight * scale.value;
       // Momentum follows the axis the drag committed to, so a flick up cannot
       // coast sideways after the finger has left the screen.
@@ -1998,7 +2251,7 @@ export function SkiaTerminal({
       const ratio = nextScale / gestureStartScale.value;
       const nextX = focalX.value - (focalX.value - gestureStartX.value) * ratio;
       const nextY = focalY.value - (focalY.value - gestureStartY.value) * ratio;
-      const minX = Math.min(0, viewport.width - contentWidth * nextScale);
+      const minX = terminalPanMinX(viewport.width, textWidth, nextScale);
       const minY = animatedVisibleHeight.value - contentHeight * nextScale;
       scale.value = nextScale;
       translateX.value = Math.max(minX, Math.min(0, nextX));

--- a/src/components/terminal-output.tsx
+++ b/src/components/terminal-output.tsx
@@ -32,6 +32,9 @@ export function TerminalPanel({
   onTwoFingerSwipe,
   screenFocused,
   paneColumns,
+  paneRows,
+  paneCursorColumn,
+  paneCursorRow,
 }: {
   sessionId: string;
   paneId: string;
@@ -77,6 +80,11 @@ export function TerminalPanel({
   screenFocused?: boolean;
   /** The pane's own width, off the gateway record; see `SkiaTerminal`. */
   paneColumns?: number;
+  /** The pane's own height, off the same record. Absent on an older gateway. */
+  paneRows?: number;
+  /** The program's cursor, when the gateway reports one. See `terminalOpenView`. */
+  paneCursorColumn?: number;
+  paneCursorRow?: number;
 }) {
   // Kept in a ref so a new callback identity (it changes whenever the parent's
   // connection/output deps do) does not re-run the effect and re-POST zoom on
@@ -171,6 +179,9 @@ export function TerminalPanel({
             onTwoFingerSwipe={onTwoFingerSwipe}
             screenFocused={screenFocused}
             paneColumns={paneColumns}
+            paneRows={paneRows}
+            paneCursorColumn={paneCursorColumn}
+            paneCursorRow={paneCursorRow}
           />
         </Animated.View>
       )}

--- a/src/lib/__tests__/herdr-entity.test.ts
+++ b/src/lib/__tests__/herdr-entity.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 
 import type { GatewayEntity } from '@/lib/gateway-entities';
 
-import { panelTitle } from '../herdr-entity';
+import { numberField, optionalNumberField, panelTitle } from '../herdr-entity';
 
 function entity(overrides: Partial<GatewayEntity>): GatewayEntity {
   return { id: 'pane-1', title: '', subtitle: '', raw: {}, ...overrides };
@@ -39,5 +39,29 @@ describe('panelTitle', () => {
     // Whitespace is not a name, so it does not beat the id either.
     expect(panelTitle(entity({ id: 'pane-9', title: '   ' }))).toBe('pane-9');
     expect(panelTitle()).toBe('Panel');
+  });
+});
+
+describe('optionalNumberField', () => {
+  test('an absent field is undefined, not the corner of the grid', () => {
+    // The whole reason this exists beside `numberField`. A pane on a gateway
+    // that reports no cursor must not read as a pane whose cursor is at 0,0 --
+    // that is a real cell, and something placed against it lands in the corner.
+    expect(numberField(entity({ raw: {} }), 'cursor_x')).toBe(0);
+    expect(optionalNumberField(entity({ raw: {} }), 'cursor_x')).toBeUndefined();
+    expect(optionalNumberField(undefined, 'cursor_x')).toBeUndefined();
+  });
+
+  test('a reported zero survives as zero', () => {
+    expect(optionalNumberField(entity({ raw: { cursor_x: 0 } }), 'cursor_x')).toBe(0);
+    expect(optionalNumberField(entity({ raw: { cursor_y: 41 } }), 'cursor_y')).toBe(41);
+  });
+
+  test('anything that is not a finite number is absent', () => {
+    expect(optionalNumberField(entity({ raw: { cursor_x: '3' } }), 'cursor_x')).toBeUndefined();
+    expect(
+      optionalNumberField(entity({ raw: { cursor_x: Number.NaN } }), 'cursor_x')
+    ).toBeUndefined();
+    expect(optionalNumberField(entity({ raw: { cursor_x: null } }), 'cursor_x')).toBeUndefined();
   });
 });

--- a/src/lib/__tests__/terminal-text-size.test.ts
+++ b/src/lib/__tests__/terminal-text-size.test.ts
@@ -18,12 +18,17 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
+  TERMINAL_MAX_FIT_SCALE,
   TERMINAL_MAX_REMEMBERED_PANE_SCALES,
   TERMINAL_MAX_SCALE,
   TERMINAL_MIN_SCALE,
   TERMINAL_TEXT_SIZE_POINTS,
   pinchedTerminalScale,
+  terminalFitToWidthScale,
   terminalFontSize,
+  terminalOpenScale,
+  terminalOpenView,
+  terminalPanMinX,
   terminalScaleOnPaneOpen,
   terminalScaleOnScreenLeave,
   terminalZoomIndicatorPercent,
@@ -62,10 +67,21 @@ function disk(): { current: TerminalPaneScales } {
 function terminal(
   setting: TerminalTextSize,
   paneContentWidth = contentWidth,
-  options: { paneId?: string; store?: { current: TerminalPaneScales } } = {}
+  options: {
+    paneId?: string;
+    store?: { current: TerminalPaneScales };
+    /** The phone's own grid, and the pane's reported width, when the walk is
+     * about the fit. Left out, they are the pre-fit world: no width reported,
+     * so `terminalOpenScale` is `terminalScaleOnPaneOpen` and the default the
+     * leave compares against is 1. */
+    phoneColumns?: number;
+    paneColumns?: number;
+  } = {}
 ) {
   const paneId = options.paneId ?? 'pane';
   const store = options.store ?? disk();
+  const phoneColumns = options.phoneColumns ?? 0;
+  let paneColumns = options.paneColumns;
   let scale = 1;
   let content = paneContentWidth;
   return {
@@ -87,14 +103,29 @@ function terminal(
     get remembered() {
       return store.current;
     },
+    /** The default this pane would open at with nothing remembered -- which is
+     * also the number the leave below has to compare against. */
+    get restingScale() {
+      return terminalFitToWidthScale(phoneColumns, paneColumns);
+    },
     openPane() {
-      scale = terminalScaleOnPaneOpen(paneId, store.current);
+      scale = terminalOpenScale({ paneId, remembered: store.current, phoneColumns, paneColumns });
+    },
+    /** tmux reports a new width for this pane -- the reader re-split the window
+     * on the Mac while the phone was elsewhere. */
+    resplit(next: number | undefined) {
+      paneColumns = next;
     },
     pinch(gestureScale: number) {
       scale = pinchedTerminalScale(scale, gestureScale);
     },
     leaveScreen() {
-      store.current = terminalScaleOnScreenLeave(paneId, scale, store.current);
+      store.current = terminalScaleOnScreenLeave(
+        paneId,
+        scale,
+        store.current,
+        terminalFitToWidthScale(phoneColumns, paneColumns)
+      );
     },
     /** Output whose longest line has changed since the pane opened. */
     outputWidth(next: number) {
@@ -350,5 +381,528 @@ describe('the pinch is remembered on its own, not folded into the settings store
     expect(shape.toLowerCase()).not.toContain('zoom');
     expect(shape.toLowerCase()).not.toContain('scale');
     expect(source.toLowerCase()).not.toContain('zoom');
+  });
+});
+
+// A pane the reader did not choose the width of.
+//
+// tmux's third split is 36 columns; the phone would have drawn 49. The app
+// lays the snapshot out at the pane's own 36 because the program on the far
+// side hard-wrapped there, so the text fills the left 40% of the screen and
+// the rest is blank. The rule below is the only thing that answers that, and
+// the reason it is here rather than in the canvas is that its whole content is
+// arithmetic plus one precedence question -- does a remembered pinch win --
+// which is exactly what a walk can pin and a screenshot cannot.
+describe('a pane narrower than the phone is drawn to fill it', () => {
+  /** The lab: an 80-column tmux window split three ways, on a ~400pt phone. */
+  const PHONE_COLUMNS = 49;
+  const NARROW = 36;
+
+  test('a narrower pane opens scaled up until its columns reach the edge', () => {
+    expect(terminalFitToWidthScale(PHONE_COLUMNS, NARROW)).toBeCloseTo(49 / 36);
+    // The number the report is about: 36 columns on a 49-column phone.
+    expect(terminalFitToWidthScale(PHONE_COLUMNS, NARROW)).toBeCloseTo(1.361, 3);
+  });
+
+  test('a pane exactly as wide as the phone is left alone', () => {
+    expect(terminalFitToWidthScale(PHONE_COLUMNS, PHONE_COLUMNS)).toBe(1);
+  });
+
+  test('a pane wider than the phone is left alone -- #643 is not reverted', () => {
+    // The three panes that made card #643, against the phone of that report.
+    // All three are wider than it, so all three still open at 1 and the
+    // indicator still reads 100% for each: one setting, one glyph size.
+    for (const columns of [65, 80, 242]) {
+      expect(terminalFitToWidthScale(45, columns)).toBe(1);
+      expect(terminalZoomPercent(terminalFitToWidthScale(45, columns))).toBe(100);
+    }
+  });
+
+  test('the fit is capped, because scaling up spends rows', () => {
+    // A 20-column pane -- the narrowest `TERMINAL_GRID_MIN_COLS` allows -- asks
+    // for 2.45 and is given 1.6. Uncapped it would trade two thirds of the
+    // pane's visible rows for width nobody asked for.
+    expect(49 / 20).toBeGreaterThan(TERMINAL_MAX_FIT_SCALE);
+    expect(terminalFitToWidthScale(PHONE_COLUMNS, 20)).toBe(TERMINAL_MAX_FIT_SCALE);
+    // And the cap stays under the pinch's own ceiling, so a reader who wants
+    // more than the default still has somewhere to go in both directions.
+    expect(TERMINAL_MAX_FIT_SCALE).toBeLessThan(TERMINAL_MAX_SCALE);
+    expect(TERMINAL_MAX_FIT_SCALE).toBeGreaterThan(TERMINAL_MIN_SCALE);
+  });
+
+  test('a pane the gateway reported no width for is not fitted', () => {
+    // An older gateway, and every SSH shell -- whose grid *is* the PTY, so it
+    // can never differ from the phone's and there is nothing to fit.
+    expect(terminalFitToWidthScale(PHONE_COLUMNS, undefined)).toBe(1);
+    expect(terminalFitToWidthScale(PHONE_COLUMNS, 0)).toBe(1);
+    expect(terminalFitToWidthScale(PHONE_COLUMNS, Number.NaN)).toBe(1);
+    // And a phone that has not been measured yet fits nothing either.
+    expect(terminalFitToWidthScale(0, NARROW)).toBe(1);
+  });
+
+  test('the narrow pane fills the width at first open, with nothing remembered', () => {
+    const pane = terminal('default', contentWidth, {
+      phoneColumns: PHONE_COLUMNS,
+      paneColumns: NARROW,
+    });
+    pane.openPane();
+    expect(pane.scale).toBeCloseTo(49 / 36);
+    expect(pane.percent).toBe(136);
+  });
+
+  test('a remembered pinch wins over the fit', () => {
+    const store = disk();
+    const options = { store, phoneColumns: PHONE_COLUMNS, paneColumns: NARROW };
+    const first = terminal('default', contentWidth, options);
+    first.openPane();
+    // The reader disagrees with the fit and pinches down past it.
+    first.pinch(0.8);
+    const chosen = first.scale;
+    expect(chosen).not.toBeCloseTo(first.restingScale);
+    first.leaveScreen();
+    expect(store.current.pane).toBeCloseTo(chosen, 2);
+
+    // Killed and relaunched: the pane opens at what the reader chose, not at
+    // the fit.
+    const later = terminal('default', contentWidth, options);
+    later.openPane();
+    expect(later.scale).toBeCloseTo(chosen, 2);
+  });
+
+  test('a fit is never written down, so a re-split re-fits', () => {
+    const store = disk();
+    const pane = terminal('default', contentWidth, {
+      store,
+      phoneColumns: PHONE_COLUMNS,
+      paneColumns: NARROW,
+    });
+    pane.openPane();
+    expect(pane.scale).toBeCloseTo(49 / 36);
+    // The reader never pinched: leaving stores nothing, because the scale on
+    // screen is the one this pane would have opened at anyway.
+    pane.leaveScreen();
+    expect(store.current).toEqual({});
+
+    // They re-split the window on the Mac; the pane is 42 columns now.
+    pane.resplit(42);
+    pane.openPane();
+    expect(pane.scale).toBeCloseTo(49 / 42);
+    // Narrow enough and the cap answers instead, still with nothing stored.
+    pane.resplit(24);
+    pane.openPane();
+    expect(pane.scale).toBe(TERMINAL_MAX_FIT_SCALE);
+    // And widened past the phone: back to 1:1, with nothing to invalidate.
+    pane.resplit(60);
+    pane.openPane();
+    expect(pane.scale).toBe(1);
+  });
+
+  test('a manual pinch survives a re-split; the fit it replaced does not', () => {
+    const store = disk();
+    const pane = terminal('default', contentWidth, {
+      store,
+      phoneColumns: PHONE_COLUMNS,
+      paneColumns: NARROW,
+    });
+    pane.openPane();
+    pane.pinch(1.2);
+    const chosen = pane.scale;
+    pane.leaveScreen();
+
+    // Same pane, re-split to a different width. The remembered number was a
+    // statement about how big this pane's text should be, not about how wide
+    // the pane was, so it still holds.
+    pane.resplit(42);
+    pane.openPane();
+    expect(pane.scale).toBeCloseTo(chosen, 2);
+    expect(pane.scale).not.toBeCloseTo(49 / 42);
+  });
+
+  test('pinching back to the fit hands the pane back to the fit', () => {
+    // The one ambiguous case, resolved as a fit: the two are the same number,
+    // so the reader sees exactly what they asked for now, and a later re-split
+    // is free to move it.
+    const store = disk();
+    const pane = terminal('default', contentWidth, {
+      store,
+      phoneColumns: PHONE_COLUMNS,
+      paneColumns: NARROW,
+    });
+    pane.openPane();
+    pane.pinch(1.3);
+    pane.leaveScreen();
+    expect(store.current.pane).toBeDefined();
+
+    const back = terminal('default', contentWidth, {
+      store,
+      phoneColumns: PHONE_COLUMNS,
+      paneColumns: NARROW,
+    });
+    back.openPane();
+    // Pinched back to where the fit had it: the entry is dropped, not rewritten.
+    back.pinch(back.restingScale / back.scale);
+    back.leaveScreen();
+    expect(store.current).toEqual({});
+  });
+
+  test('the wide pane keeps the memory it always had', () => {
+    // The unchanged path, walked end to end: a pane the fit never touches
+    // stores and restores a pinch exactly as it does on main, and a pinch back
+    // to 1 still earns its slot back.
+    const store = disk();
+    const wide = terminal('default', contentWidth, {
+      store,
+      phoneColumns: PHONE_COLUMNS,
+      paneColumns: 242,
+    });
+    wide.openPane();
+    expect(wide.scale).toBe(1);
+    wide.pinch(0.8);
+    wide.leaveScreen();
+    expect(store.current.pane).toBeCloseTo(0.8, 2);
+
+    const again = terminal('default', contentWidth, {
+      store,
+      phoneColumns: PHONE_COLUMNS,
+      paneColumns: 242,
+    });
+    again.openPane();
+    expect(again.scale).toBeCloseTo(0.8, 2);
+    again.pinch(1 / 0.8);
+    again.leaveScreen();
+    expect(store.current).toEqual({});
+  });
+
+  test('a stale entry falls back to the fit, not to 1', () => {
+    // A tmux server restart reuses pane ids. The entry is unreadable, so the
+    // pane is treated as one that was never pinched -- which now means fitted.
+    expect(
+      terminalOpenScale({
+        paneId: 'reused',
+        remembered: { reused: Number.NaN },
+        phoneColumns: PHONE_COLUMNS,
+        paneColumns: NARROW,
+      })
+    ).toBeCloseTo(49 / 36);
+  });
+});
+
+// The pan's other end. A fitted pane is the first case where the canvas is
+// wider than the text it is drawing, so it is the first case where "how far
+// may this be panned" and "how wide is the surface" are different questions.
+describe('a fitted pane cannot be panned into blank canvas', () => {
+  const VIEWPORT = 402;
+  const CELL = 7.8;
+  const PADDING = 7;
+  const textWidth = (columns: number) => columns * CELL + PADDING * 2;
+
+  test('a pane whose text does not reach the edge does not pan', () => {
+    // 36 columns at 1:1 -- today's behaviour, and the arithmetic is the same
+    // either way because `contentWidth` is floored at the viewport.
+    expect(terminalPanMinX(VIEWPORT, textWidth(36), 1)).toBe(0);
+    // Scaled up to the cap, a 20-column pane still does not reach the edge,
+    // and still does not pan. Measured against the canvas it would have panned
+    // 241pt into nothing.
+    expect(terminalPanMinX(VIEWPORT, textWidth(20), TERMINAL_MAX_FIT_SCALE)).toBe(0);
+    expect(VIEWPORT - VIEWPORT * TERMINAL_MAX_FIT_SCALE).toBeLessThan(-240);
+  });
+
+  test('the fit lands the last column inside the edge, never past it', () => {
+    // The canvas draws the first column one padding in and scales that offset
+    // with everything else, so the last column's right edge is
+    // `scale * (padding + columns * cellWidth)`. The fit's ceiling is what
+    // keeps that inside the viewport for every width at once: the text is
+    // `scale * columns * cellWidth` = `phoneColumns * cellWidth` wide, which is
+    // the phone's own text width, and the scaled leading padding adds
+    // `scale * padding` against the `2 * padding` the phone left itself -- so
+    // any cap below 2 fits, and this one is 1.6.
+    expect(TERMINAL_MAX_FIT_SCALE).toBeLessThan(2);
+    const phoneColumns = Math.floor((VIEWPORT - PADDING * 2) / CELL);
+    for (let columns = 20; columns < phoneColumns; columns++) {
+      const scale = terminalFitToWidthScale(phoneColumns, columns);
+      const lastColumnEdge = (PADDING + columns * CELL) * scale;
+      expect(lastColumnEdge).toBeLessThanOrEqual(VIEWPORT);
+      // Whatever pan is left is the grid's own trailing padding coming into
+      // view -- less than the padding itself, and never a blank column.
+      const minX = terminalPanMinX(VIEWPORT, textWidth(columns), scale);
+      expect(minX).toBeLessThanOrEqual(0);
+      expect(minX).toBeGreaterThan(-PADDING * TERMINAL_MAX_FIT_SCALE);
+    }
+  });
+
+  test('a wide pane pans exactly as far as it always has', () => {
+    // Wider than the viewport, so `contentWidth` *is* the text width and this
+    // is the expression the pan has always evaluated -- at 1:1 and pinched.
+    for (const scale of [TERMINAL_MIN_SCALE, 1, 1.4, TERMINAL_MAX_SCALE]) {
+      const wide = textWidth(242);
+      expect(terminalPanMinX(VIEWPORT, wide, scale)).toBe(
+        Math.min(0, VIEWPORT - Math.max(VIEWPORT, wide) * scale)
+      );
+    }
+    // And it does pan: a 242-column pane is far wider than the phone.
+    expect(terminalPanMinX(VIEWPORT, textWidth(242), 1)).toBeLessThan(-1400);
+  });
+});
+
+// Where a pane bigger than the phone puts the reader when it opens.
+//
+// The measured case: a single tmux window at 359x82 running nvim, against a
+// phone whose own grid is about 50x30. Drawn 1:1 at the origin -- today -- the
+// reader gets rows 1-30 of 82 and columns 1-50 of 359, which is the corner
+// nvim leaves empty. The matrix that produced these numbers also established
+// that the rendering itself is faithful at every width (the app's frame and
+// tmux's own `capture-pane` agree line for line at 36, 100, 173 and 359
+// columns), so what is being fixed here is the viewport, not the layout.
+describe('a pane bigger than the phone opens somewhere worth looking', () => {
+  const PHONE = { phoneColumns: 50, phoneRows: 30 };
+  const WIDE = { paneColumns: 359, paneRows: 82 };
+
+  test('a shell is never placed: its newest line is the point', () => {
+    // Streams rest at the bottom and follow output; that is the whole contract
+    // and this rule does not touch it.
+    expect(terminalOpenView({ ...PHONE, ...WIDE, ownsScreen: false })).toEqual({
+      column: 0,
+      row: 0,
+    });
+  });
+
+  test('a pane that fits is not placed on either axis', () => {
+    expect(terminalOpenView({ ...PHONE, paneColumns: 36, paneRows: 20, ownsScreen: true })).toEqual(
+      { column: 0, row: 0 }
+    );
+    // Exactly the phone's own grid still counts as fitting.
+    expect(terminalOpenView({ ...PHONE, paneColumns: 50, paneRows: 30, ownsScreen: true })).toEqual(
+      { column: 0, row: 0 }
+    );
+  });
+
+  test('with no cursor reported, a big editor opens bottom-left', () => {
+    // 82 rows less the 30 the phone shows: the pane's last row is on the
+    // bottom edge, which is where nvim's status and message line lives.
+    expect(terminalOpenView({ ...PHONE, ...WIDE, ownsScreen: true })).toEqual({
+      column: 0,
+      row: 52,
+    });
+  });
+
+  test('a pane taller but not wider is placed only on the axis that overflows', () => {
+    expect(terminalOpenView({ ...PHONE, paneColumns: 40, paneRows: 82, ownsScreen: true })).toEqual(
+      { column: 0, row: 52 }
+    );
+    expect(
+      terminalOpenView({ ...PHONE, paneColumns: 359, paneRows: 20, ownsScreen: true })
+    ).toEqual({ column: 0, row: 0 });
+  });
+
+  test('a reported cursor is centred in the viewport', () => {
+    // The cursor mid-file: half a screen of context on each side of it.
+    expect(
+      terminalOpenView({ ...PHONE, ...WIDE, cursorColumn: 180, cursorRow: 41, ownsScreen: true })
+    ).toEqual({ column: 155, row: 26 });
+  });
+
+  test('a cursor near an edge is clamped inside the pane, never past it', () => {
+    // Top-left corner: centring would ask for a negative origin.
+    expect(
+      terminalOpenView({ ...PHONE, ...WIDE, cursorColumn: 0, cursorRow: 0, ownsScreen: true })
+    ).toEqual({ column: 0, row: 0 });
+    // Bottom-right corner: centring would ask to run off the end, so the pane's
+    // last row and column sit on the edges instead.
+    expect(
+      terminalOpenView({ ...PHONE, ...WIDE, cursorColumn: 358, cursorRow: 81, ownsScreen: true })
+    ).toEqual({ column: 309, row: 52 });
+  });
+
+  test('half a cursor is no cursor', () => {
+    // The gateway is allowed to report neither; it must not be trusted to
+    // report exactly one and have the other read as column 0.
+    expect(terminalOpenView({ ...PHONE, ...WIDE, cursorColumn: 180, ownsScreen: true })).toEqual({
+      column: 0,
+      row: 52,
+    });
+    expect(terminalOpenView({ ...PHONE, ...WIDE, cursorRow: 41, ownsScreen: true })).toEqual({
+      column: 0,
+      row: 52,
+    });
+    expect(
+      terminalOpenView({
+        ...PHONE,
+        ...WIDE,
+        cursorColumn: Number.NaN,
+        cursorRow: 41,
+        ownsScreen: true,
+      })
+    ).toEqual({ column: 0, row: 52 });
+  });
+
+  test('a pane the gateway did not measure is left where it has always opened', () => {
+    // herdr today: no width, no height. The old behaviour is the safe answer.
+    expect(terminalOpenView({ ...PHONE, ownsScreen: true })).toEqual({ column: 0, row: 0 });
+    expect(terminalOpenView({ ...PHONE, paneColumns: 359, ownsScreen: true })).toEqual({
+      column: 0,
+      row: 0,
+    });
+  });
+});
+
+// The two rules meeting. A narrow pane gets both -- scaled up to fill the
+// width, and placed, because scaling up is what makes it too tall to see whole.
+describe('the fit and the placement agree about how many cells are on the glass', () => {
+  test('a fitted pane is placed against the rows it actually shows', () => {
+    // 36x40 nvim on a 48x27 phone. The fit draws it at 48/36 = 1.33x, so the
+    // glass holds 27/1.33 = 20 of its rows, not 27. Placed against 27 the pane
+    // would open seven rows short of the bottom it was asked for.
+    const scale = terminalFitToWidthScale(48, 36);
+    expect(scale).toBeCloseTo(48 / 36);
+    const placed = terminalOpenView({
+      paneColumns: 36,
+      paneRows: 40,
+      phoneColumns: 48,
+      phoneRows: 27,
+      scale,
+      ownsScreen: true,
+    });
+    // 40 rows less the 20 that fit: the pane's last row is on the bottom edge.
+    expect(placed.row).toBe(20);
+    expect(placed.column).toBe(0);
+    // And the fit has taken the horizontal overflow away entirely, so there is
+    // nothing to place on that axis.
+    expect(placed.column).toBe(0);
+  });
+
+  test('a pane that fits at 1:1 but not once scaled up is still placed', () => {
+    // 36x24 on a 48x27 phone fits vertically at 1:1 and does not at 1.33x.
+    const scale = terminalFitToWidthScale(48, 36);
+    expect(
+      terminalOpenView({
+        paneColumns: 36,
+        paneRows: 24,
+        phoneColumns: 48,
+        phoneRows: 27,
+        ownsScreen: true,
+      })
+    ).toEqual({ column: 0, row: 0 });
+    expect(
+      terminalOpenView({
+        paneColumns: 36,
+        paneRows: 24,
+        phoneColumns: 48,
+        phoneRows: 27,
+        scale,
+        ownsScreen: true,
+      })
+    ).toEqual({ column: 0, row: 4 });
+  });
+
+  test('an absent or nonsense scale is 1:1', () => {
+    const base = {
+      paneColumns: 359,
+      paneRows: 82,
+      phoneColumns: 48,
+      phoneRows: 27,
+      ownsScreen: true,
+    };
+    expect(terminalOpenView(base).row).toBe(55);
+    expect(terminalOpenView({ ...base, scale: 0 }).row).toBe(55);
+    expect(terminalOpenView({ ...base, scale: Number.NaN }).row).toBe(55);
+  });
+});
+
+// The two backends as gateway v0.8.1 actually reports them, which is the whole
+// reason every geometry input here is optional. Measured against a live 0.8.1
+// on both: tmux fills in all five fields, herdr fills in one.
+describe('the backends as v0.8.1 reports them', () => {
+  const PHONE = { phoneColumns: 48, phoneRows: 27 };
+
+  test('tmux: width, height and a cursor, so the pane opens on the cursor', () => {
+    // The measured single-pane case: 359x82 nvim, cursor at column 184 row 7.
+    expect(
+      terminalOpenView({
+        ...PHONE,
+        paneColumns: 359,
+        paneRows: 82,
+        cursorColumn: 184,
+        cursorRow: 7,
+        ownsScreen: true,
+      })
+    ).toEqual({ column: 160, row: 0 });
+  });
+
+  test('herdr: a height, no width, no cursor, no alternate flag', () => {
+    // v0.8.1 reports `height` from `scroll.viewport_rows` and leaves the other
+    // four null -- herdr's socket API has no pane width, no alt-screen flag and
+    // no cursor at protocol 20. Without columns there is no way to know what
+    // overflows, so the pane opens exactly where it opens today and the parser
+    // keeps measuring its own width. Half a geometry is not a geometry.
+    expect(terminalOpenView({ ...PHONE, paneRows: 81, ownsScreen: true })).toEqual({
+      column: 0,
+      row: 0,
+    });
+    // And with the alternate flag missing the app may still decide a pane owns
+    // the screen by other means; that must not change the answer either.
+    expect(terminalOpenView({ ...PHONE, paneRows: 81, ownsScreen: false })).toEqual({
+      column: 0,
+      row: 0,
+    });
+  });
+
+  test('a cursor is viewport-relative, so row 0 is the pane top', () => {
+    // The gateway states zero-based, column then row, from the top left of the
+    // viewport rather than of the scrollback -- which is the frame of reference
+    // this rule works in, so no adjustment is applied to it anywhere.
+    expect(
+      terminalOpenView({
+        ...PHONE,
+        paneColumns: 359,
+        paneRows: 82,
+        cursorColumn: 0,
+        cursorRow: 0,
+        ownsScreen: true,
+      })
+    ).toEqual({ column: 0, row: 0 });
+  });
+});
+
+// A remembered pinch is a scale like any other, and the placement has to count
+// in it. Found on a device: an Android emulator carrying a stale entry for a
+// reused pane id opened a 359-column pane at 1.44x while the placement was
+// still computed at 1:1, which put the reader a third of a screen from where
+// the cursor was.
+describe('the placement counts the cells the opening scale actually shows', () => {
+  const PANE = { paneColumns: 359, paneRows: 82, ownsScreen: true as const };
+  const PHONE = { phoneColumns: 52, phoneRows: 48 };
+
+  test('a remembered pinch moves the placement, not just the glyphs', () => {
+    const remembered = { pane: 1.44 };
+    const scale = terminalOpenScale({
+      paneId: 'pane',
+      remembered,
+      phoneColumns: PHONE.phoneColumns,
+      paneColumns: PANE.paneColumns,
+    });
+    expect(scale).toBeCloseTo(1.44);
+    // 52 columns at 1:1, but only 36 of them once the pane is drawn at 1.44x.
+    const atOne = terminalOpenView({ ...PANE, ...PHONE, cursorColumn: 184, cursorRow: 7 });
+    const atPinch = terminalOpenView({
+      ...PANE,
+      ...PHONE,
+      scale,
+      cursorColumn: 184,
+      cursorRow: 7,
+    });
+    expect(atOne.column).toBe(158);
+    expect(atPinch.column).toBe(166);
+    // The cursor is centred in both, which is the point: each is right for the
+    // number of columns its own scale puts on the glass.
+    expect(atOne.column + 52 / 2).toBeCloseTo(184, 0);
+    expect(atPinch.column + 52 / 1.44 / 2).toBeCloseTo(184, 0);
+  });
+
+  test('the fit and a remembered pinch are the same input to the placement', () => {
+    // Nothing here knows or cares which of the two produced the number; there
+    // is one opening scale and the placement is computed against it.
+    const fitted = terminalOpenView({ ...PANE, ...PHONE, scale: 1.44 });
+    const pinched = terminalOpenView({ ...PANE, ...PHONE, scale: 1.44 });
+    expect(fitted).toEqual(pinched);
   });
 });

--- a/src/lib/herdr-entity.ts
+++ b/src/lib/herdr-entity.ts
@@ -11,6 +11,23 @@ export function numberField(entity: HerdrEntity, key: string): number {
   return typeof value === 'number' ? value : 0;
 }
 
+/**
+ * The same read, for a field whose 0 is a real value rather than a miss.
+ *
+ * `numberField` answers 0 for "absent", which is exactly right for a width or a
+ * height -- neither can legitimately be zero, so callers map 0 back to
+ * "unknown" with `|| undefined`. It is exactly wrong for a coordinate: column 0
+ * row 0 is the top-left cell, and a pane whose cursor the gateway never
+ * reported would otherwise read as a pane whose cursor is in the corner.
+ */
+export function optionalNumberField(
+  entity: HerdrEntity | undefined,
+  key: string
+): number | undefined {
+  const value = entity?.raw[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
 export function panelTitle(pane?: HerdrEntity, agent?: HerdrEntity): string {
   // A name the user set on the pane wins over everything, so a rename always
   // shows even when an agent is attached.

--- a/src/lib/terminal-text-size.ts
+++ b/src/lib/terminal-text-size.ts
@@ -71,6 +71,72 @@ export const TERMINAL_MIN_SCALE = 0.62;
 /** How far in a pinch may zoom -- roughly three words to a line at 1.8. */
 export const TERMINAL_MAX_SCALE = 1.8;
 
+/**
+ * How far the fit below may zoom a pane that is narrower than the phone's grid.
+ *
+ * The fit exists because a pane the reader did not choose the width of --
+ * tmux's third split, 36 columns of an 80-column window -- otherwise draws its
+ * text across the left 40% of the phone and leaves the rest blank. Scaling it
+ * up until its columns reach the edge is the whole idea, and for the panes that
+ * motivated it the ratio does the work on its own: 36 columns on a 49-column
+ * phone is 1.36, and nothing here binds.
+ *
+ * The cap is for the other end, and it is a limit on rows rather than on
+ * columns. Scaling up costs vertical room in exact proportion -- at 1.6 a
+ * viewport that showed 44 rows shows 27, at 2.5 it shows 17 -- and a pane's
+ * shape is as much its height as its width. `TERMINAL_GRID_MIN_COLS` says a
+ * 20-column pane is legal, so an uncapped fit would ask for 2.5 and hand back
+ * a pane with a third of its rows: bigger, and less of the thing the reader
+ * opened.
+ *
+ * 1.6 rather than the pinch's own 1.8 because this is a *default*, and a
+ * default that opens at the outer limit of the gesture that overrides it
+ * leaves the reader nowhere to go. At 1.6 the pinch still has room in both
+ * directions -- 0.62 below, 1.8 above -- so a reader who disagrees with the
+ * fit can say so and be remembered (see `terminalScaleOnScreenLeave`).
+ *
+ * A pane narrow enough to hit the cap keeps some empty width on the right.
+ * That is the honest answer rather than a failure: at that point filling the
+ * width and keeping the pane readable are two different requests, and the one
+ * the reader made was to read the pane.
+ */
+export const TERMINAL_MAX_FIT_SCALE = 1.6;
+
+/**
+ * The scale at which a pane's own columns fill the phone's grid -- or 1 when
+ * they already do, or more than do.
+ *
+ * The gateway reports a pane's real width and the canvas lays the snapshot out
+ * at exactly that many columns, because the program on the far side hard-wrapped
+ * its own text there; reflowing a 36-column pane to 49 would re-break lines
+ * Claude Code and nvim had already broken. So the pane's width is fixed and the
+ * only free variable is how big each column is drawn.
+ *
+ * Columns rather than points on purpose: both numbers are counts of the same
+ * cell, so their ratio is exactly the factor that puts the pane's last column
+ * where the phone's last column would have been, and it needs no cell advance,
+ * no padding and no viewport to say so. It is also very slightly conservative
+ * -- the phone's own column count is floored -- which is the direction to err,
+ * because the alternative is a fitted pane whose right-hand column sits a
+ * fraction past the edge.
+ *
+ * Returns 1, not a smaller number, for a pane as wide as the phone or wider.
+ * Shrinking those is the question card #643 already answered: it gave panes of
+ * different widths different glyph sizes under one Text size setting. A wide
+ * pane keeps its 1:1 text and is read by panning across it, exactly as it is
+ * today. `undefined` columns -- a gateway too old to report a width, and every
+ * SSH shell, whose grid *is* the PTY and can never differ from the phone's --
+ * likewise mean 1 and no fit at all.
+ */
+export function terminalFitToWidthScale(phoneColumns: number, paneColumns?: number): number {
+  if (typeof paneColumns !== 'number' || !Number.isFinite(paneColumns) || paneColumns <= 0) {
+    return 1;
+  }
+  if (!Number.isFinite(phoneColumns) || phoneColumns <= 0) return 1;
+  if (paneColumns >= phoneColumns) return 1;
+  return Math.min(phoneColumns / paneColumns, TERMINAL_MAX_FIT_SCALE);
+}
+
 /** The point size the setting names, falling back to the middle one. */
 export function terminalFontSize(size: TerminalTextSize): number {
   return TERMINAL_TEXT_SIZE_POINTS[size] ?? TERMINAL_TEXT_SIZE_POINTS.default;
@@ -120,11 +186,92 @@ export const TERMINAL_MAX_REMEMBERED_PANE_SCALES = 64;
  * read by moving across it. What changed is only that a reader who decides a
  * particular pane is worth a different size no longer has to make that
  * decision again every time they come back to it.
+ *
+ * A fit did come back, and #643 is not reverted: `terminalFitToWidthScale`
+ * only ever scales *up*, only ever a pane the gateway reports as narrower than
+ * the phone's own grid, and it is never remembered. The three panes that made
+ * #643 -- 65, 80 and 242 columns on a 45-column phone -- are all wider than
+ * the phone, so all three still open at 1 and the indicator still reads 100%
+ * for all three. What is fitted is the case that rule had no answer for: a
+ * pane whose columns do not reach the edge, which has no reason to be drawn
+ * small and cannot be panned to fix it.
  */
 export function terminalScaleOnPaneOpen(paneId: string, remembered: TerminalPaneScales): number {
   const value = remembered[paneId];
   if (typeof value !== 'number' || !Number.isFinite(value)) return 1;
   return Math.max(TERMINAL_MIN_SCALE, Math.min(TERMINAL_MAX_SCALE, value));
+}
+
+/** What a pane needs to know about itself to be opened at the right size. */
+export interface TerminalOpenScaleInput {
+  /** The pane whose remembered pinch is being looked up. */
+  paneId: string;
+  /** The table as the canvas last loaded or saved it. */
+  remembered: TerminalPaneScales;
+  /** Columns the phone would draw at this viewport and font (`terminalGridFor`). */
+  phoneColumns: number;
+  /** The pane's own width as the gateway reports it; `undefined` if it did not. */
+  paneColumns?: number;
+}
+
+/**
+ * The size a pane opens at: the reader's own answer if they have given one,
+ * otherwise the fit, otherwise the Text size setting's 1:1.
+ *
+ * The two halves are `terminalScaleOnPaneOpen` and `terminalFitToWidthScale`,
+ * unchanged and each still testable on its own; this is only the order they are
+ * asked in. A remembered pinch wins outright -- a reader who has said what size
+ * this pane should be has said it about this pane, and a default that argued
+ * with them would be the app changing its mind every time they came back.
+ *
+ * **A fit is never written down, and that is the whole answer to "does a pane's
+ * column count changing reset a remembered scale".** The fit is recomputed from
+ * the pane's current width every time the pane is opened, so a reader who never
+ * pinched gets a new fit the moment tmux reports a new width -- re-split the
+ * window on the Mac and the phone re-fits, with nothing to invalidate, because
+ * there was never a stored number to be wrong. A reader who *did* pinch has an
+ * entry, and it survives the re-split, because it was a statement about how big
+ * they wanted this pane's text and not about how wide the pane happened to be.
+ *
+ * `terminalScaleOnScreenLeave` is what keeps that true: handed the same default
+ * this function just produced, it drops rather than stores a scale that has come
+ * back to it (see its own note). So the one ambiguous case -- a reader who
+ * pinches to within half a percent of the fit -- resolves as a fit, which draws
+ * exactly what they asked for now and re-fits later. Ambiguous because the two
+ * are the same number; harmless because the number is the same.
+ */
+export function terminalOpenScale({
+  paneId,
+  remembered,
+  phoneColumns,
+  paneColumns,
+}: TerminalOpenScaleInput): number {
+  const value = remembered[paneId];
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return terminalScaleOnPaneOpen(paneId, remembered);
+  }
+  return terminalFitToWidthScale(phoneColumns, paneColumns);
+}
+
+/**
+ * How far left the pane may be panned: the point where its last column reaches
+ * the right edge, and never past it.
+ *
+ * `textWidth` is the drawn width of the pane's own columns plus the grid's
+ * padding -- `frame.columns * cellWidth + horizontalPadding * 2` -- and
+ * deliberately not the canvas's `contentWidth`, which is that number floored at
+ * the viewport width so a short pane still has a full-width surface to draw on.
+ *
+ * For every pane wider than the viewport the two are the same number and this
+ * is the arithmetic the pan has always used. They differ only for a pane
+ * narrower than the phone: there `contentWidth` is the viewport, so scaling up
+ * made the *surface* grow with the scale while the text stayed where it was,
+ * and the reader could pan a fitted pane sideways into blank canvas. Measured
+ * against the text instead, a pane too narrow to overflow simply does not pan.
+ */
+export function terminalPanMinX(viewportWidth: number, textWidth: number, scale: number): number {
+  'worklet';
+  return Math.min(0, viewportWidth - textWidth * scale);
 }
 
 /**
@@ -153,7 +300,17 @@ export function terminalScaleOnPaneOpen(paneId: string, remembered: TerminalPane
  * there is nothing worth remembering, so the entry is dropped rather than
  * written as 1 -- a pane pinched back to default earns its slot back
  * immediately instead of occupying one with a number that would only ever
- * have been read as the fallback anyway. Otherwise the pane is re-inserted at
+ * have been read as the fallback anyway.
+ *
+ * `defaultScale` is which number counts as "the size it would have opened at
+ * anyway", and it is 1 -- the setting's own size, byte for byte the rule this
+ * function has always applied -- for every pane except one the fit has scaled
+ * up (`terminalFitToWidthScale`). For those it is the fit, and dropping there
+ * rather than storing is what makes a fit a default instead of a decision: a
+ * narrow pane the reader only looked at leaves nothing behind, so it is fitted
+ * again from whatever width tmux reports next time, while a narrow pane the
+ * reader actually pinched leaves the number they chose and keeps it through a
+ * re-split. See `terminalOpenScale`, which is handed the same default. Otherwise the pane is re-inserted at
  * the end of the table, so trimming to `TERMINAL_MAX_REMEMBERED_PANE_SCALES`
  * drops whichever pane has gone longest untouched, not whichever was pinched
  * first.
@@ -173,13 +330,15 @@ export function terminalScaleOnPaneOpen(paneId: string, remembered: TerminalPane
 export function terminalScaleOnScreenLeave(
   paneId: string,
   scale: number,
-  remembered: TerminalPaneScales
+  remembered: TerminalPaneScales,
+  defaultScale = 1
 ): TerminalPaneScales {
   if (!paneId) return remembered;
   const clamped =
     Math.round(Math.max(TERMINAL_MIN_SCALE, Math.min(TERMINAL_MAX_SCALE, scale)) * 100) / 100;
   const { [paneId]: _dropped, ...rest } = remembered;
-  if (Math.abs(clamped - 1) < 0.005) return rest;
+  const resting = Number.isFinite(defaultScale) && defaultScale > 0 ? defaultScale : 1;
+  if (Math.abs(clamped - Math.round(resting * 100) / 100) < 0.005) return rest;
   const entries = Object.entries(rest);
   const kept = entries.slice(
     Math.max(0, entries.length - (TERMINAL_MAX_REMEMBERED_PANE_SCALES - 1))
@@ -251,4 +410,126 @@ export function terminalZoomIndicatorPercent(
 export function terminalZoomLabel(size: TerminalTextSize, scale: number): string {
   const name = TERMINAL_TEXT_SIZE_NAMES[size] ?? TERMINAL_TEXT_SIZE_NAMES.default;
   return `${name} · ${terminalZoomPercent(scale)}%`;
+}
+
+/** Where a pane should be sitting when it opens, in the pane's own cells. */
+export interface TerminalOpenViewInput {
+  /** The pane's own grid, as the gateway reports it. Absent on an old gateway. */
+  paneColumns?: number;
+  paneRows?: number;
+  /** The grid this phone would draw at this viewport and font, at 1:1. */
+  phoneColumns: number;
+  phoneRows: number;
+  /**
+   * The scale the pane is opening at (`terminalOpenScale`).
+   *
+   * The phone's grid is stated at 1:1, but the pane is drawn at this, so the
+   * cells that actually fit on the glass are `phoneColumns / scale` by
+   * `phoneRows / scale`. It matters: a 36-column pane fitted to 1.33x shows 20
+   * of its 40 rows, not 27, and a placement computed against 27 would leave the
+   * pane seven rows short of the bottom it was asked to open at.
+   */
+  scale?: number;
+  /** The program's cursor, when the gateway reports one. Both or neither. */
+  cursorColumn?: number;
+  cursorRow?: number;
+  /** Whether the program has taken the whole screen (`alternate_on`). */
+  ownsScreen: boolean;
+}
+
+/**
+ * The pane cell that should sit at the top-left of the viewport when the pane
+ * opens. `{ column: 0, row: 0 }` means "exactly what this app has always done".
+ */
+export interface TerminalOpenView {
+  column: number;
+  row: number;
+}
+
+/** What a pane that should not be placed at all answers. */
+const TERMINAL_OPEN_VIEW_ORIGIN: TerminalOpenView = { column: 0, row: 0 };
+
+/**
+ * Which corner of a pane the reader is put in front of when it opens.
+ *
+ * The problem this answers is not width and not height but *area*. A tmux
+ * window at 359x82 -- one editor, no splits -- is 29,000 cells; the phone's
+ * grid is about 50x30. Drawn 1:1 and parked at the origin, which is what the
+ * canvas does today, the reader is shown the top-left 5% of the pane: rows 1-30
+ * of 82 and columns 1-50 of 359. nvim's dashboard is centred around row 41,
+ * its status line is row 82, and anything right-aligned is three hundred
+ * columns away, so the one screen the reader is given is the one part of the
+ * pane the program deliberately left empty.
+ *
+ * Scaling cannot fix it and this function does not try: fitting 359 columns
+ * into 50 is 0.14x, a 1.8pt font, and fitting both axes is the same 0.14x. A
+ * pane bigger than the phone can only be read by moving around it, so the
+ * question worth answering is where to start.
+ *
+ * **Only a pane that owns the screen is placed.** A shell is a stream: its
+ * newest line is the point, the canvas already rests it at the bottom, and
+ * `followOutput` keeps it there -- placing it anywhere else would be arguing
+ * with the reason it is on screen. An editor is a picture, and which part of
+ * the picture the reader lands on is a real choice with no default.
+ *
+ * **A pane that fits is not placed either**, on either axis, so every pane
+ * small enough to be seen whole opens exactly where it opens today.
+ *
+ * Otherwise:
+ * - **The cursor, when the gateway reports one**, centred in the viewport and
+ *   clamped inside the pane. It is the best available answer to "where is the
+ *   program actually working": nvim's cursor is in the file, an agent's is at
+ *   its prompt. Centred rather than cornered because a cursor at the edge of
+ *   the screen shows the reader half the context.
+ * - **Bottom-left otherwise.** Not the origin, which is the corner that is
+ *   empty in every full-screen program worth opening: nvim's status and message
+ *   line, a shell's prompt, and an agent's newest output all live on the last
+ *   row, and the left is where a line starts. It is the corner most likely to
+ *   be carrying the thing that changed most recently.
+ *
+ * Pure, and in cells rather than points: the canvas owns the cell advance, the
+ * row pitch, the padding and the clamps, and a rule expressed in points could
+ * not be checked against a pane's geometry without restating all four.
+ */
+export function terminalOpenView({
+  paneColumns,
+  paneRows,
+  phoneColumns,
+  phoneRows,
+  scale = 1,
+  cursorColumn,
+  cursorRow,
+  ownsScreen,
+}: TerminalOpenViewInput): TerminalOpenView {
+  if (!ownsScreen) return TERMINAL_OPEN_VIEW_ORIGIN;
+  const columns =
+    Number.isFinite(paneColumns) && (paneColumns ?? 0) > 0 ? (paneColumns as number) : 0;
+  const rows = Number.isFinite(paneRows) && (paneRows ?? 0) > 0 ? (paneRows as number) : 0;
+  if (columns <= 0 || rows <= 0) return TERMINAL_OPEN_VIEW_ORIGIN;
+  if (!Number.isFinite(phoneColumns) || !Number.isFinite(phoneRows)) {
+    return TERMINAL_OPEN_VIEW_ORIGIN;
+  }
+  const drawnScale = Number.isFinite(scale) && scale > 0 ? scale : 1;
+  const visibleColumns = Math.max(0, phoneColumns) / drawnScale;
+  const visibleRows = Math.max(0, phoneRows) / drawnScale;
+  const spareColumns = Math.max(0, columns - visibleColumns);
+  const spareRows = Math.max(0, rows - visibleRows);
+  if (spareColumns === 0 && spareRows === 0) return TERMINAL_OPEN_VIEW_ORIGIN;
+
+  const hasCursor =
+    typeof cursorColumn === 'number' &&
+    Number.isFinite(cursorColumn) &&
+    typeof cursorRow === 'number' &&
+    Number.isFinite(cursorRow);
+  if (!hasCursor) {
+    // Bottom-left: the last row of the pane at the bottom of the viewport.
+    // Rounded up, because a partly visible row at the top is a row the reader
+    // can read, while stopping short leaves the last row half off the bottom.
+    return { column: 0, row: Math.ceil(spareRows) };
+  }
+  const clamp = (value: number, limit: number) => Math.max(0, Math.min(limit, Math.round(value)));
+  return {
+    column: clamp((cursorColumn as number) - visibleColumns / 2, spareColumns),
+    row: clamp((cursorRow as number) - visibleRows / 2, spareRows),
+  };
 }

--- a/src/terminal/terminal-core.ts
+++ b/src/terminal/terminal-core.ts
@@ -342,7 +342,7 @@ export class TerminalEmulator {
     this.openRun = false;
   }
 
-  frame(): TerminalFrame {
+  frame(minRows = 0): TerminalFrame {
     const buffer = this.active;
     return buildTerminalFrame(
       buffer.grid,
@@ -350,7 +350,8 @@ export class TerminalEmulator {
       buffer.cursorX,
       buffer.cursorY,
       this.cursorVisible,
-      this.title
+      this.title,
+      minRows
     );
   }
 
@@ -784,11 +785,23 @@ export class TerminalEmulator {
 
 /**
  * Materialises a frame from a grid: trailing blank rows are trimmed, but never
- * below the cursor row. `rowHasContent` reads the packed cells directly, so the
- * scan allocates nothing -- only the (changed) lines kept below are built.
+ * below the cursor row -- nor below `minRows`, when a caller knows the grid's
+ * real height and the trim would otherwise shorten it. `rowHasContent` reads
+ * the packed cells directly, so the scan allocates nothing -- only the
+ * (changed) lines kept below are built.
  *
  * Shared by `TerminalEmulator.frame()` and the snapshot fast path so both
  * produce byte-identical frames from identical cells.
+ *
+ * `minRows` is a floor on the frame's total rows and never a truncation: a
+ * frame already taller than it -- an alt-screen pane whose read carried a few
+ * rows of main-screen scrollback above it, say -- keeps every row it has. It is
+ * a floor rather than an exact height because this function cannot tell a
+ * pane's screen from the history above it; what it guarantees is that a pane
+ * reporting an 82-row screen never produces a frame shorter than 82, which is
+ * what stops anything positioned against the frame's last row from landing
+ * above the pane's real bottom. 0 -- the default, and what every caller that
+ * does not know a height passes -- is exactly the old behaviour.
  */
 function buildTerminalFrame(
   grid: TerminalGrid,
@@ -796,7 +809,8 @@ function buildTerminalFrame(
   cursorX: number,
   cursorY: number,
   cursorVisible: boolean,
-  title: string | null
+  title: string | null,
+  minRows = 0
 ): TerminalFrame {
   const total = grid.totalRows();
   const cursorRow = grid.scrollbackCount() + cursorY;
@@ -807,6 +821,7 @@ function buildTerminalFrame(
       break;
     }
   }
+  if (minRows > 0) lastLine = Math.max(lastLine, Math.min(total, minRows) - 1);
   const lines: TerminalLine[] = [];
   for (let row = 0; row <= lastLine; row += 1) lines.push(grid.lineAt(row));
   return {
@@ -828,19 +843,27 @@ let forceFullEmulation = false;
 export function parseTerminalSnapshot(
   input: string,
   theme: TerminalTheme = DEFAULT_TERMINAL_THEME,
-  columns?: number
+  columns?: number,
+  rows?: number
 ): TerminalFrame {
+  const reportedRows = rows && rows > 0 ? rows : 0;
   if (!forceFullEmulation) {
-    const flat = parseFlatSnapshot(input, theme, columns);
+    const flat = parseFlatSnapshot(input, theme, columns, reportedRows);
     if (flat) return flat;
   }
   const measured = measureSnapshot(input);
   // A reported width is the pane's own; the measurement is what to do when
   // nobody said. Clamping a reported width against MAX_SNAPSHOT_COLUMNS would
   // reintroduce exactly the overflow this parameter exists to remove.
+  //
+  // A reported height is the same promise about the other axis, and it is a
+  // floor on both the grid and the frame rather than a size: the read is a tail
+  // that may carry scrollback above the screen, so it can legitimately be
+  // taller than the pane, and it must never be cut down to fit. What it may not
+  // be is *shorter* than the pane the gateway described.
   const dimensions = {
     columns: columns && columns > 0 ? columns : measured.columns,
-    rows: measured.rows,
+    rows: Math.max(measured.rows, reportedRows),
   };
   const terminal = new TerminalEmulator({
     columns: dimensions.columns,
@@ -854,7 +877,7 @@ export function parseTerminalSnapshot(
   // going to be finished by a next chunk, and `flush` handles it exactly as
   // the single write did before `write` learned to wait for one.
   terminal.flush();
-  return terminal.frame();
+  return terminal.frame(reportedRows);
 }
 
 /**
@@ -901,7 +924,8 @@ export function snapshotQualifiesForFlatPath(input: string): boolean {
 function parseFlatSnapshot(
   input: string,
   theme: TerminalTheme,
-  columns?: number
+  columns?: number,
+  minRows = 0
 ): TerminalFrame | null {
   const scan = scanFlatSnapshot(input);
   if (!scan) return null;
@@ -930,7 +954,10 @@ function parseFlatSnapshot(
   if (scan.widest > widthCeiling || lineCount > EMULATED_ROW_CAP) return null;
   const gridColumns =
     suppliedColumns ?? clamp(Math.max(MIN_SNAPSHOT_COLUMNS, scan.widest), 2, MAX_SNAPSHOT_COLUMNS);
-  const rows = clamp(Math.max(2, lineCount + 1), 2, EMULATED_ROW_CAP);
+  // The grid is allocated to whichever is taller: the lines this snapshot
+  // actually has, or the screen the gateway says the pane has. Allocating to
+  // the smaller of the two would leave `buildTerminalFrame` nothing to floor.
+  const rows = clamp(Math.max(2, lineCount + 1, minRows), 2, EMULATED_ROW_CAP);
   const grid = new TerminalGrid(gridColumns, rows, 0);
   // One mutable style carried across lines, exactly as the emulator carries it:
   // an unterminated SGR keeps applying to the rows below.
@@ -968,7 +995,7 @@ function parseFlatSnapshot(
     cursorX = column >= gridColumns ? gridColumns - 1 : column;
   }
 
-  return buildTerminalFrame(grid, gridColumns, cursorX, lineCount - 1, true, null);
+  return buildTerminalFrame(grid, gridColumns, cursorX, lineCount - 1, true, null, minRows);
 }
 
 /** Lines made only of ASCII printables; laid out without any width lookup. */


### PR DESCRIPTION
A pane the phone cannot show whole is drawn at 1:1 in the top-left corner and the reader has to go looking for the part that matters. Two rules fix the two shapes that takes: a pane **narrower** than the phone's grid is scaled up to fill the width, and a full-screen pane **bigger** than the grid opens on its cursor instead of at the origin.

Additive. Both rules are pure functions with tests, and each answers `1` / `{0,0}` — "exactly what this app does today" — for every pane they do not apply to. The gesture, dock, commit-pacing and touch-input paths from #20, #24, #28, #31 and #32 are not in the diff; checked by set-comparing every line those PRs added to `skia-terminal.tsx` against every line this one removes, the only match is a bare `useEffect(() => {`.

## What the measurements found first

I built the width matrix before writing the scaling, against my own gateway with a tmux window split three ways plus single panes at 100, 173 and 359 columns, nvim with a netrw tree in each, and ran the reads through the app's own parser.

| pane | reported | vp_rows | alt | read lines | `measured.columns` | cols used | app vs `capture-pane` |
|---|---|---|---|---|---|---|---|
| 36x40 shell | 36x40 | 40 | no | 44 | 143 | 36 | 40/40 rows **identical** |
| 36x40 nvim | 36x40 | 40 | yes | 40 | 40 | 36 | 40/40 **identical** |
| 100x30 nvim | 100x30 | 30 | yes | 32 | 100 | 100 | 30/30 **identical** |
| 173x50 nvim | 173x50 | 50 | yes | 52 | 171 | 173 | 50/50 **identical** |
| **359x82 nvim** | 359x82 | 82 | yes | 84 | **264** | 359 | 82/82 **identical** |

Three things came out of that:

**The rendering was never wrong.** The app's frame and tmux's own `capture-pane` agree line for line at every width, 359x82 included. What was wrong is the *visible region*: against a ~52x48 phone grid the reader got rows 1–48 of 82 and columns 1–52 of 359, which is the corner nvim leaves empty. Its dashboard is centred near row 41, its status line is row 82, and the file tree in this lab sits at column 184.

**Scaling cannot fix the wide case, so this does not try.** Fitting 359 columns into 52 is 0.14x — a 1.8pt font — and fitting both axes is the same 0.14x. A pane bigger than the phone can only be read by moving around it, so the question worth answering is where to start.

**The measured fallback is wrong on both backends, in opposite directions.** tmux right-trims its rows, so `measured.columns` for the 359-column pane is 264 — a 95-column error — but it is never used, because tmux reports `width`. herdr right-pads, so its measured value happens to be the pane's real width, and that is the only reason the herdr path has been correct: padding, not reporting. Neither backend is safe on the other's habit, which is why this PR takes the grid from the pane object whenever there is one.

## The rules

Both live in `src/lib/terminal-text-size.ts`, next to `terminalScaleOnPaneOpen`.

**`terminalFitToWidthScale(phoneColumns, paneColumns)`** — `min(phoneColumns / paneColumns, 1.6)`, and `1` for a pane as wide as the phone or wider, or one whose width the gateway never reported. Columns rather than points, because both numbers count the same cell, so their ratio is exactly the factor that puts the pane's last column where the phone's last column would have been.

**The cap is 1.6, and it is a limit on rows.** Scaling up spends vertical room in exact proportion: at 1.6 a viewport showing 44 rows shows 27, at 2.5 it shows 17. `TERMINAL_GRID_MIN_COLS` says a 20-column pane is legal, so an uncapped fit would ask for 2.5 and hand back a pane with a third of its rows — bigger, and less of the thing the reader opened. 1.6 rather than the pinch's own 1.8 because this is a *default*, and a default that opens at the outer limit of the gesture that overrides it leaves the reader nowhere to go.

**#643 is not reverted.** The old fit scaled panes *down* and gave three panes three glyph sizes under one setting. This one only ever scales *up*, only ever a pane narrower than the phone's grid, and is never written down. The three panes that made #643 — 65, 80 and 242 columns on a 45-column phone — are all wider than the phone, so all three still open at 1 and the indicator still reads 100% for each.

**`terminalOpenView({...})`** — which cell of the pane sits at the top-left when it opens. Only a pane that owns the screen is placed: a shell is a stream, its newest line is the point, and the canvas already rests it at the bottom. A pane that fits is not placed either. Otherwise the cursor, centred and clamped inside the pane; and bottom-left when no cursor is reported, because that is where nvim's status and message line, a shell's prompt and an agent's newest output all live.

**A remembered pinch still wins, and a fit is never stored.** That is the whole answer to "does a pane's column count changing reset a remembered scale": the fit is recomputed from the pane's current width every open, so a reader who never pinched is re-fitted the moment tmux reports a new width, with nothing to invalidate; a reader who did pinch has an entry, and it survives the re-split, because it was a statement about how big they wanted this pane's text and not about how wide the pane happened to be. `terminalScaleOnScreenLeave` is what keeps that true — handed the same default, it drops rather than stores a scale that has come back to it.

## Grid authority

`parseTerminalSnapshot` takes `rows` as well as `columns`, and rows is a **floor, never a truncation**, applied once in `buildTerminalFrame` so the fast path and the emulator produce identical frames. Handed to the parse only for a program that owns the screen — a shell's frame is a tail of a stream and has no height to be wrong about. Absent, everything falls back to the measured values exactly as now.

Against gateway v0.8.1, measured on both backends: tmux fills in `width`, `height`, `alternate_on`, `cursor_x` and `cursor_y`; herdr fills in `height` and leaves the other four `null`. Every one is read as optional, and both shapes are pinned by tests.

**One bug this found by reading rather than by running:** `numberField` answers `0` for an absent field. Read through it, `cursor_x` would have been `0` on every pane of every gateway that does not send it, so every editor would have claimed a cursor in its top-left corner and been placed there — the exact position this change exists to stop. Hence `optionalNumberField`, where absent and zero are different answers.

## Three bugs the device pass found

None of these were visible from the tests, and all three are why the diff is bigger than the two rules.

1. **The placement was clamped away.** Applied in the switch render, the pan clamp is built from the frame's width — and on that render the frame is still the *outgoing* pane's. A 359-column pane placed at column 158 opened at column 1. Both axes now land on the first frame that belongs to the new pane.
2. **The one-shot lost races.** Armed as a shared value in the switch render and cleared by whichever applied frame got there first, the arm ran and the frame that consumed it read 0. It is now a ref keyed to the opening: the switch render arms it, the first frame carrying the pane's own rows spends it, and every frame after that leaves the transform alone — so a reader who pans is never argued with.
3. **The placement counted at the wrong scale.** It was computed against the *fit*, but a pane opens at its remembered pinch when it has one. An emulator carrying a stale entry for a reused pane id opened this pane at 1.44x while the placement still counted 52 columns instead of the 36 actually on the glass — a third of a screen out. There is now one opening scale, and both the canvas and the placement use it.

## Verified on device

Own gateway v0.8.1 on its own port, own state and config dirs, own tmux socket, own herdr instance isolated by `XDG_CONFIG_HOME`. The maintainer's gateway and herdr were never touched.

**iOS (`muqun-ios`, iPhone 17 Pro, 402pt, grid 52x48)** — branch against `main`, same lab, same panes:

| pane | on `main` | on this branch |
|---|---|---|
| 36-col shell | text stops at ~69% of the width, right third empty | fills the width, box-drawing and the 36-char ruler aligned edge to edge |
| 36-col nvim | same, at 1:1 | fills the width; both nvim windows visible across all 36 columns |
| 73-col shell | runs off the right edge, pans | **unchanged** |
| 359x82 nvim | columns 1–48, rows 1–41 — the empty corner | opens on the netrw tree at the cursor, columns ~161–208, cursor line highlighted |

**Android (`muqun_android`, 411dp, grid 52x48)** — the 359x82 pane opens on the same cursor region, banner and full file listing, cursor line `../` highlighted. One false alarm worth recording: the first opens after pairing rendered the banner and then blank rows. That was a stale window in the pane cache from the first partial read after pairing, not this change — a relaunch, which clears the in-memory cache, renders it correctly and repeatedly.

Scrollback follow is untouched for shells (they are never placed), and a placed pane releases follow exactly the way a reader scrolling up does, so the Latest pill, the clamps and re-engagement behave as they already do.

**`dumpsys gfxinfo dev.osuki.muqun`**, reset before each run, three switches into the 359-column pane and back per run:

| arm | run | frames | janky | p50 | p90 | p95 |
|---|---|---|---|---|---|---|
| `main` | 1 | 547 | 10.42% | 17 ms | 27 ms | 32 ms |
| `main` | 2 | 549 | 9.84% | 17 ms | 26 ms | 32 ms |
| this branch | 1 | 547 | 11.88% | 17 ms | 29 ms | 34 ms |
| this branch | 2 | 539 | 10.76% | 17 ms | 22 ms | 32 ms |

Both runs per arm are reported rather than the flattering one. p50 is identical at one frame, the p90s cross over between runs (this branch has both the worst and the best), and the janky share sits at 10–12% on both. The scale is a transform on an already-recorded picture — nothing here re-parses, re-records or re-measures — so there was no reason to expect a cost, and none is visible.

## Gates

```
npx tsc --noEmit     clean
bun run lint         oxlint --deny-warnings, clean
bun run format:check All matched files use the correct format.
bun test src         2772 pass, 2 skip, 0 fail (104 files)
```

Rebased on `origin/main` at fb13541, after #37, #38 and #39. #39 matters to this change and improves it: an alternate-screen pane now draws only its `viewport_rows`, so the placement counts from the pane's true row 0 rather than from two rows of leaked main-screen scrollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
