### PR TITLE
fix(terminal): the scrollback comes back the moment a program leaves the screen

### DIFF
--- a/src/components/server-terminal-workspace.tsx
+++ b/src/components/server-terminal-workspace.tsx
@@ -148,6 +148,7 @@ import {
   panePrefetchAccepted,
   panePrefetchTargets,
   paneReadIsCurrent,
+  paneWindowWorthFiling,
   recallPaneWindow,
   rememberPaneWindow,
   retainPanes,
@@ -1777,8 +1778,17 @@ export function ServerTerminalWorkspace({
     // `output` is the render's own value, which on this render is still the
     // outgoing pane's window; the depth beside it is read from the refs, which
     // no post-commit write has reached yet either.
+    //
+    // A program leaving the alternate screen is a switch with the same pane on
+    // both sides, and its last frame is not filed: the cache holds one window
+    // per pane, and that slot is holding the scrollback filed on the way in,
+    // which the recall below is about to ask for. See `paneWindowWorthFiling`.
+    // The shape is read from `heldShapeRef`, not `outputShape` -- on this
+    // render the latter already says `main`.
     const held: PaneWindow | null =
-      leaving && output
+      leaving &&
+      output &&
+      paneWindowWorthFiling(leaving, selection.paneId, heldShapeRef.current.endsWith(':alt'))
         ? {
             shape: heldShapeRef.current,
             output,

--- a/src/lib/__tests__/pane-cache.test.ts
+++ b/src/lib/__tests__/pane-cache.test.ts
@@ -22,10 +22,12 @@ import {
   panePrefetchTargets,
   paneReadIsCurrent,
   paneWindowIsCurrent,
+  paneWindowWorthFiling,
   recallPaneWindow,
   rememberPaneWindow,
   retainPanes,
 } from '../pane-cache';
+import { foldPaneRead } from '../../terminal/history';
 
 /** The shape every window in these tests is of, unless one is being contrasted with another. */
 const ANSI = 'ansi:recent-unwrapped';
@@ -94,6 +96,91 @@ describe('remembering and recalling', () => {
     cache = rememberPaneWindow(cache, 'p2', windowOf('b'));
     recallPaneWindow(cache, 'p1', ANSI);
     expect(paneIdsOf(cache)).toEqual(['p2', 'p1']);
+  });
+});
+
+// A pane is left twice when a program takes the screen: once on the way into
+// the alternate screen and once on the way out, with the same pane id on both
+// sides. The cache holds one window per pane, so what is filed on the way out
+// decides whether the scrollback filed on the way in is still there to hand
+// back. Filing the program's last frame was the blank after `less` quit.
+describe('leaving the alternate screen', () => {
+  const MAIN = `${ANSI}:main`;
+  const ALT = `${ANSI}:alt`;
+  const rows = (from: number, to: number) =>
+    Array.from({ length: to - from }, (_, index) => String(from + index)).join('\n');
+
+  /** The switch block's rule, driven the way the workspace drives it. */
+  function turn(
+    cache: ReturnType<typeof rememberPaneWindow>,
+    leaving: string,
+    arriving: string,
+    held: PaneWindow
+  ) {
+    return paneWindowWorthFiling(leaving, arriving, held.shape.endsWith(':alt'))
+      ? rememberPaneWindow(cache, leaving, held)
+      : cache;
+  }
+
+  test('the scrollback filed on the way in comes back whole on the way out', () => {
+    const scrollback = windowOf(rows(0, 480), 3, {
+      shape: MAIN,
+      lineLimit: 480,
+      canLoadEarlier: true,
+      earlierRows: 480,
+      lastRead: { start: 100, end: 580 },
+    });
+    // In: the shell's window is filed under the same pane id.
+    let cache = turn(emptyPaneCache, 'p1', 'p1', scrollback);
+    expect(recallPaneWindow(cache, 'p1', ALT)).toBeNull();
+    // Out: the program's last frame is not, so the scrollback is still there.
+    const frame = windowOf('~\n~\n:q', 9, { shape: ALT, lineLimit: 240, earlierRows: 3 });
+    cache = turn(cache, 'p1', 'p1', frame);
+    expect(cache.entries).toHaveLength(1);
+    expect(recallPaneWindow(cache, 'p1', MAIN)).toEqual(scrollback);
+  });
+
+  test('the way in still files the scrollback, whatever the pane held before', () => {
+    const cache = turn(emptyPaneCache, 'p1', 'p1', windowOf('$ less notes', 1, { shape: MAIN }));
+    expect(recallPaneWindow(cache, 'p1', MAIN)?.output).toBe('$ less notes');
+  });
+
+  // The #33 hit: leave an editor pane for another pane and come back to it
+  // still running, and its frame is painted from the cache.
+  test('a real switch away from an editor pane still files its frame', () => {
+    let cache = turn(emptyPaneCache, 'p1', 'p1', windowOf('$ nvim', 1, { shape: MAIN }));
+    const frame = windowOf('~\n~\n-- INSERT --', 4, { shape: ALT });
+    cache = turn(cache, 'p1', 'p2', frame);
+    expect(recallPaneWindow(cache, 'p1', ALT)).toEqual(frame);
+    expect(recallPaneWindow(cache, 'p1', MAIN)).toBeNull();
+  });
+
+  // What the refresh that follows the restore does with rows the shell printed
+  // while the program had the screen. The window comes back exactly as it was
+  // filed, and the fold is the same one door -- so the tail is stitched when
+  // the read reaches back into the window, and goes on top when it does not.
+  test('rows printed behind the program are folded on top of the restored window, once', () => {
+    const scrollback = windowOf(rows(0, 480), 3, { shape: MAIN, lineLimit: 480 });
+    let cache = turn(emptyPaneCache, 'p1', 'p1', scrollback);
+    cache = turn(cache, 'p1', 'p1', windowOf('~\n:q', 5, { shape: ALT }));
+    const restored = recallPaneWindow(cache, 'p1', MAIN);
+    expect(restored).not.toBeNull();
+
+    // More than a page (240) printed, and the refresh at the restored depth
+    // still reaches back into what the window holds.
+    const stitched = foldPaneRead(restored!.output, rows(300, 780), 'refresh', restored!.lineLimit);
+    expect(stitched).toBe(rows(300, 780));
+
+    // So much printed that the refresh shares nothing with the window: it is
+    // the newest thing there is and goes on top, bounded to the depth held.
+    const outran = foldPaneRead(restored!.output, rows(600, 1080), 'refresh', restored!.lineLimit);
+    expect(outran).toBe(rows(600, 1080));
+
+    for (const window of [stitched, outran]) {
+      const numbers = window.split('\n').map(Number);
+      expect(new Set(numbers).size).toBe(numbers.length);
+      expect(numbers).toEqual([...numbers].sort((a, b) => a - b));
+    }
   });
 });
 

--- a/src/lib/pane-cache.ts
+++ b/src/lib/pane-cache.ts
@@ -189,6 +189,33 @@ export function rememberPaneWindow(
 }
 
 /**
+ * Whether the window a switch leaves behind is worth filing at all.
+ *
+ * A pane is left in two ways, and the cache holds one window per pane. Moving
+ * to another pane is the plain case: whatever was on screen is worth having
+ * back, an editor's frame included -- the reader may return to it still
+ * running, and that is the hit the cache was built for.
+ *
+ * The other way is the pane staying selected while its shape turns. A program
+ * takes the alternate screen and the shell's scrollback is filed on the way
+ * in, exactly as a switch would file it. On the way out the program's last
+ * frame is not worth filing, and filing it is harmful: one window per pane
+ * means it replaces the scrollback filed on the way in, so the recall that
+ * follows, asked for the main screen, misses on shape and the reader sees a
+ * blank until the next poll -- for a window that was in the cache a moment
+ * ago. The frame belongs to a program that has exited and nothing will ask
+ * for it again, so it is left unfiled and the scrollback survives to be
+ * handed back whole.
+ */
+export function paneWindowWorthFiling(
+  leavingPaneId: string,
+  arrivingPaneId: string,
+  heldOwnsScreen: boolean
+): boolean {
+  return leavingPaneId !== arrivingPaneId || !heldOwnsScreen;
+}
+
+/**
  * Store a window fetched to warm a pane nobody has asked for yet.
  *
  * {@link rememberPaneWindow} with the one rule a warm-up has and a real read


### PR DESCRIPTION
Regression from #39: after a full-screen program (`less`, nvim) exits, the pane shows the loading mark until the next poll brings the shell's history back.

## Root cause

`outputShape` carries `alt`/`main` since #39, and `paneSwitched` keys on `paneId|outputShape`, so leaving the alternate screen runs the pane-switch block with the same pane id on both sides. On the way out the block filed the program's last frame (`held`, shape `...:alt`) with `rememberPaneWindow`, which keeps one entry per pane id -- so that write replaced the `:main` window filed on the way in. `recallPaneWindow` then missed on shape, the block did `setOutput('')` and `setPaneRevision(-1)`, the layout effect bumped `outputRequestIdRef` and discarded any read in flight, and only the 1 s poll repopulated the pane.

## Fix

One rule, `paneWindowWorthFiling(leavingPaneId, arrivingPaneId, heldOwnsScreen)`: a window is filed on a real pane switch (any shape, so a switch away from a running editor still caches its frame -- the #33 hit) and on the way *into* the alternate screen; it is not filed when the pane is unchanged and the held window is an alternate-screen frame. The program that drew that frame has exited and nothing will ask for it again, so the `:main` entry survives and the recall hits in the same render, restoring output, line limit, `canLoadEarlier`, earlier rows, last read and revision together.

Diff scope, deliberately narrow:

- `src/lib/pane-cache.ts`: the new pure rule.
- `src/components/server-terminal-workspace.tsx`: the `held` condition in the switch block calls it with `heldShapeRef.current.endsWith(':alt')`; nothing else in the block, the layout effect or the read effect changes.
- `src/lib/__tests__/pane-cache.test.ts`: four tests.

The optional immediate refresh on the flip (adding `outputShape` to the read effect's deps) is **not** in this PR. With the recall hitting, the window is on screen on the switch render and the 1 s poll folds the shell's new prompt in on the next tick, which is the latency the pane had before #39; there is no workspace-level harness to prove the extra dependency safe, so it stays out.

## Tests

Red before the rule, green after:

- the scrollback filed on the way in comes back whole on the way out (file `:main`, turn to `:alt`, turn back, recall `:main` is the original window, depth and all);
- the way in still files the scrollback;
- a real switch away from an editor pane still files its frame, and `:main` is gone for that pane as before;
- rows printed behind the program are folded on top of the restored window once: a refresh reaching back into the window is stitched, a refresh that shares nothing with it goes on top bounded to the depth held, and in both cases no row is duplicated or reordered.

## Gates

```
tsc --noEmit      clean
oxlint            --deny-warnings, clean
oxfmt --check     All matched files use the correct format.
bun test src      2770 pass, 2 skip, 0 fail
```

## On device

iOS simulator (iPhone 17, iOS 26.5), this branch loaded from its own Metro, against a private gateway (0.8.1, own HOME, own port) driving a private tmux server (`tmux -L`), 100x40 pane. The user's gateway on :23847 and the default tmux socket were not touched.

How the flip was triggered: `alternate_on` is only read on `refreshData`, so for both exits I simply waited for the 12 s slow poll (the shell's screen shows as an alternate-screen frame until then, as before). For the switch test the second tmux window's structural event did it.

- `cat` of 400 numbered lines, `less` on the file, `q`. Recorded the simulator through the exit and stepped the frames: on the frame the flip lands the history is on screen; no loading mark in any frame. Bottom rows `lab$ less numbered.txt` / `lab$` match `tmux capture-pane -J -S -`.
- After the exit, two upward pans page cleanly through 377..336 and 350..309, contiguous, with no trace of the `less` frame in the history.
- nvim on the same file, `:q!`. Same result on the flip frame: the window is back, no loading mark. Bottom rows `lab$ nvim numbered.txt` / `lab$` match the capture.
- Before/after on the same lab, nvim exit: `main` @ 18917f6 shows the loading mark on the flip frame and paints the window from the poll one to two frames later; this branch paints the window on the flip frame itself.
- nvim running, switched to a second pane (shell) through the navigator and back: the nvim frame is on screen as the sheet dismisses, no loading mark -- the #33 hit is intact.

One thing seen on both arms and left alone: after nvim exits, the view lands at the top of the restored window with the Latest pill showing, because #40's open placement released `followOutput` on the way into the editor and nothing re-engages it on the way out. Same before and after this change; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
