### PR TITLE
fix(terminal): the shell follows its output again when a program hands the screen back

### DIFF
--- a/src/components/skia-terminal.tsx
+++ b/src/components/skia-terminal.tsx
@@ -56,7 +56,7 @@ import { PressableScale } from '@/components/pressable-scale';
 import { useCoalescedValue } from '@/hooks/use-coalesced-value';
 import { useFreezeGate, useFrozenValue } from '@/hooks/use-frozen-value';
 import { useLatestRef, useResetSignal } from '@/hooks/use-render-refs';
-import { latestPillVisible } from '@/lib/dock-presentation';
+import { followsOutputOnScreenRelease, latestPillVisible } from '@/lib/dock-presentation';
 import { feedback } from '@/lib/feedback';
 import { fadeOut, timing, zoomIn, zoomOut } from '@/lib/motion';
 import { isSafeExternalLink } from '@/lib/safe-link';
@@ -1090,6 +1090,29 @@ export function SkiaTerminal({
     // copy that pane's text.
     clearSelection();
   }, [clearSelection, followOutput, pullDistance, snapToBottomNext, terminalId, translateY]);
+
+  // The reset above, for the one switch that keeps the terminal id: a program
+  // handing the screen back. The placement on the way into an editor releases
+  // `followOutput` to hold its position (see the applied-frame effect below),
+  // and nothing on the way out took it back, so `:q!` handed the shell's
+  // scrollback to a canvas still parked where the editor had been placed --
+  // at the top of the window, under a Latest pill. `followsOutputOnScreenRelease`
+  // is the whole rule: the same pane, owning the screen last render and not
+  // this one. The way in, a real switch and a reader scrolled up in a shell
+  // all answer false there and are left exactly as they were.
+  //
+  // `snapToBottomNext` rather than an ease, as on a switch: the window under
+  // the canvas is changing from the editor's frame to the scrollback, and the
+  // prompt should simply be there rather than scroll into place.
+  const screenTenancyRef = useRef({ terminalId, ownsScreen });
+  useEffect(() => {
+    const previous = screenTenancyRef.current;
+    const next = { terminalId, ownsScreen };
+    screenTenancyRef.current = next;
+    if (!followsOutputOnScreenRelease(previous, next)) return;
+    followOutput.value = true;
+    snapToBottomNext.value = true;
+  }, [followOutput, ownsScreen, snapToBottomNext, terminalId]);
 
   // How many columns this phone would draw into this viewport at this font --
   // the same function, on the same constants, that sizes an SSH PTY to this

--- a/src/lib/__tests__/dock-presentation.test.ts
+++ b/src/lib/__tests__/dock-presentation.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, test } from 'bun:test';
 
 import {
   dockPresentation,
+  followsOutputOnScreenRelease,
   latestPillVisible,
   type DockPresentationInput,
 } from '@/lib/dock-presentation';
@@ -484,5 +485,31 @@ describe('the jump-to-latest pill', () => {
         expect(latestPillVisible({ following, selecting, ownsScreen: true })).toBe(false);
       }
     }
+  });
+});
+
+describe('followsOutputOnScreenRelease', () => {
+  const editor = { terminalId: '%1', ownsScreen: true };
+  const shell = { terminalId: '%1', ownsScreen: false };
+
+  test('the pane that gave the screen back follows its output again', () => {
+    // nvim's `:q!` puts the shell's scrollback back on a canvas the editor's
+    // placement had left unfollowed, and the prompt belongs at the bottom.
+    expect(followsOutputOnScreenRelease(editor, shell)).toBe(true);
+  });
+
+  test("not on the way in, which is the placement's business", () => {
+    expect(followsOutputOnScreenRelease(shell, editor)).toBe(false);
+  });
+
+  test('not across a pane switch, which resets the canvas on its own', () => {
+    expect(followsOutputOnScreenRelease(editor, { ...shell, terminalId: '%2' })).toBe(false);
+    expect(followsOutputOnScreenRelease({ ...editor, terminalId: '%2' }, shell)).toBe(false);
+  });
+
+  test('never while nothing about the screen changed', () => {
+    // A reader scrolled up in a shell is never hauled back by a re-render.
+    expect(followsOutputOnScreenRelease(shell, shell)).toBe(false);
+    expect(followsOutputOnScreenRelease(editor, editor)).toBe(false);
   });
 });

--- a/src/lib/dock-presentation.ts
+++ b/src/lib/dock-presentation.ts
@@ -332,3 +332,36 @@ export interface LatestPillInput {
 export function latestPillVisible({ following, selecting, ownsScreen }: LatestPillInput): boolean {
   return !following && !selecting && !ownsScreen;
 }
+
+/** What the canvas knows about the pane it is resting on, on one render. */
+export interface PaneScreenTenancy {
+  /** The pane the canvas is showing. */
+  terminalId: string;
+  /** A full-screen program owns it, in the sense of {@link LatestPillInput}. */
+  ownsScreen: boolean;
+}
+
+/**
+ * Whether the canvas goes back to following the output between two renders.
+ *
+ * A pane bigger than the phone is placed on the way into an editor -- put in
+ * front of the cursor rather than at its resting anchor -- and to hold that
+ * placement the canvas stops following, exactly as it would for a reader who
+ * had scrolled up. That is the right state for the editor and the wrong one
+ * for what comes after it: `:q!` hands the shell's scrollback back to a canvas
+ * that is still unfollowed, so the prompt the reader just came back to sits
+ * off the bottom of a window parked at its top, under a "Latest" pill that
+ * offers the way down. Measured on device, before and after #46.
+ *
+ * So the one transition that undoes the release is the reverse of the one
+ * that made it: the same pane, owning the screen on the last render and not on
+ * this one. Nothing else qualifies. The way in stays the placement's business;
+ * a pane switch already resets the canvas on the terminal id and is left to it;
+ * and a shell that stays a shell never has its reader's scroll argued with.
+ */
+export function followsOutputOnScreenRelease(
+  previous: PaneScreenTenancy,
+  next: PaneScreenTenancy
+): boolean {
+  return previous.terminalId === next.terminalId && previous.ownsScreen && !next.ownsScreen;
+}


### PR DESCRIPTION
## What

After nvim exits (`:q!`), the restored main-screen window now rests at the bottom, on the prompt, with no "Latest" pill -- the same state as if the reader had tapped Latest.

## Why

PR #40's open placement puts a pane bigger than the phone in front of the cursor on the way into an editor, and to hold that placement the canvas releases `followOutput` (the applied-frame effect in `skia-terminal.tsx`). Nothing re-engaged it on the way out: the canvas resets on a `terminalId` change and on a Latest tap, and an alternate-screen exit is neither -- same pane, same id, only the shape turns from `:alt` back to `:main`. So `:q!` handed the shell's scrollback (restored whole since #46) to a canvas still parked where the editor had been placed, which is the top of the restored window, under a pill offering the way down. Reproduced on device before and after #46, as reported.

## Fix

- `src/lib/dock-presentation.ts`: `followsOutputOnScreenRelease(previous, next)` -- true only when the same pane owned the screen on the last render and does not on this one. The way in, a pane switch and a shell that stays a shell all answer false.
- `src/components/skia-terminal.tsx`: one effect beside the pane-switch reset that keeps the last `{ terminalId, ownsScreen }` pair and, when the rule fires, sets `followOutput = true` and `snapToBottomNext = true`, so the first restored frame snaps to the bottom exactly as a switch does. Nothing on the way in, on a real switch, or while the reader is scrolled up in a shell is touched.
- `src/lib/__tests__/dock-presentation.test.ts`: the rule, red without it.

No other files changed.

## Checks

- `npx tsc --noEmit`, `bun run lint`, `bun run format:check`, `bun test src` (2776 tests, 0 fail) -- all green.
- Not run: `bash scripts/e2e.sh` (maestro gate; the shared devices were held by other sessions for most of this work, and the change is in the terminal canvas rather than a screen the flows cover).

## Device verification

iPhone 17 simulator (`muqun-ios`), this branch's bundle from a private Metro, a private `muqun-gateway` on a private port with its own `tmux -L` server, one 200x60 tmux window, 400 numbered lines printed in the pane.

1. `nvim`, then `:q!`, wait for the flip: the view is at the bottom, the prompt visible, no Latest pill. On the pre-fix canvas code (same session, same flow) the window came back parked around line 170 of 400 with the Latest pill showing.
2. A drag up in the plain shell pane shows the Latest pill as before; tapping it returns to the bottom and the pill goes.
3. `nvim` in one pane, switch to a second pane and back, `:q!`: same result as 1 -- bottom, prompt, no pill.

The main-screen scrollback read and its cache (#46) are untouched; the pane came back with its 400 lines intact in every run.
