### PR TITLE
fix(markdown): math follows the theme instead of the renderer's light defaults

### DIFF
--- a/src/lib/__tests__/markdown-style.test.ts
+++ b/src/lib/__tests__/markdown-style.test.ts
@@ -1,0 +1,55 @@
+// The markdown theme, checked against every palette the app ships.
+//
+// The renderer paints its own defaults for any key the style leaves out, and
+// those defaults were mixed for a light page: a display formula came out on a
+// light grey slab in the dark theme, and inline math in a grey that barely
+// read. What is pinned here is the rule that would have caught it -- every
+// fill and every ink in the style comes from the palette it was built from,
+// and a formula sits on the same fill as a code block.
+import * as bunTest from 'bun:test';
+
+import { THEME_PACKS } from '@/constants/theme-packs';
+
+const { describe, expect, test } = bunTest;
+// `mock` is missing from the bun:test typings this project resolves, but the
+// runtime has it. The style reads one constant off React Native, which cannot
+// load in a bare bun process.
+const { module: mockModule } = (
+  bunTest as unknown as { mock: { module: (id: string, factory: () => unknown) => void } }
+).mock;
+
+mockModule('react-native', () => ({
+  Platform: { OS: 'ios', Version: '17.0' },
+  StyleSheet: { hairlineWidth: 0.5 },
+}));
+
+const { createMarkdownStyle } = await import('../markdown-style');
+
+const MODES = ['light', 'dark'] as const;
+
+describe('createMarkdownStyle', () => {
+  for (const pack of THEME_PACKS) {
+    for (const mode of MODES) {
+      const colors = pack[mode].colors;
+      const style = createMarkdownStyle(colors);
+
+      test(`${pack.id} ${mode}: a display formula sits on the code-block fill`, () => {
+        expect(style.math?.backgroundColor).toBe(colors.surfaceRaised);
+        expect(style.math?.backgroundColor).toBe(style.codeBlock?.backgroundColor);
+      });
+
+      test(`${pack.id} ${mode}: math is inked with the body colour`, () => {
+        expect(style.math?.color).toBe(colors.text);
+        expect(style.inlineMath?.color).toBe(colors.text);
+        expect(style.math?.color).toBe(style.codeBlock?.color);
+      });
+
+      test(`${pack.id} ${mode}: a formula keeps the renderer's own size and alignment`, () => {
+        // Only the colours are overridden: the light theme has always shown the
+        // renderer's defaults for the rest, and this keeps it that way.
+        expect(Object.keys(style.math ?? {}).sort()).toEqual(['backgroundColor', 'color']);
+        expect(Object.keys(style.inlineMath ?? {})).toEqual(['color']);
+      });
+    }
+  }
+});

--- a/src/lib/markdown-style.ts
+++ b/src/lib/markdown-style.ts
@@ -113,6 +113,17 @@ export function createMarkdownStyle(colors: Colors): MarkdownStyle {
       marginBottom: 12,
       syntaxColors: syntaxColors(colors),
     },
+    // A formula is the one other block the renderer paints a fill behind, and
+    // without these two it paints its own: a light grey slab under the display
+    // block and a light-page grey for the inline span, in both themes. It sits
+    // on the code-block fill and is inked with the body colour for the same
+    // reason a code block is. Size, padding and alignment stay the renderer's
+    // defaults, which is what the light theme has always shown.
+    math: {
+      color: text,
+      backgroundColor: codeBackground,
+    },
+    inlineMath: { color: text },
     thematicBreak: { color: border, height: StyleSheet.hairlineWidth, marginBottom: 12 },
     table: {
       ...base,


### PR DESCRIPTION
## What

`createMarkdownStyle` set no `math` / `inlineMath` keys, so `react-native-enriched-markdown` painted its own light-page defaults for both: a `#F3F4F6` slab behind a `$$` display block and a grey ink for `$x^2$` inline spans. Right by accident on the light theme; a bright patch with unreadable inline math on the dark one.

The two keys are now derived the way the neighbouring code block is: the fill from the theme's `surfaceRaised` (the code-block fill), the ink from the theme's `text`. Size, padding and alignment stay at the renderer's defaults, so the light theme keeps its look apart from the formula fill now matching the code block beside it.

`src/lib/__tests__/markdown-style.test.ts` walks every theme pack in both modes and pins the rule: a formula sits on the code-block fill, is inked with the body colour, and only the colours are overridden.

## Verified

- `npx tsc --noEmit`, `bun run lint`, `bun run format:check`, `bun test src` (2916 pass, 2 skip, 0 fail) all green.
- On one device (the Android emulator, `sdk_gphone16k_arm64`, debug build served from this branch's Metro): opened the demo workspace, the files sheet, `dark-mode.md` (which carries a `$$` block and an inline `$...$` span).
  - Dark theme: the display formula sits on the raised surface (`#131B26`) with white ink; inline math is white and reads at body contrast. Before the change the same screen showed a white slab and grey inline math.
  - Light theme (switched in Settings > Color mode): the formula sits on the warm raised fill (`#ECE7DF`), the same fill as the table header and inline code beside it, with dark ink; inline math is dark. Layout, size and centring unchanged.
- iOS was not re-verified on a device: both booted simulators were bound to other agents' sessions for the whole window. The iOS renderer reads `math.backgroundColor` / `inlineMath.color` through the same style props (`ios/utils/StylePropsUtils.h` in the library), so the keys reach it the same way.
