### PR TITLE
perf(simfarm): frames bypass React and the socket outlives the screen

### DIFF
--- a/src/app/commands.tsx
+++ b/src/app/commands.tsx
@@ -99,8 +99,12 @@ import {
 import { describeGatewayFailure } from '@/lib/network-error';
 import { quickActionAvailability } from '@/lib/quick-actions';
 import { responsiveWorkspaceLayout } from '@/lib/responsive-layout';
+import { SIMFARM_DEFAULT_PORT, simfarmSocketUrl } from '@/lib/simfarm';
+import { warmSimfarm } from '@/lib/simfarm-stream';
 import { useComposerDraftStore } from '@/stores/composer-draft';
+import { useGatewayConnectionStore } from '@/stores/gateway-connection';
 import { usePanelPickerStore } from '@/stores/panel-picker';
+import { useServerSimfarm } from '@/stores/server-simfarm';
 import { useSimfarmSplit } from '@/stores/simfarm-split';
 import {
   addQuickCommand,
@@ -397,6 +401,25 @@ export default function QuickCommandsScreen() {
    */
   function openSimulatorPreview() {
     if (!available.canPreviewSimulator) return;
+    // The socket first, the screen second. Opening the preview was measured
+    // as a chain of round trips walked only after the route had mounted; the
+    // socket's part of the chain starts here, under the navigation, on the
+    // port the probe last found (or simfarm's default, which is what the
+    // probe tries first). The probe still runs and still decides -- a socket
+    // to a port with nothing on it dies on its own, and the gate the probe
+    // applies is applied here too.
+    const allowed = params.canOpenWeb === '1';
+    const opening = !(isPadLayout && simfarmSplitOpen);
+    if (opening) {
+      const gateway = useGatewayConnectionStore.getState();
+      const record =
+        gateway.records.find((entry) => entry.serverId === params.serverId) ??
+        (gateway.record?.serverId === params.serverId ? gateway.record : undefined);
+      const port = params.serverId
+        ? (useServerSimfarm.getState().byServer[params.serverId] ?? SIMFARM_DEFAULT_PORT)
+        : SIMFARM_DEFAULT_PORT;
+      warmSimfarm(simfarmSocketUrl(record?.url, port), allowed);
+    }
     // On a Pad the preview belongs beside the terminal, not over it: the whole
     // reason to want it there is watching the simulator redraw *while* the
     // agent works, and a sheet covering the terminal gives back exactly the

--- a/src/components/simfarm-preview.tsx
+++ b/src/components/simfarm-preview.tsx
@@ -14,6 +14,7 @@ import { feedback } from '@/lib/feedback';
 import { COPIED_HOLD_MS } from '@/lib/pairing-scan';
 import { SIMFARM_DEFAULT_PORT, SIMFARM_RUN_COMMAND, simfarmSocketUrl } from '@/lib/simfarm';
 import { probeSimfarm, type SimfarmProbe } from '@/lib/simfarm-client';
+import { warmSimfarm } from '@/lib/simfarm-stream';
 import { parsePort } from '@/lib/web-service';
 
 /**
@@ -122,6 +123,11 @@ export function SimfarmPreview({
     async (candidate: number) => {
       const mine = (attempt.current += 1);
       setLooking(true);
+      // The socket beside the probe rather than after it: the two are
+      // independent round trips to the same port, and a look that finds a
+      // simfarm finds the socket already open. One that finds nothing finds
+      // the socket already dead, which costs nothing.
+      warmSimfarm(simfarmSocketUrl(gatewayUrl, candidate), allowed);
       const result = await probeSimfarm(gatewayUrl, candidate, allowed);
       if (attempt.current !== mine) return;
       setAnswer({ port: candidate, probe: result });

--- a/src/components/simfarm-stage.tsx
+++ b/src/components/simfarm-stage.tsx
@@ -1,6 +1,6 @@
 import { useLingui } from '@lingui/react/macro';
 import { Input, Spinner, Text, useThemeTokens } from '@osuki-dev/ui';
-import { Canvas, Fill, Group, Image as SkiaImage, vec } from '@shopify/react-native-skia';
+import { Canvas, Fill, Group, Image as SkiaImage } from '@shopify/react-native-skia';
 import {
   ArrowLeft,
   ChevronDown,
@@ -21,6 +21,7 @@ import { KeyboardStickyView } from 'react-native-keyboard-controller';
 import Animated, {
   ReduceMotion,
   useAnimatedStyle,
+  useDerivedValue,
   useReducedMotion,
   useSharedValue,
   withTiming,
@@ -46,6 +47,7 @@ import {
   simfarmRestingOffset,
   SIMFARM_MAX_ZOOM,
   SIMFARM_MIN_ZOOM,
+  type SimfarmPlacement,
   type SimfarmPoint,
 } from '@/lib/simfarm-frame';
 import {
@@ -85,6 +87,17 @@ import { useSimfarmStream, type SimfarmStreamError } from '@/lib/simfarm-stream'
  * strip with a camera. On a screen with no cutout the band is `HANDLE_BAND`
  * tall, which is the least the handle needs; `simfarmRestingOffset` is what
  * hangs the overflow off the bottom rather than half of it back into the band.
+ *
+ * ## What React draws, and what it does not
+ *
+ * Not the frames. A frame arriving is a change to one Skia node's image and
+ * nothing else, and putting it through a render of this component cost more
+ * JS thread than everything else on the screen together -- `useSimfarmStream`
+ * has the numbers. So the image is a shared value Skia reads on the UI
+ * runtime, and so are the zoom and the pan, because a two-finger drag is the
+ * same shape of change: sixty small updates a second to where one node is
+ * drawn. What React renders here is the chrome, the picker, the composer and
+ * the states with no picture, on the events those actually change on.
  */
 export function SimfarmStage({
   url,
@@ -112,9 +125,10 @@ export function SimfarmStage({
   const stream = useSimfarmStream(url, devices);
 
   const [viewport, setViewport] = useState({ width: 0, height: 0 });
-  const [zoom, setZoom] = useState(1);
+  /** How far past the fit the reader has pinched; on the UI runtime, see `placement`. */
+  const zoom = useSharedValue(SIMFARM_MIN_ZOOM);
   /** Where the reader dragged the picture to; `null` until they have. */
-  const [offset, setOffset] = useState<SimfarmPoint | null>(null);
+  const offset = useSharedValue<SimfarmPoint | null>(null);
   const [picking, setPicking] = useState(false);
   const [typing, setTyping] = useState(false);
   const [draft, setDraft] = useState('');
@@ -200,17 +214,50 @@ export function SimfarmStage({
    * the fit is worked out against `inner` and then moved down by the band, so
    * the rectangle drawn into and the rectangle a finger is resolved against
    * are the same rectangle by construction.
+   *
+   * Worked out on the UI runtime, where the zoom and the pan live, so a pinch
+   * or a drag moves the picture without a render; a touch reads the same
+   * value back from the JS side, which is one synchronous hop and still the
+   * one rectangle.
    */
-  const placement = useMemo(() => {
+  const placement = useDerivedValue<SimfarmPlacement | null>(() => {
     if (frame === null || inner.height <= 0) return null;
     const placed = placeSimfarmFrame(
       frame,
       inner,
-      zoom,
-      offset ?? simfarmRestingOffset(frame, inner, zoom)
+      zoom.value,
+      offset.value ?? simfarmRestingOffset(frame, inner, zoom.value)
     );
     return { ...placed, y: placed.y + topBand };
-  }, [frame, inner, offset, topBand, zoom]);
+  });
+
+  /**
+   * The rectangle the frame is drawn into, which is the placement turned the
+   * way the frames arrive. A quarter turn swaps what the decoded frame
+   * measures against what the reader sees: `screen.width/height` are already
+   * the upright picture, the frames are not, so the rectangle is the
+   * placement with its sides exchanged about the same centre.
+   */
+  const rotation = screen?.rotation ?? 0;
+  const quarterTurned = rotation % 180 !== 0;
+  const picture = useDerivedValue(() => {
+    const placed = placement.value;
+    if (placed === null) return { x: 0, y: 0, width: 0, height: 0 };
+    if (!quarterTurned) {
+      return { x: placed.x, y: placed.y, width: placed.width, height: placed.height };
+    }
+    return {
+      x: placed.x + (placed.width - placed.height) / 2,
+      y: placed.y + (placed.height - placed.width) / 2,
+      width: placed.height,
+      height: placed.width,
+    };
+  });
+  const centre = useDerivedValue(() => {
+    const placed = placement.value;
+    if (placed === null) return { x: 0, y: 0 };
+    return { x: placed.x + placed.width / 2, y: placed.y + placed.height / 2 };
+  });
 
   const onLayout = useCallback((event: LayoutChangeEvent) => {
     const { width, height } = event.nativeEvent.layout;
@@ -218,22 +265,24 @@ export function SimfarmStage({
   }, []);
 
   /**
-   * How far in from the sides a touch may begin and still be an edge gesture
-   * on the device. Android keeps the outermost strip of the screen for its
-   * own back gesture, so there the device's edge starts past it -- the
-   * reasoning is with `simfarmEdgeBands`.
+   * A touch, resolved against the rectangle that was drawn.
+   *
+   * The bands are how far in from the sides a touch may begin and still be
+   * an edge gesture on the device. Android keeps the outermost strip of the
+   * screen for its own back gesture, so there the device's edge starts past
+   * it -- the reasoning is with `simfarmEdgeBands`.
    */
-  const bands = useMemo(
-    () => (placement === null ? undefined : simfarmEdgeBands(Platform.OS, placement.width)),
-    [placement]
-  );
-
   const forward = useCallback(
     (phase: SimfarmTouchPhase, x: number, y: number) => {
-      if (placement === null) return;
-      stream.touch({ phase, ...simfarmNormalizedPoint({ x, y }, placement), bands });
+      const placed = placement.value;
+      if (placed === null) return;
+      stream.touch({
+        phase,
+        ...simfarmNormalizedPoint({ x, y }, placed),
+        bands: simfarmEdgeBands(Platform.OS, placed.width),
+      });
     },
-    [bands, placement, stream]
+    [placement, stream]
   );
 
   /**
@@ -265,11 +314,11 @@ export function SimfarmStage({
     (deviceId: string) => {
       chrome.touched();
       setPicking(false);
-      setZoom(1);
-      setOffset(null);
+      zoom.value = SIMFARM_MIN_ZOOM;
+      offset.value = null;
       stream.select(deviceId);
     },
-    [chrome, stream]
+    [chrome, offset, stream, zoom]
   );
 
   /**
@@ -342,35 +391,37 @@ export function SimfarmStage({
    * The split is the whole reason a drag can be forwarded at all. If panning
    * were one finger there would be no way to scroll the app under test, and if
    * it were a mode there would be a mode to be in the wrong one of.
+   *
+   * Both stay on the UI runtime: they write the shared values the placement
+   * is derived from, and nothing else needs to hear about a drag in flight.
    */
   const shift = useMemo(
     () =>
       Gesture.Pan()
         .minPointers(2)
-        .runOnJS(true)
         .onChange((event) => {
-          if (placement === null || frame === null) return;
-          setOffset((current) => {
-            const from = current ?? simfarmRestingOffset(frame, inner, zoom);
-            return clampSimfarmOffset(placement, inner, {
-              x: from.x + event.changeX,
-              y: from.y + event.changeY,
-            });
+          'worklet';
+          const placed = placement.value;
+          if (placed === null || frame === null) return;
+          const from = offset.value ?? simfarmRestingOffset(frame, inner, zoom.value);
+          offset.value = clampSimfarmOffset(placed, inner, {
+            x: from.x + event.changeX,
+            y: from.y + event.changeY,
           });
         }),
-    [frame, inner, placement, zoom]
+    [frame, inner, offset, placement, zoom]
   );
 
   const magnify = useMemo(
     () =>
-      Gesture.Pinch()
-        .runOnJS(true)
-        .onChange((event) => {
-          setZoom((current) =>
-            Math.min(SIMFARM_MAX_ZOOM, Math.max(SIMFARM_MIN_ZOOM, current * event.scaleChange))
-          );
-        }),
-    []
+      Gesture.Pinch().onChange((event) => {
+        'worklet';
+        zoom.value = Math.min(
+          SIMFARM_MAX_ZOOM,
+          Math.max(SIMFARM_MIN_ZOOM, zoom.value * event.scaleChange)
+        );
+      }),
+    [zoom]
   );
 
   const gesture = useMemo(
@@ -492,34 +543,18 @@ export function SimfarmStage({
             landscape picture's side bands are that ground rather than a hole. */}
         <Canvas style={styles.fill} opaque>
           <Fill color={theme.colors.background} />
-          {stream.image !== null && placement !== null && screen !== null ? (
-            <Group
-              transform={[{ rotate: (screen.rotation * Math.PI) / 180 }]}
-              origin={vec(placement.x + placement.width / 2, placement.y + placement.height / 2)}>
-              <SkiaImage
-                image={stream.image}
-                // A quarter turn swaps what the decoded frame measures against
-                // what the reader sees, so the rectangle drawn into is the
-                // placement turned the same way. `screen.width/height` are
-                // already the upright picture; the frames are not.
-                x={
-                  placement.x +
-                  (screen.rotation % 180 === 0 ? 0 : (placement.width - placement.height) / 2)
-                }
-                y={
-                  placement.y +
-                  (screen.rotation % 180 === 0 ? 0 : (placement.height - placement.width) / 2)
-                }
-                width={screen.rotation % 180 === 0 ? placement.width : placement.height}
-                height={screen.rotation % 180 === 0 ? placement.height : placement.width}
-                fit="fill"
-              />
+          {/* The image, its rectangle and the turn's centre are all shared
+              values: a frame, a pinch or a drag reaches this node on the UI
+              runtime and this tree is not visited again for any of them. */}
+          {stream.hasImage && screen !== null ? (
+            <Group transform={[{ rotate: (rotation * Math.PI) / 180 }]} origin={centre}>
+              <SkiaImage image={stream.image} rect={picture} fit="fill" />
             </Group>
           ) : null}
         </Canvas>
       </GestureDetector>
 
-      {stream.image === null ? (
+      {!stream.hasImage ? (
         <View style={styles.waiting} pointerEvents="none">
           {stream.error !== null ? (
             <>
@@ -684,7 +719,7 @@ export function SimfarmStage({
             {/* A shutdown that failed while a picture is on screen has no
                 other place to say so: the waiting area above draws the error
                 only when there is nothing else to draw. */}
-            {stream.error !== null && stream.image !== null ? (
+            {stream.error !== null && stream.hasImage ? (
               <View style={[styles.pickerFoot, { borderTopColor: theme.colors.border }]}>
                 <Text
                   variant="label"

--- a/src/lib/__tests__/simfarm-frame-ring.test.ts
+++ b/src/lib/__tests__/simfarm-frame-ring.test.ts
@@ -1,0 +1,81 @@
+// The frames kept alive behind the one on screen.
+//
+// The property pinned here is ordering: a frame is handed back for disposal
+// only once `depth` newer frames have been pushed after it, and never in any
+// other order than oldest first. The defect this exists for is the picture
+// going blank while the state says `live`, which is what disposing a frame
+// before the UI runtime has recorded it looks like -- and it looks like
+// nothing else, so the arithmetic is pinned on its own.
+import { describe, expect, test } from 'bun:test';
+
+import { SimfarmFrameRing } from '@/lib/simfarm-frame-ring';
+
+describe('a ring of three', () => {
+  test('hands nothing back while it is filling', () => {
+    const ring = new SimfarmFrameRing<string>(3);
+    expect(ring.push('a')).toBeNull();
+    expect(ring.push('b')).toBeNull();
+    expect(ring.push('c')).toBeNull();
+    expect(ring.size).toBe(3);
+  });
+
+  test('hands back the frame exactly three behind the newest, oldest first', () => {
+    const ring = new SimfarmFrameRing<string>(3);
+    ring.push('a');
+    ring.push('b');
+    ring.push('c');
+    expect(ring.push('d')).toBe('a');
+    expect(ring.push('e')).toBe('b');
+    expect(ring.push('f')).toBe('c');
+    expect(ring.size).toBe(3);
+  });
+
+  test('every frame ever pushed comes back exactly once, in push order', () => {
+    const ring = new SimfarmFrameRing<number>(3);
+    const out: number[] = [];
+    for (let i = 0; i < 20; i += 1) {
+      const stale = ring.push(i);
+      if (stale !== null) out.push(stale);
+    }
+    out.push(...ring.drain());
+    expect(out).toEqual(Array.from({ length: 20 }, (_, i) => i));
+  });
+
+  test('a frame is never handed back before three newer ones were pushed', () => {
+    const ring = new SimfarmFrameRing<number>(3);
+    for (let i = 0; i < 50; i += 1) {
+      const stale = ring.push(i);
+      if (stale !== null) expect(i - stale).toBe(3);
+    }
+  });
+});
+
+describe('draining', () => {
+  test('returns everything held, oldest first, and holds nothing after', () => {
+    const ring = new SimfarmFrameRing<string>(3);
+    ring.push('a');
+    ring.push('b');
+    expect(ring.drain()).toEqual(['a', 'b']);
+    expect(ring.size).toBe(0);
+    expect(ring.drain()).toEqual([]);
+  });
+
+  test('a drained ring fills again from empty', () => {
+    const ring = new SimfarmFrameRing<string>(2);
+    ring.push('a');
+    ring.push('b');
+    ring.drain();
+    expect(ring.push('c')).toBeNull();
+    expect(ring.push('d')).toBeNull();
+    expect(ring.push('e')).toBe('c');
+  });
+});
+
+describe('the depth', () => {
+  test('one is the least a ring may keep', () => {
+    const ring = new SimfarmFrameRing<string>(1);
+    expect(ring.push('a')).toBeNull();
+    expect(ring.push('b')).toBe('a');
+    expect(() => new SimfarmFrameRing<string>(0)).toThrow(/at least one frame/);
+  });
+});

--- a/src/lib/__tests__/simfarm-session-cache.test.ts
+++ b/src/lib/__tests__/simfarm-session-cache.test.ts
@@ -1,0 +1,284 @@
+// The sockets kept open after the preview closes.
+//
+// What is pinned is the lifetime: a released session survives for one grace
+// period and is handed back whole -- open, attached, last frame and all -- to
+// a screen that returns inside it; it is closed when the period runs out,
+// when the app goes away, when the gateway changes, when another machine's
+// session is opened, and the moment its transport drops. The socket is a
+// fake that records what happened to it, the clock is a fake that fires when
+// told, like the session's own tests.
+import { describe, expect, test } from 'bun:test';
+
+import { parseSimfarmDevices } from '@/lib/simfarm';
+import { SIMFARM_CHANNEL, SIMFARM_VIDEO_TAG } from '@/lib/simfarm-protocol';
+import { SimfarmSession, type SimfarmTransport } from '@/lib/simfarm-session';
+import { SimfarmSessionCache } from '@/lib/simfarm-session-cache';
+
+const RUNNING = {
+  id: 'ios:running',
+  name: 'iPhone 17 (iOS 26.5)',
+  state: 'booted',
+  screen: { width: 1206, height: 2622, scale: 3 },
+  capabilities: { video: ['h264', 'jpeg'], text: true, buttons: ['home'], boot: true },
+};
+
+const URL_A = 'ws://mac.tailnet:8801/v1';
+const URL_B = 'ws://other.tailnet:8801/v1';
+
+class FakeSocket implements SimfarmTransport {
+  readyState = 1;
+  readonly sent: Uint8Array[] = [];
+  closed = false;
+  constructor(readonly session: SimfarmSession) {}
+  send(data: Uint8Array): void {
+    this.sent.push(data);
+  }
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    // As a real socket does: closing reports back as dropped.
+    this.session.dropped();
+  }
+  requests(): Record<string, unknown>[] {
+    return this.sent
+      .filter((bytes) => bytes[0] === SIMFARM_CHANNEL.CONTROL)
+      .map((bytes) => JSON.parse(Buffer.from(bytes.subarray(1)).toString('utf8')));
+  }
+}
+
+class FakeClock {
+  private readonly pending = new Map<number, () => void>();
+  private next = 1;
+  schedule = (run: () => void, _ms: number): (() => void) => {
+    const id = this.next++;
+    this.pending.set(id, run);
+    return () => {
+      this.pending.delete(id);
+    };
+  };
+  armed(): number {
+    return this.pending.size;
+  }
+  elapse(): void {
+    const due = [...this.pending.values()];
+    this.pending.clear();
+    for (const run of due) run();
+  }
+}
+
+function json(channel: number, body: unknown): ArrayBuffer {
+  return Uint8Array.from([channel, ...Buffer.from(JSON.stringify(body), 'utf8')]).buffer;
+}
+const devicesEvent = (devices: unknown[]) =>
+  json(SIMFARM_CHANNEL.EVENT, { ev: 'devices', devices });
+const reply = (body: Record<string, unknown>) => json(SIMFARM_CHANNEL.CONTROL, body);
+const frame = (streamId: number, ...jpeg: number[]) =>
+  Uint8Array.from([SIMFARM_CHANNEL.VIDEO, streamId, SIMFARM_VIDEO_TAG.KEY, ...jpeg]).buffer;
+
+function harness() {
+  const clock = new FakeClock();
+  const sockets: FakeSocket[] = [];
+  const cache = new SimfarmSessionCache({
+    open: (_url, session) => {
+      const socket = new FakeSocket(session);
+      sockets.push(socket);
+      session.connect(socket);
+      session.opened();
+    },
+    schedule: clock.schedule,
+    graceMs: 60_000,
+  });
+  return { cache, clock, sockets };
+}
+
+/** Walk a session to `live` on the one running device. */
+function goLive(session: SimfarmSession, streamId = 7) {
+  session.received(devicesEvent([RUNNING]));
+  session.received(reply({ id: 1, ok: true, streamId, device: RUNNING }));
+  session.received(frame(streamId, 0xff, 0xd8, 0xff));
+}
+
+describe('holding', () => {
+  test('the first hold opens one socket and a second hold on the same url shares it', () => {
+    const { cache, sockets } = harness();
+    const first = cache.acquire(URL_A);
+    const second = cache.acquire(URL_A);
+    expect(sockets).toHaveLength(1);
+    expect(second.entry).toBe(first.entry);
+    expect(cache.size).toBe(1);
+  });
+
+  test('a session is not idle while anyone holds it', () => {
+    const { cache, clock } = harness();
+    const hold = cache.acquire(URL_A);
+    expect(cache.isIdle(URL_A)).toBe(false);
+    expect(clock.armed()).toBe(0);
+    hold.release();
+    expect(cache.isIdle(URL_A)).toBe(true);
+    expect(clock.armed()).toBe(1);
+  });
+
+  test('releasing twice counts once', () => {
+    const { cache } = harness();
+    const one = cache.acquire(URL_A);
+    const two = cache.acquire(URL_A);
+    one.release();
+    one.release();
+    expect(cache.isIdle(URL_A)).toBe(false);
+    two.release();
+    expect(cache.isIdle(URL_A)).toBe(true);
+  });
+});
+
+describe('the grace period', () => {
+  test('a released session is handed back whole to a screen that returns in time', () => {
+    const { cache, clock, sockets } = harness();
+    const first = cache.acquire(URL_A);
+    goLive(first.entry.session);
+    expect(first.entry.session.getState().status).toBe('live');
+    expect(first.entry.lastFrame).toEqual(Uint8Array.from([0xff, 0xd8, 0xff]));
+
+    first.release();
+    expect(clock.armed()).toBe(1);
+    const again = cache.acquire(URL_A);
+    expect(again.entry).toBe(first.entry);
+    expect(again.entry.session.getState().status).toBe('live');
+    expect(again.entry.lastFrame).toEqual(Uint8Array.from([0xff, 0xd8, 0xff]));
+    // Still the one socket, still attached: no detach was sent.
+    expect(sockets).toHaveLength(1);
+    expect(sockets[0].closed).toBe(false);
+    expect(sockets[0].requests().map((r) => r.op)).toEqual(['attach']);
+    // And the timer that would have closed it is gone.
+    expect(clock.armed()).toBe(0);
+  });
+
+  test('a session nobody came back for is detached and closed when the period runs out', () => {
+    const { cache, clock, sockets } = harness();
+    const hold = cache.acquire(URL_A);
+    goLive(hold.entry.session);
+    hold.release();
+    clock.elapse();
+    expect(sockets[0].closed).toBe(true);
+    expect(sockets[0].requests().map((r) => r.op)).toEqual(['attach', 'detach']);
+    expect(cache.size).toBe(0);
+    expect(hold.entry.lastFrame).toBeNull();
+    // The next screen starts over on a new socket.
+    const fresh = cache.acquire(URL_A);
+    expect(sockets).toHaveLength(2);
+    expect(fresh.entry).not.toBe(hold.entry);
+  });
+
+  test('the last frame is the newest one, and none once the stream was let go', () => {
+    const { cache } = harness();
+    const hold = cache.acquire(URL_A);
+    const { session } = hold.entry;
+    goLive(session);
+    session.received(frame(7, 0xaa));
+    expect(hold.entry.lastFrame).toEqual(Uint8Array.from([0xaa]));
+    // Picking another device drops the stream and the picture with it.
+    session.select('ios:other');
+    expect(hold.entry.lastFrame).toBeNull();
+  });
+
+  test('a frame is kept as its own copy, not as a view on the message', () => {
+    const { cache } = harness();
+    const hold = cache.acquire(URL_A);
+    goLive(hold.entry.session);
+    const message = frame(7, 0x11, 0x22);
+    hold.entry.session.received(message);
+    new Uint8Array(message).fill(0);
+    expect(hold.entry.lastFrame).toEqual(Uint8Array.from([0x11, 0x22]));
+  });
+});
+
+describe('warming', () => {
+  test('a warmed socket is the one the screen is handed, and is on its way to live meanwhile', () => {
+    const { cache, clock, sockets } = harness();
+    cache.warm(URL_A);
+    expect(sockets).toHaveLength(1);
+    expect(cache.isIdle(URL_A)).toBe(true);
+    expect(clock.armed()).toBe(1);
+    // The list arrives before the route has mounted; the attach goes out.
+    sockets[0].session.received(devicesEvent([RUNNING]));
+    expect(sockets[0].requests().map((r) => r.op)).toEqual(['attach']);
+
+    const hold = cache.acquire(URL_A);
+    expect(hold.entry.session).toBe(sockets[0].session);
+    expect(sockets).toHaveLength(1);
+    expect(clock.armed()).toBe(0);
+  });
+
+  test('a warmed socket nobody asks for closes when the period runs out', () => {
+    const { cache, clock, sockets } = harness();
+    cache.warm(URL_A);
+    clock.elapse();
+    expect(sockets[0].closed).toBe(true);
+    expect(cache.size).toBe(0);
+  });
+
+  test('warming what is already open changes nothing', () => {
+    const { cache, sockets } = harness();
+    const hold = cache.acquire(URL_A);
+    cache.warm(URL_A);
+    expect(sockets).toHaveLength(1);
+    expect(cache.isIdle(URL_A)).toBe(false);
+    hold.release();
+  });
+
+  test('the probe seeds the list of a socket opened before it, until the server speaks', () => {
+    const { cache, sockets } = harness();
+    cache.warm(URL_A);
+    const seed = parseSimfarmDevices({ devices: [RUNNING] });
+    const hold = cache.acquire(URL_A, seed);
+    expect(hold.entry.session.getState().devices).toEqual(seed);
+    // Seeding attaches to nothing: that is the server's list to decide on.
+    expect(sockets[0].requests()).toEqual([]);
+  });
+});
+
+describe('letting go', () => {
+  test('closing the idle sessions spares the held one', () => {
+    const { cache, sockets } = harness();
+    const held = cache.acquire(URL_A);
+    cache.closeIdle();
+    expect(sockets[0].closed).toBe(false);
+    held.release();
+    cache.closeIdle();
+    expect(sockets[0].closed).toBe(true);
+    expect(cache.size).toBe(0);
+  });
+
+  test('opening another machine closes the idle one', () => {
+    const { cache, sockets } = harness();
+    const a = cache.acquire(URL_A);
+    a.release();
+    cache.acquire(URL_B);
+    expect(sockets[0].closed).toBe(true);
+    expect(sockets[1].closed).toBe(false);
+    expect(cache.size).toBe(1);
+  });
+
+  test('a transport that dropped while idle is gone at once', () => {
+    const { cache, clock, sockets } = harness();
+    const hold = cache.acquire(URL_A);
+    hold.release();
+    sockets[0].session.dropped();
+    expect(cache.size).toBe(0);
+    expect(clock.armed()).toBe(0);
+  });
+
+  test('a transport that dropped while held is kept for the screen, and not after', () => {
+    const { cache, clock, sockets } = harness();
+    const hold = cache.acquire(URL_A);
+    sockets[0].session.dropped();
+    // The screen is showing "lost" and its Look again; the entry is still its.
+    expect(cache.size).toBe(1);
+    expect(hold.entry.session.getState().status).toBe('lost');
+    hold.release();
+    expect(cache.size).toBe(0);
+    expect(clock.armed()).toBe(0);
+    // Looking again is a new socket.
+    cache.acquire(URL_A);
+    expect(sockets).toHaveLength(2);
+  });
+});

--- a/src/lib/simfarm-frame-ring.ts
+++ b/src/lib/simfarm-frame-ring.ts
@@ -1,0 +1,48 @@
+/**
+ * The last few frames, kept alive behind the one on screen.
+ *
+ * Skia images are native memory with a JS handle. Dropping one without
+ * disposing it leaks a whole frame, and at eight frames a second that is
+ * visible in minutes -- so they are disposed by hand. But not the moment the
+ * next one arrives: the picture is recorded on the UI runtime a little after
+ * the frame is handed over, and disposing the previous frame before that
+ * recording has happened empties the very image about to be drawn. The
+ * picture then goes blank while the state says `live`, which the emulator is
+ * slow enough to show every time.
+ *
+ * So a frame is released only once `depth` newer frames have been handed over
+ * after it. The ring is the arithmetic of that and nothing else: it does not
+ * know what a frame is, and it never calls `dispose` -- the caller is told what
+ * fell off the far end and frees it where it is safe to, which is on the
+ * runtime that draws.
+ */
+export class SimfarmFrameRing<T> {
+  private held: T[] = [];
+
+  constructor(private readonly depth: number) {
+    if (!(depth >= 1)) throw new RangeError('a frame ring keeps at least one frame');
+  }
+
+  /** How many frames are held right now. */
+  get size(): number {
+    return this.held.length;
+  }
+
+  /**
+   * Keep `next` as the newest frame. Returns the frame that fell off the far
+   * end -- the one that is now `depth` frames behind -- or `null` while the
+   * ring is still filling.
+   */
+  push(next: T): T | null {
+    this.held.push(next);
+    if (this.held.length <= this.depth) return null;
+    return this.held.shift() ?? null;
+  }
+
+  /** Everything held, oldest first; nothing is held afterwards. */
+  drain(): T[] {
+    const all = this.held;
+    this.held = [];
+    return all;
+  }
+}

--- a/src/lib/simfarm-frame.ts
+++ b/src/lib/simfarm-frame.ts
@@ -40,6 +40,22 @@
  */
 import { type SimfarmEdge } from '@/lib/simfarm-protocol';
 
+/**
+ * The two clamps, ahead of everything that uses them: they run on the UI
+ * runtime too, and a worklet captures what it calls when it is made, which
+ * for a module-level function is module evaluation -- a helper declared
+ * further down the file is `undefined` at that moment.
+ */
+function clamp(value: number, low: number, high: number): number {
+  'worklet';
+  if (!Number.isFinite(value)) return low;
+  return Math.min(high, Math.max(low, value));
+}
+
+function clamp01(value: number): number {
+  return clamp(value, 0, 1);
+}
+
 export interface SimfarmSize {
   width: number;
   height: number;
@@ -127,6 +143,7 @@ export function simfarmEdgeBands(
  * in landscape. See the note above for why it is not `min` of the two.
  */
 export function simfarmFitScale(frame: SimfarmSize, viewport: SimfarmSize): number {
+  'worklet';
   if (frame.width <= 0 || frame.height <= 0) return 1;
   if (viewport.width <= 0 || viewport.height <= 0) return 1;
   return viewport.height >= viewport.width
@@ -147,6 +164,7 @@ export function clampSimfarmOffset(
   viewport: SimfarmSize,
   offset: SimfarmPoint
 ): SimfarmPoint {
+  'worklet';
   const limitX = Math.max(0, (content.width - viewport.width) / 2);
   const limitY = Math.max(0, (content.height - viewport.height) / 2);
   return {
@@ -170,6 +188,7 @@ export function placeSimfarmFrame(
   zoom = 1,
   offset: SimfarmPoint = { x: 0, y: 0 }
 ): SimfarmPlacement {
+  'worklet';
   const scale = simfarmFitScale(frame, viewport) * clamp(zoom, SIMFARM_MIN_ZOOM, SIMFARM_MAX_ZOOM);
   const width = frame.width * scale;
   const height = frame.height * scale;
@@ -214,6 +233,7 @@ export function simfarmRestingOffset(
   viewport: SimfarmSize,
   zoom = 1
 ): SimfarmPoint {
+  'worklet';
   const scale = simfarmFitScale(frame, viewport) * clamp(zoom, SIMFARM_MIN_ZOOM, SIMFARM_MAX_ZOOM);
   return { x: 0, y: Math.max(0, (frame.height * scale - viewport.height) / 2) };
 }
@@ -260,13 +280,4 @@ export function simfarmEdgeAt(
     }
   }
   return nearest;
-}
-
-function clamp(value: number, low: number, high: number): number {
-  if (!Number.isFinite(value)) return low;
-  return Math.min(high, Math.max(low, value));
-}
-
-function clamp01(value: number): number {
-  return clamp(value, 0, 1);
 }

--- a/src/lib/simfarm-session-cache.ts
+++ b/src/lib/simfarm-session-cache.ts
@@ -1,0 +1,231 @@
+/**
+ * The sockets behind the preview, kept for a while after the preview closes.
+ *
+ * ## Why the socket outlives the screen
+ *
+ * Opening the preview was measured at 770-1640 ms from the tap to a picture,
+ * and almost all of it is a chain of round trips that has to be walked in
+ * order: open the socket, wait for the device list, send the attach, wait for
+ * the server to start its encoder, wait for the first frame. Closing the
+ * preview threw the whole chain away, so glancing at the simulator, going
+ * back to the terminal and glancing again paid it twice.
+ *
+ * So a session is not closed when its screen goes. It is *released*: the
+ * socket stays open and attached, the last frame it delivered is kept, and
+ * only after `graceMs` with nobody holding it is it let go. A screen that
+ * comes back inside that window is handed the same session, already live,
+ * and the frame it kept -- so the picture is on screen at the first layout
+ * and the stream takes over from there. The tile that opens the preview
+ * calls `warm` before the route even mounts, for the same reason from the
+ * other end: the socket's round trips run under the navigation instead of
+ * after it.
+ *
+ * ## What it costs, and the two things that stop it
+ *
+ * A held socket is a server still encoding a picture nobody is looking at,
+ * for a minute at most, and a JS thread still receiving it. That is the trade,
+ * and it is bounded twice over: one idle session at a time (a new one closes
+ * the others), and the caller closes every idle session on the two events
+ * after which "reopening soon" is no longer likely -- the app going to the
+ * background, and the gateway changing. A session whose transport dropped is
+ * never kept; there is nothing in it worth keeping.
+ *
+ * ## Why it is pure
+ *
+ * Keyed by the socket URL, which is the gateway's host and simfarm's port and
+ * nothing else, and driven through an `open` callback that makes the socket,
+ * so the whole of the timing -- grace, reuse, release on the two events --
+ * can be pinned with a fake socket and a fake clock, like the session it
+ * holds.
+ */
+import { type SimfarmDevice } from '@/lib/simfarm';
+import { SimfarmSession, type SimfarmSchedule } from '@/lib/simfarm-session';
+
+/**
+ * How long a released session is kept.
+ *
+ * Long enough for "close, read the terminal, look again"; short enough that a
+ * simulator left encoding for nobody stops within the minute.
+ */
+export const SIMFARM_SESSION_GRACE_MS = 60_000;
+
+/**
+ * One socket and the session driving it.
+ *
+ * `lastFrame` is the newest jpeg the session delivered for the device it is
+ * attached to, `null` when there is none -- the session clears it when it
+ * lets go of a stream, so a reopened preview never shows a frame of the
+ * device before the one it is about to attach to.
+ */
+export interface SimfarmSessionEntry {
+  readonly url: string;
+  readonly session: SimfarmSession;
+  readonly lastFrame: Uint8Array | null;
+  /** Every frame from now on, and `null` when the picture no longer applies. */
+  onFrame(listener: (payload: Uint8Array | null) => void): () => void;
+}
+
+/** A screen's claim on an entry; `release` starts the grace period. */
+export interface SimfarmSessionHold {
+  readonly entry: SimfarmSessionEntry;
+  release(): void;
+}
+
+class Entry implements SimfarmSessionEntry {
+  lastFrame: Uint8Array | null = null;
+  holders = 0;
+  /** The cancel for the grace timer, while one is running. */
+  grace: (() => void) | null = null;
+  lost = false;
+  dead = false;
+  readonly session: SimfarmSession;
+  private readonly listeners = new Set<(payload: Uint8Array | null) => void>();
+
+  constructor(
+    readonly url: string,
+    seed: SimfarmDevice[],
+    schedule: SimfarmSchedule | undefined
+  ) {
+    this.session = new SimfarmSession({
+      seed,
+      schedule,
+      onFrame: (payload) => this.frame(payload),
+    });
+  }
+
+  onFrame(listener: (payload: Uint8Array | null) => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private frame(payload: Uint8Array | null): void {
+    // A copy, because the payload is a view on the socket message's buffer
+    // and this one is kept past the message.
+    const kept = payload === null ? null : payload.slice();
+    this.lastFrame = kept;
+    for (const listener of this.listeners) listener(kept);
+  }
+}
+
+const scheduleWithTimers: SimfarmSchedule = (run, ms) => {
+  const timer = setTimeout(run, ms);
+  return () => clearTimeout(timer);
+};
+
+export class SimfarmSessionCache {
+  private readonly entries = new Map<string, Entry>();
+  private readonly open: (url: string, session: SimfarmSession) => void;
+  private readonly schedule: SimfarmSchedule;
+  private readonly graceMs: number;
+
+  constructor(options: {
+    /** Make the socket for `url` and wire it to `session`; see `useSimfarmStream`. */
+    open: (url: string, session: SimfarmSession) => void;
+    schedule?: SimfarmSchedule;
+    graceMs?: number;
+  }) {
+    this.open = options.open;
+    this.schedule = options.schedule ?? scheduleWithTimers;
+    this.graceMs = options.graceMs ?? SIMFARM_SESSION_GRACE_MS;
+  }
+
+  /**
+   * Open the socket for `url` now, for a screen that is about to ask for it.
+   *
+   * Nothing holds it, so the grace period starts at once: a screen that never
+   * arrives -- the probe said no, the route was left -- costs one socket for
+   * one grace period, and one that does arrive finds it open.
+   */
+  warm(url: string, seed: SimfarmDevice[] = []): void {
+    const existing = this.entries.get(url);
+    if (existing !== undefined) {
+      existing.session.seed(seed);
+      return;
+    }
+    const entry = this.create(url, seed);
+    this.startGrace(entry);
+  }
+
+  /** The session for `url`, opened now if there is none, held until `release`. */
+  acquire(url: string, seed: SimfarmDevice[] = []): SimfarmSessionHold {
+    let entry = this.entries.get(url);
+    if (entry === undefined) entry = this.create(url, seed);
+    else entry.session.seed(seed);
+    entry.holders += 1;
+    this.cancelGrace(entry);
+    let released = false;
+    return {
+      entry,
+      release: () => {
+        if (released) return;
+        released = true;
+        entry.holders -= 1;
+        if (entry.holders > 0) return;
+        if (entry.lost) this.drop(entry);
+        else this.startGrace(entry);
+      },
+    };
+  }
+
+  /** Let go of every session nobody is holding. */
+  closeIdle(): void {
+    for (const entry of [...this.entries.values()]) {
+      if (entry.holders === 0) this.drop(entry);
+    }
+  }
+
+  /** How many sessions are open, held or not. */
+  get size(): number {
+    return this.entries.size;
+  }
+
+  /** Whether `url` has a session open that nobody is holding. */
+  isIdle(url: string): boolean {
+    const entry = this.entries.get(url);
+    return entry !== undefined && entry.holders === 0;
+  }
+
+  private create(url: string, seed: SimfarmDevice[]): Entry {
+    // One idle socket at a time: a preview of another machine is the moment
+    // the last one stopped being "about to be reopened".
+    this.closeIdle();
+    const entry = new Entry(url, seed, this.schedule);
+    this.entries.set(url, entry);
+    entry.session.subscribe((state) => {
+      if (state.status !== 'lost' || entry.lost) return;
+      entry.lost = true;
+      // Nothing to keep: the screen holding it is told, and lets go in its
+      // own time; an idle one is dropped now.
+      if (entry.holders === 0) this.drop(entry);
+    });
+    this.open(url, entry.session);
+    return entry;
+  }
+
+  private startGrace(entry: Entry): void {
+    this.cancelGrace(entry);
+    entry.grace = this.schedule(() => {
+      entry.grace = null;
+      this.drop(entry);
+    }, this.graceMs);
+  }
+
+  private cancelGrace(entry: Entry): void {
+    if (entry.grace === null) return;
+    entry.grace();
+    entry.grace = null;
+  }
+
+  private drop(entry: Entry): void {
+    // Releasing the session closes its socket, and a closing socket reports
+    // itself dropped -- which lands back here through the subscription above.
+    if (entry.dead) return;
+    entry.dead = true;
+    this.cancelGrace(entry);
+    if (this.entries.get(entry.url) === entry) this.entries.delete(entry.url);
+    entry.lastFrame = null;
+    entry.session.release();
+  }
+}

--- a/src/lib/simfarm-session.ts
+++ b/src/lib/simfarm-session.ts
@@ -232,6 +232,20 @@ export class SimfarmSession {
     };
   }
 
+  /**
+   * What a probe found, offered after the fact.
+   *
+   * A session opened ahead of the probe starts with no list; the probe's
+   * answer fills it so the picker has rows before the socket has said
+   * anything. Only while the list is empty: once the server has spoken, its
+   * list is the newer one, and this must not attach to anything -- that is
+   * `onDevices`'s decision, made on the server's word.
+   */
+  seed(devices: SimfarmDevice[]): void {
+    if (devices.length === 0 || this.state.devices.length > 0) return;
+    this.update({ devices });
+  }
+
   // ---------------------------------------------------------------------------
   // the transport's side
   // ---------------------------------------------------------------------------

--- a/src/lib/simfarm-stream.ts
+++ b/src/lib/simfarm-stream.ts
@@ -2,11 +2,12 @@
  * The socket behind the preview: one WebSocket, one attached device, one
  * picture, and the four kinds of input that go back the other way.
  *
- * `simfarm-protocol.ts` is the bytes, `simfarm-frame.ts` is the arithmetic and
- * `simfarm-session.ts` is the state machine; this is the part that has to hold
- * a connection open and a native image alive, and it is separated from all
- * three for the reason the rest of this feature is: the pure files are worth
- * pinning exactly, and pinning them must not need a socket or Skia.
+ * `simfarm-protocol.ts` is the bytes, `simfarm-frame.ts` is the arithmetic,
+ * `simfarm-session.ts` is the state machine and `simfarm-session-cache.ts` is
+ * the lifetime; this is the part that has to open a real socket and hold a
+ * native image alive, and it is separated from all four for the reason the
+ * rest of this feature is: the pure files are worth pinning exactly, and
+ * pinning them must not need a socket, Skia or a UI runtime.
  *
  * ## Why the frames are jpeg and drawn with Skia
  *
@@ -22,6 +23,38 @@
  * would have to be base64-encoded again, at about 1.5 MB a second, to be handed
  * back to a component that would decode them a third time.
  *
+ * ## Why a frame never goes through React
+ *
+ * It used to: each frame was `setImage`, a render of the stage, a commit, and
+ * a re-walk of the Skia tree to record a new picture. Measured on the
+ * emulator that was 50-60 ms of JS thread per frame in a debug build, the JS
+ * thread two-thirds busy at ten frames a second, and half of the frames
+ * arriving never reaching a commit at all because the socket's own work kept
+ * starving the scheduler. None of it drew anything different: the tree is
+ * the same tree with a different image in one node.
+ *
+ * So the image is a shared value. Skia reads it on the UI runtime and
+ * re-records the picture there when it changes, and the stage is not
+ * rendered again -- what reaches React is the one bit it draws by, whether
+ * there is a picture at all. What is left on the JS thread per frame is the
+ * socket's base64 decode (the platform's, not ours), a header parse, and the
+ * creation of a lazily-decoded image handle: the JPEG itself is decoded at
+ * draw time on the render thread, which is also why nothing here decodes it.
+ *
+ * ## Why a frame is disposed on the UI runtime, and three frames late
+ *
+ * A Skia image is native memory with a JS handle, and dropping the handle
+ * does not free it; `dispose` does. Disposing the previous frame the moment
+ * the next arrives emptied the very image the UI runtime was about to record
+ * -- the picture went blank while the state said `live`, which the emulator
+ * showed every time -- so `simfarm-frame-ring.ts` holds the last few and
+ * hands back the one that fell off the end, and *that* is disposed in the
+ * same UI-runtime job that installs the newest frame. The job runs after the
+ * jobs that installed the frames in between, and Skia records each installed
+ * frame in a microtask right behind its job, so by the time a frame is
+ * disposed it has been recorded and superseded. The ring's depth is slack on
+ * top of that ordering, not a substitute for it.
+ *
  * ## What it deliberately does not do
  *
  * It does not reconnect, on its own or on request. A socket that dropped is
@@ -34,15 +67,21 @@
  */
 import { Skia, type SkImage } from '@shopify/react-native-skia';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { AppState } from 'react-native';
+import { useSharedValue, type SharedValue } from 'react-native-reanimated';
+import { scheduleOnUI } from 'react-native-worklets';
 
 import { type SimfarmDevice } from '@/lib/simfarm';
 import { type SimfarmEdgeBands } from '@/lib/simfarm-frame';
+import { SimfarmFrameRing } from '@/lib/simfarm-frame-ring';
 import { type SimfarmButton, type SimfarmTouchPhase } from '@/lib/simfarm-protocol';
 import {
   initialSimfarmSessionState,
-  SimfarmSession,
+  type SimfarmSession,
   type SimfarmSessionState,
 } from '@/lib/simfarm-session';
+import { SimfarmSessionCache } from '@/lib/simfarm-session-cache';
+import { useGatewayConnectionStore } from '@/stores/gateway-connection';
 
 export type {
   SimfarmStreamError,
@@ -50,11 +89,17 @@ export type {
   SimfarmStreamStatus,
 } from '@/lib/simfarm-session';
 
-/** How many decoded frames are kept alive behind the one on screen; see `shown`. */
+/** How many frames are kept alive behind the one on screen; see the note above. */
 const SIMFARM_FRAME_RING = 3;
 
 export interface SimfarmStream extends SimfarmSessionState {
-  image: SkImage | null;
+  /**
+   * The frame to draw, for the UI runtime. Hand it to Skia as a prop; never
+   * read it during a render, which is what `hasImage` is for.
+   */
+  image: SharedValue<SkImage | null>;
+  /** Whether there is a frame on screen -- the one bit of the picture React draws by. */
+  hasImage: boolean;
   /** Show a device: attach if it is running, start it first if it is not. */
   select: (deviceId: string) => void;
   /** Turn a device off, letting go of it first if it is the one on screen. */
@@ -69,6 +114,65 @@ export interface SimfarmStream extends SimfarmSessionState {
   press: (button: SimfarmButton) => void;
 }
 
+/** The socket for `url`, wired to `session`, for the cache to open. */
+function openSocket(url: string, session: SimfarmSession): void {
+  const socket = new WebSocket(url);
+  socket.binaryType = 'arraybuffer';
+  session.connect({
+    get readyState() {
+      return socket.readyState;
+    },
+    send: (bytes) => socket.send(bytes),
+    close: () => socket.close(),
+  });
+  socket.onopen = () => session.opened();
+  socket.onmessage = (event: { data: unknown }) => {
+    const data = event.data;
+    if (typeof data === 'string' || !(data instanceof ArrayBuffer)) return;
+    session.received(data);
+  };
+  // A session that has already let go is told about a close it caused, and
+  // takes no harm from it.
+  socket.onerror = () => session.dropped();
+  socket.onclose = () => session.dropped();
+}
+
+const cache = new SimfarmSessionCache({ open: openSocket });
+
+/**
+ * The two events after which an idle socket is not worth keeping: the app
+ * leaving the screen, and the gateway -- the machine the sockets belong to --
+ * changing under it. Installed once, the first time there is a socket to
+ * watch over.
+ */
+let watching = false;
+function watchOver(): void {
+  if (watching) return;
+  watching = true;
+  AppState.addEventListener('change', (state) => {
+    if (state !== 'active') cache.closeIdle();
+  });
+  useGatewayConnectionStore.subscribe((state, previous) => {
+    if (state.record?.url !== previous.record?.url) cache.closeIdle();
+  });
+}
+
+/**
+ * Open the socket for `url` now, ahead of the screen that will show it.
+ *
+ * Called from the tile that opens the preview, so the socket's round trips
+ * run under the route's own mounting instead of after it, and from the probe,
+ * so they run beside it instead of behind it. `null` is a gateway with no
+ * address to build one from; `allowed` is the gate the probe applies, applied
+ * here first -- a socket to a connection the preview may not be offered on
+ * is exactly the thing the gate exists to prevent.
+ */
+export function warmSimfarm(url: string | null, allowed: boolean): void {
+  if (url === null || !allowed) return;
+  watchOver();
+  cache.warm(url);
+}
+
 /**
  * A live picture of one device on `url`, and the way back to it.
  *
@@ -78,7 +182,8 @@ export interface SimfarmStream extends SimfarmSessionState {
  */
 export function useSimfarmStream(url: string | null, seed: SimfarmDevice[]): SimfarmStream {
   const [state, setState] = useState<SimfarmSessionState>(() => initialSimfarmSessionState(seed));
-  const [image, setImage] = useState<SkImage | null>(null);
+  const image = useSharedValue<SkImage | null>(null);
+  const [hasImage, setHasImage] = useState(false);
 
   /**
    * The session behind the socket in flight, kept out of React state on
@@ -86,102 +191,66 @@ export function useSimfarmStream(url: string | null, seed: SimfarmDevice[]): Sim
    * created in, and it is replaced whenever the socket is.
    */
   const session = useRef<SimfarmSession | null>(null);
-  /**
-   * The last few frames, newest last, so the one on screen is never freed
-   * from under the renderer.
-   *
-   * Skia images are native memory with a JS handle. Dropping one without
-   * disposing it leaks a whole frame, and at six frames a second that is
-   * visible in minutes rather than hours -- so they are disposed by hand. But
-   * not the moment the next one arrives: the render thread draws what React
-   * last committed, a little after the commit, and on a loaded phone that is
-   * after the frame behind it has already been handed over. Disposing the
-   * previous frame at that point frees the very image being drawn, and the
-   * picture goes blank while the state says `live` -- measured on the
-   * emulator, which is slow enough to show it every time. A ring of
-   * `SIMFARM_FRAME_RING` frames costs a few megabytes and puts the dispose two
-   * frames behind the draw.
-   */
-  const shown = useRef<SkImage[]>([]);
-
-  /**
-   * Let go of every frame held.
-   *
-   * A named callback rather than the body of an unmount effect, because the
-   * effect's cleanup may not reach into a ref: by the time a cleanup runs the
-   * ref can already point at something else. Here it points at exactly what
-   * this is meant to free, and going through a stable callback says so.
-   */
-  const dropImage = useCallback(() => {
-    for (const held of shown.current) held.dispose();
-    shown.current = [];
-  }, []);
-
-  const showImage = useCallback((next: SkImage | null) => {
-    setImage(next);
-    if (next === null) return;
-    const ring = shown.current;
-    ring.push(next);
-    while (ring.length > SIMFARM_FRAME_RING) ring.shift()?.dispose();
-  }, []);
 
   useEffect(() => {
     if (url === null) {
       setState((current) => ({ ...current, status: 'lost' }));
       return;
     }
+    watchOver();
+    const hold = cache.acquire(url, seed);
+    const { entry } = hold;
+    session.current = entry.session;
 
-    const live = new SimfarmSession({
-      seed,
-      onFrame: (payload) => {
-        if (payload === null) {
-          showImage(null);
-          return;
+    const ring = new SimfarmFrameRing<SkImage>(SIMFARM_FRAME_RING);
+    // Whether the last frame handed over was a picture, so React is told
+    // only when that changes and not eight times a second.
+    let showing = false;
+    const show = (payload: Uint8Array | null) => {
+      if (payload === null) {
+        const stale = ring.drain();
+        scheduleOnUI(() => {
+          'worklet';
+          image.value = null;
+          for (const held of stale) held.dispose();
+        });
+        if (showing) {
+          showing = false;
+          setHasImage(false);
         }
-        // `slice`, not the view: the payload borrows the socket message's
-        // buffer, and Skia holds the bytes for as long as the image lives.
-        const decoded = Skia.Image.MakeImageFromEncoded(Skia.Data.fromBytes(payload.slice()));
-        if (decoded !== null) showImage(decoded);
-      },
-    });
-    session.current = live;
-    setState(live.getState());
-    const unsubscribe = live.subscribe(setState);
-
-    let closed = false;
-    const socket = new WebSocket(url);
-    socket.binaryType = 'arraybuffer';
-    live.connect({
-      get readyState() {
-        return socket.readyState;
-      },
-      send: (bytes) => socket.send(bytes),
-      close: () => socket.close(),
-    });
-    socket.onopen = () => live.opened();
-    socket.onmessage = (event: { data: unknown }) => {
-      const data = event.data;
-      if (typeof data === 'string' || !(data instanceof ArrayBuffer)) return;
-      live.received(data);
+        return;
+      }
+      // Lazy: the handle is made here, the JPEG is decoded where it is drawn.
+      const decoded = Skia.Image.MakeImageFromEncoded(Skia.Data.fromBytes(payload));
+      if (decoded === null) return;
+      const stale = ring.push(decoded);
+      scheduleOnUI(() => {
+        'worklet';
+        image.value = decoded;
+        if (stale !== null) stale.dispose();
+      });
+      if (!showing) {
+        showing = true;
+        setHasImage(true);
+      }
     };
-    socket.onerror = () => {
-      if (!closed) live.dropped();
-    };
-    socket.onclose = () => {
-      if (!closed) live.dropped();
-    };
+    // The frame a kept session already has, so a reopened preview draws it at
+    // its first layout and the stream takes over from there.
+    if (entry.lastFrame !== null) show(entry.lastFrame);
+    const stopFrames = entry.onFrame(show);
+    setState(entry.session.getState());
+    const stopState = entry.session.subscribe(setState);
 
     return () => {
-      closed = true;
-      unsubscribe();
-      live.release();
-      if (session.current === live) session.current = null;
+      stopFrames();
+      stopState();
+      if (session.current === entry.session) session.current = null;
+      // The session keeps its own copy of the last frame; the images made
+      // from it here are this screen's, and go with it.
+      show(null);
+      hold.release();
     };
-  }, [seed, showImage, url]);
-
-  // The last frame outlives the socket by one render otherwise, and a native
-  // buffer nobody can reach is the definition of a leak.
-  useEffect(() => dropImage, [dropImage]);
+  }, [image, seed, url]);
 
   const select = useCallback((deviceId: string) => session.current?.select(deviceId), []);
   const shutdown = useCallback((deviceId: string) => session.current?.shutdown(deviceId), []);
@@ -190,7 +259,7 @@ export function useSimfarmStream(url: string | null, seed: SimfarmDevice[]): Sim
   const press = useCallback((button: SimfarmButton) => session.current?.press(button), []);
 
   return useMemo(
-    () => ({ ...state, image, select, shutdown, touch, type, press }),
-    [image, press, select, shutdown, state, touch, type]
+    () => ({ ...state, image, hasImage, select, shutdown, touch, type, press }),
+    [hasImage, image, press, select, shutdown, state, touch, type]
   );
 }


### PR DESCRIPTION
## What

The simulator preview was measured on main (debug builds, Android emulator as the viewer): every frame went through React, and opening it walked a serial chain of round trips after the route had mounted. This makes frames bypass React and the socket outlive the screen.

1. **Frames bypass React.** `useSimfarmStream` puts the current `SkImage` in a Reanimated shared value; the stage hands it to Skia's `<Image>` as a prop and is not rendered again per frame. What reaches React is one boolean, `hasImage`, which flips on the null/picture transition only. The 3-frame ring from #51 is now the pure `SimfarmFrameRing` (`src/lib/simfarm-frame-ring.ts`); the frame that falls off it is disposed on the UI runtime in the same job that installs the newest one, after Skia has recorded the frames in between. Zoom, pan and the placement moved to shared/derived values, so a two-finger drag or pinch does not render either; the placement functions in `simfarm-frame.ts` are worklets now (same code, `'worklet'` directive, `clamp` moved ahead of its callers because a worklet captures what it calls at module evaluation). No JS decode was added: the image handle is lazy, the JPEG is decoded where it is drawn.
2. **Opening.** `SimfarmSessionCache` (`src/lib/simfarm-session-cache.ts`, module level, keyed by the socket URL = gateway host + simfarm port) owns sockets. The Simulator tile calls `warmSimfarm` before navigating, so the socket's round trips run under the route's mounting; the preview warms again beside the probe rather than after it; the session attaches on the first `devices` event as before. A closed preview releases its session instead of closing it: the socket stays attached and the last frame is kept for 60 s, and a preview reopened inside that window is handed the same live session and draws the kept frame at its first layout. Idle sessions are closed on app background, on gateway change, when another machine's session is opened, and immediately when their transport drops. The gate is respected: nothing is warmed unless `allowed`.
3. The base64 path and the server are untouched.

## Measurements

Android emulator (`muqun android`, Android 17, 4 vCPU) as the viewer, streaming the simfarm's `android:emulator-5554` device (460x1024 JPEG), debug bundle from Metro, mock gateway. "Before" is main with the measurement worktree's instrumentation; "after" is this branch with equivalent instrumentation (not shipped: a stash of it exists locally, nothing in the PR). Same machine, same hour.

| | before (main) | after |
|---|---|---|
| frames received per 5 s | 34-44 | 47-51 |
| frames reaching a commit / handed to the UI runtime | 18-22 (50-60%) | 47-51 (100%) |
| frames drawn by the Skia canvas per 5 s | 11-13 (~30%) | 22-24 (~48%) |
| React renders per frame | 1 (stage render 73-99 ms mean) | 0 (one render in total, when the first picture arrived) |
| JS thread busy | 55-67% | 24-30% |
| tap to picture, cold open | 915 ms, 760 ms | 603 ms, 642 ms, 653 ms |
| tap to picture, reopened within grace | (same as cold) | 394 ms |

Open chain, after, cold (ms from the tap): route render 17-20, probe 177-215 to 245-310, stage layout 308-367, first frame 600-651, picture recorded on the UI runtime 603-653. Reopened inside the grace period: route render 16, probe 221 to 257, stage layout 297, kept frame handed 326, picture recorded 394 -- the picture is there at the first layout and the live stream takes over.

"Frames drawn" after is bounded by the emulator, not by JS: `SkiaViewApi.setJsiProperty` (the native draw of a new picture) takes ~170 ms per picture on the emulator's software GL, and the UI runtime coalesces frames that arrive during a draw to the newest one. On a device with a GPU that draw is under a millisecond (measured on iOS in the notes).

## Remaining costs (not changed here)

- The platform WebSocket's base64 decode is now the largest JS cost per frame: 4-11 ms mean for 5-20 KB Android frames; on the same viewer attached to an iOS simulator (1206x2622, ~212 KB/frame) it is 62 ms mean, p90 156 ms, and the JS thread is 62% busy at 8 fps. The server-side resolution cap is being added separately.
- On the emulator the native draw (~170 ms per picture) is the ceiling on the drawn frame rate.
- The probe still gates the stage: a reopen inside the grace period waits for `/healthz` + `/devices` (~40-100 ms) before the stage mounts, although the socket is already live.
- A grace-kept socket keeps the server encoding and the JS thread receiving for up to 60 s after close.

## Tests

- `simfarm-frame-ring.test.ts`: a frame is handed back for disposal only once three newer ones were pushed, oldest first, every frame exactly once; drain order.
- `simfarm-session-cache.test.ts` (fake socket, fake clock): reuse on reopen inside the grace period with the socket still attached and the last frame kept; close and detach when the period runs out; warm ahead of the screen; the probe's seed applied to a warmed session without attaching; `closeIdle` spares held sessions; another machine closes the idle one; a dropped transport is gone at once when idle and after release when held; the kept frame is a copy, and none once the stream was let go.

`npx tsc --noEmit`, `bun run lint`, `bun run format:check`, `bun test src` (3033 tests) all green.

## Device verification (Android emulator viewer)

- Picture, chrome collapse after the timeout and the handle bringing it back, the picker with its rows and shut-down buttons, close and reopen: verified.
- One-finger tap forwarded end to end (viewer -> simfarm -> device): a tap on the picture of the emulator's own handle toggled the real chrome.
- Two-finger pan runs on the UI runtime (offset updates traced); the pinch handler runs on the UI runtime too (traced through `gesture transform`), the tooling's synthetic pinch does not produce a scale change on either build, so the zoom arithmetic (unchanged) was not exercised by hand.
- Grace socket: still open after closing the preview, closed when the app went to the background (checked with `lsof` on the simfarm host).
- Light and dark themes: stage ground and glass chrome follow the theme.
- Boot and shutdown were not exercised on the shared simulators (the state machine is unchanged and covered by `simfarm-session.test.ts`).
- The colour drift visible in a recursive preview (the emulator watching itself) is the feedback loop through the screen encoder and is depth-dependent; the picture of a non-recursive source (an iOS simulator) matched the simulator's own screenshot.
