### PR TITLE
fix(terminal): the room an agent left on its screen is not transcript

### DIFF
--- a/src/components/server-terminal-workspace.tsx
+++ b/src/components/server-terminal-workspace.tsx
@@ -1485,8 +1485,9 @@ export function ServerTerminalWorkspace({
   // The other axis of the same report, and read for the same reason: the pane's
   // own grid is what the snapshot should be laid out on, rather than however
   // many lines the read happened to return. `undefined` for a gateway that did
-  // not say -- every herdr pane today reports neither -- which leaves the
-  // parser's own measurement in charge exactly as it is now.
+  // not say -- a herdr pane on a gateway older than the one that reads the
+  // shell's own terminal size for it -- which leaves the parser's own
+  // measurement in charge exactly as it is now.
   const selectedPaneRows = selectedPane
     ? numberField(selectedPane, 'height') || undefined
     : undefined;

--- a/src/lib/__tests__/terminal-text-size.test.ts
+++ b/src/lib/__tests__/terminal-text-size.test.ts
@@ -430,6 +430,21 @@ describe('a pane narrower than the phone is drawn to fill it', () => {
     expect(TERMINAL_MAX_FIT_SCALE).toBeGreaterThan(TERMINAL_MIN_SCALE);
   });
 
+  test('a narrow agent pane is fitted exactly as a narrow editor is', () => {
+    // The fit knows nothing about what the pane runs, and that is the rule:
+    // a Claude Code pane and an nvim pane in the same narrow Herdr column
+    // must not open at two sizes. Measured on herdr 0.8.2: three columns
+    // side by side gave grids of 64, 32 and 31; on this phone the 32-column
+    // editor opens at 49/32 and the 31-column agent at 49/31, both under the
+    // cap, and only a pane narrower than 49/1.6 -- thirty columns -- meets
+    // it. At the cap a 30-column pane still reaches 48 of 49 columns, which
+    // is why 1.6 stands for these panes as it did for tmux's 36.
+    expect(terminalFitToWidthScale(PHONE_COLUMNS, 32)).toBeCloseTo(49 / 32);
+    expect(terminalFitToWidthScale(PHONE_COLUMNS, 31)).toBeCloseTo(49 / 31);
+    expect(terminalFitToWidthScale(PHONE_COLUMNS, 30)).toBe(TERMINAL_MAX_FIT_SCALE);
+    expect(30 * TERMINAL_MAX_FIT_SCALE).toBeGreaterThanOrEqual(PHONE_COLUMNS - 1);
+  });
+
   test('a pane the gateway reported no width for is not fitted', () => {
     // An older gateway, and every SSH shell -- whose grid *is* the PTY, so it
     // can never differ from the phone's and there is nothing to fit.

--- a/src/terminal/__tests__/history.test.ts
+++ b/src/terminal/__tests__/history.test.ts
@@ -15,6 +15,7 @@ import { describe, expect, test } from 'bun:test';
 
 import {
   applyTerminalFrame,
+  collapseScreenGaps,
   foldPaneRead,
   hasEarlierAfterPage,
   hasEarlierTerminalOutput,
@@ -348,6 +349,98 @@ describe('a screen-owning pane replaces rather than accumulates (card #795, defe
   });
 });
 
+// A full-screen program that scrolls -- Claude Code -- on a backend that
+// cannot say it owns the screen. Measured on herdr 0.8.2 against a real
+// 59-row Claude Code pane before its first prompt, through the gateway, on
+// both `visible` and `recent-unwrapped`: one blank row, a four-row header,
+// forty-eight blank rows, a six-row box. tmux would report `alternate_on` and
+// the read would be a picture; herdr has no such flag, so the read is folded
+// as scrollback and the forty-eight rows were drawn as transcript -- a
+// composer with half a screen of nothing above it, bottom-anchored.
+describe('the room a program left on its screen is not transcript', () => {
+  const header = [
+    '',
+    '           Claude Code v2.1.263',
+    ' A  Fable 5.1',
+    ' B  Claude Max',
+    '  C  /tmp/proj',
+  ];
+  const box = ['             * high · /effort', '---', '>', '---', '  manual mode on'];
+  const blanks = (count: number) => Array.from({ length: count }, () => '');
+  const screen = (transcript: string[]) => {
+    const gap = 59 - header.length - transcript.length - box.length;
+    return [...header, ...transcript, ...blanks(gap), ...box].join('\n');
+  };
+  const rows = (text: string) => text.split('\n');
+
+  test('forty-eight unpainted rows between the header and the box become one', () => {
+    const drawn = rows(foldPaneRead('', screen([]), 'refresh', MAXIMUM, false, 59));
+    expect(drawn).toHaveLength(header.length + 1 + box.length);
+    expect(drawn.slice(0, header.length)).toEqual(header);
+    expect(drawn[header.length]).toBe('');
+    expect(drawn.slice(-box.length)).toEqual(box);
+  });
+
+  test('a transcript growing into the gap folds into one window, not a stack of screens', () => {
+    let window = foldPaneRead('', screen([]), 'refresh', MAXIMUM, false, 59);
+    const transcript = ['> hello', '', 'Hello. How can I help?'];
+    window = applyTerminalFrame(window, screen(transcript), MAXIMUM, false, 59);
+    window = applyTerminalFrame(
+      window,
+      screen([...transcript, '', '> thanks']),
+      MAXIMUM,
+      false,
+      59
+    );
+    const drawn = rows(window);
+    expect(drawn.filter((row) => row.includes('Claude Code v2.1.263'))).toHaveLength(1);
+    expect(drawn.filter((row) => row === '>')).toHaveLength(1);
+    expect(drawn.slice(-box.length)).toEqual(box);
+    expect(drawn.join('\n')).toContain('> thanks');
+    expect(drawn.length).toBeLessThan(2 * (header.length + box.length + 5));
+  });
+
+  test('a run shorter than four stays: a shell leaves a couple of blank rows and keeps them', () => {
+    const read = ['$ make', '', '', '', 'ok', '$ '].join('\n');
+    expect(collapseScreenGaps(read, 6)).toBe(read);
+    expect(collapseScreenGaps(read, 59)).toBe(read);
+  });
+
+  test('only the screen is collapsed; the history the gateway kept above it is not', () => {
+    // Eight rows of history the gateway kept, then exactly one 59-row screen.
+    const history = ['printed one', ...blanks(6), 'printed two'];
+    const read = [...history, ...header, ...blanks(49), ...box].join('\n');
+    const drawn = rows(collapseScreenGaps(read, 59));
+    // The six blank rows in history are still six.
+    expect(drawn.slice(0, history.length)).toEqual(history);
+    // The forty-nine in the screen are one.
+    expect(drawn).toHaveLength(history.length + header.length + 1 + box.length);
+  });
+
+  test('a screen-owning pane keeps every row of its picture', () => {
+    const read = screen([]);
+    expect(foldPaneRead('', read, 'refresh', MAXIMUM, true, 59)).toBe(read);
+    expect(applyTerminalFrame('', read, MAXIMUM, true, 59)).toBe(read);
+  });
+
+  test('a pane whose height the gateway did not report keeps the old behaviour', () => {
+    const read = screen([]);
+    expect(collapseScreenGaps(read, 0)).toBe(read);
+    expect(foldPaneRead('', read, 'refresh', MAXIMUM)).toBe(read);
+  });
+
+  test('a read with nothing to collapse comes back byte for byte', () => {
+    const read = 'one\r\ntwo\r\n\r\nthree';
+    expect(collapseScreenGaps(read, 4)).toBe(read);
+    expect(collapseScreenGaps('', 4)).toBe('');
+  });
+
+  test('a trailing run inside the screen is room too', () => {
+    const read = ['prompt', ...blanks(10)].join('\n');
+    expect(rows(collapseScreenGaps(read, 20))).toEqual(['prompt', '']);
+  });
+});
+
 describe("the pane's own viewport rows", () => {
   test('reads the metric', () => {
     expect(terminalViewportRows({ max_offset_from_bottom: 0, viewport_rows: 23 })).toBe(23);
@@ -374,7 +467,12 @@ describe("the pane's own viewport rows", () => {
 
 describe("the gateway's scrollback metric", () => {
   test('is the rows above the viewport plus the viewport itself', () => {
-    expect(terminalScrollbackRows({ max_offset_from_bottom: 908, viewport_rows: 65 })).toBe(973);
+    expect(
+      terminalScrollbackRows({
+        max_offset_from_bottom: 908,
+        viewport_rows: 65,
+      })
+    ).toBe(973);
   });
 
   test('is absent rather than guessed at when the block is not a metric', () => {
@@ -533,7 +631,10 @@ describe('a range decides whether there is more, once there is one', () => {
 
 describe('the next page above the one held', () => {
   test('the next page is the one above the page held, and they do not overlap', () => {
-    expect(nextPageRange({ start: 900 }, 500)).toEqual({ start: 400, end: 900 });
+    expect(nextPageRange({ start: 900 }, 500)).toEqual({
+      start: 400,
+      end: 900,
+    });
   });
 
   test('the next page stops at the top instead of going negative', () => {

--- a/src/terminal/history.ts
+++ b/src/terminal/history.ts
@@ -294,6 +294,29 @@ const FURNITURE_MIN_ROWS = 2;
 const FURNITURE_VOLATILE_ROWS = 1;
 
 /**
+ * The shortest run of blank rows on a screen that is room rather than text.
+ *
+ * A full-screen program that scrolls -- Claude Code -- paints its header at
+ * the top of its screen and its composer at the bottom, and while the
+ * transcript is shorter than the screen the rows between them are simply
+ * unpainted. Measured on herdr 0.8.2 against a real 59-row Claude Code pane
+ * before its first prompt: one blank row, a four-row header, forty-eight blank
+ * rows, a six-row box. tmux reports such a pane as owning the screen and its
+ * read takes {@link altScreenFrame}, a picture placed at its bottom-left, so
+ * the gap is the top of the picture and scrolls away. Herdr cannot report it
+ * (it has no alternate-screen flag), so the same read takes the fold below as
+ * if the pane printed and scrolled -- and there the forty-eight rows are
+ * transcript, drawn and bottom-anchored, and the reader sees a composer with
+ * half a screen of nothing above it.
+ *
+ * Four, matching {@link REPEAT_BLOCK_ROWS} and {@link SCREEN_MIN_MATCH_ROWS}:
+ * this file's threshold for "a run of rows, not a coincidence". A shell
+ * leaves one or two blank rows between commands and keeps them; a program
+ * that left four in a row on its own screen was not printing.
+ */
+const SCREEN_GAP_ROWS = 4;
+
+/**
  * How much of the window's own tail a deeper read is allowed to disagree with
  * and still be recognised as reaching further back.
  *
@@ -331,7 +354,12 @@ export function foldPaneRead(
   ownsScreen = false,
   screenRows = 0
 ): string {
-  const incoming = sanitizePaneRead(latestOutput);
+  // A screen-owning read is a picture and keeps every row of it; a read
+  // folded as scrollback has the room its program left on the screen taken
+  // out first, so it is never drawn as transcript. See {@link collapseScreenGaps}.
+  const incoming = ownsScreen
+    ? sanitizePaneRead(latestOutput)
+    : collapseScreenGaps(sanitizePaneRead(latestOutput), screenRows);
   if (!currentOutput) return trimTerminalWindow(incoming, maximumLines);
   if (!incoming) return trimTerminalWindow(currentOutput, maximumLines);
 
@@ -488,6 +516,56 @@ export function altScreenFrame(output: string, screenRows: number): string {
   const rows = terminalLines(output);
   if (rows.length <= screenRows) return output;
   return rows.slice(rows.length - screenRows).join('\n');
+}
+
+/**
+ * A read with the room its program left on the screen taken out: every run of
+ * {@link SCREEN_GAP_ROWS} or more blank rows inside the screen -- the read's
+ * last `screenRows` rows -- becomes one blank row.
+ *
+ * Only the screen. Rows above it are the window's history as the gateway
+ * kept it, and a blank block there was printed by something. The screen is
+ * the one region a program paints as a rectangle rather than as a stream, so
+ * it is the one region in which "blank" can mean "not painted" -- and it is
+ * where the forty-eight rows of the measurement above sit.
+ *
+ * One row rather than none, so a header and the box under it stay two things.
+ * A pane whose height the gateway did not report (`0`) keeps its read intact,
+ * exactly as it did before this existed. The read comes back untouched, byte
+ * for byte, when there is nothing to collapse: this runs on every main-screen
+ * fold, and a read must not be re-serialised for no reason.
+ */
+export function collapseScreenGaps(output: string, screenRows: number): string {
+  if (!output || screenRows <= 0) return output;
+  try {
+    const rows = terminalLines(output);
+    const screenStart = Math.max(0, rows.length - screenRows);
+    const kept = rows.slice(0, screenStart);
+    let blank = 0;
+    let collapsed = false;
+    const flush = () => {
+      if (blank >= SCREEN_GAP_ROWS) {
+        kept.push('');
+        collapsed = true;
+      } else {
+        for (let step = 0; step < blank; step += 1) kept.push('');
+      }
+      blank = 0;
+    };
+    for (let index = screenStart; index < rows.length; index += 1) {
+      const row = rows[index];
+      if (row.trim() === '') {
+        blank += 1;
+        continue;
+      }
+      flush();
+      kept.push(row);
+    }
+    flush();
+    return collapsed ? kept.join('\n') : output;
+  } catch {
+    return output;
+  }
 }
 
 /**


### PR DESCRIPTION
## What the phone saw

A Claude Code pane in a narrow, tall Herdr column rendered as a strip: 31 columns at 1:1 across the left of the screen, the composer box at the bottom, half a screen of nothing above it. The nvim pane beside it rendered as thirteen 178-column lines, bottom-anchored, the top two thirds empty.

## Reproduced, with data

Isolated herdr 0.8.2 on a private socket, a shell, `nvim notes.md` and real Claude Code 2.1.263 (no prompt sent) in three columns whose grids `stty size` gave as 59x64, 59x32 and 59x31. Through gateway 0.8.1, before:

```
w1:p2 (nvim)   width null  foreground_command null  title null
               visible           58 rows, widest 32
               recent-unwrapped  13 rows, widest 178
w1:p4 (claude) width null  foreground_command null  agent claude
               visible           59 rows, widest 31, 51 blank rows
               recent-unwrapped  59 rows, widest 31, 51 blank rows
```

Two causes, one per pane, and only one of them is this app's:

1. The nvim pane was read `recent-unwrapped` because `isFullScreenTuiPane` keys on `foreground_command`, which the gateway never had for a herdr pane (herdr's pane payload does not carry it, and its metadata for that pane says nothing else either). Herdr's `visible` read is the wrapped screen, so the frame was right there to ask for; the gateway now asks `pane.process_info` and reports `foreground_command: nvim` and `width: 32` (osuki-dev/muqun-gateway, "name a pane's foreground program and its width"). Nothing in this app changes for that: the editor path, `visible`, `altScreenFrame` and the fit all already do the right thing once the two fields arrive.

2. The Claude pane's screen is one blank row, a four-row header, forty-eight blank rows and a six-row box. tmux reports `alternate_on`, so its read is a picture placed at the bottom-left and the gap is the top of the picture. Herdr has no such flag, so the read takes the main-screen fold, and there the forty-eight rows are transcript: drawn, bottom-anchored, half a screen of nothing. This is the app's to fix, and it is the one change here.

## The rule

In `foldPaneRead`, before a read is placed, and only on the main-screen path: inside the screen -- the read's last `viewport_rows` rows, the one region a program paints as a rectangle -- a run of four or more blank rows becomes one (`collapseScreenGaps`, `SCREEN_GAP_ROWS = 4`). Four is this file's own threshold for "a run of rows, not a coincidence" (`REPEAT_BLOCK_ROWS`, `SCREEN_MIN_MATCH_ROWS`); a shell's one or two blank rows between commands are kept. Rows above the screen are history the gateway kept and are left alone. A screen-owning read is a picture and is left alone. A pane whose height the gateway did not report is left alone. A read with nothing to collapse comes back byte for byte.

The width rule is the existing one, unchanged: `terminalFitToWidthScale` scales any pane the gateway reports narrower than the phone's grid, whatever it runs. A test pins it with the grids measured here: 32 and 31 columns open at 49/32 and 49/31 on a 49-column phone, under the 1.6 cap; only a pane narrower than 31 meets the cap, and at the cap a 30-column pane still reaches 48 of the 49 columns. That is why 1.6 stands: the cap is a limit on rows lost, and these panes do not reach it.

A measured width was considered and rejected for the fit: herdr trims each row, so the widest row of a read is content-dependent (a quiet shell measures as wide as its prompt), the parser floors it at 40, and a scale that follows content jumps. The width has to be a fact about the pane, which is why it comes from the gateway.

## On the device (one iOS simulator, `muqun-ios`, Metro from this branch, a scratch gateway on 127.0.0.1 built from the paired gateway branch)

Before (gateway 0.8.1, app main): as described above.
After: the Claude pane is its 31 columns scaled to the phone's width, header directly above the composer with one blank row between, nothing dead above; the nvim pane is 58 wrapped 32-column rows scaled to the width with the editor key row.

Regression set, same session, same app: a 200x50 tmux shell pane after `seq 1 400` rests at rows 371-400 plus the prompt at 1:1 before and after; paging by drag reaches rows 162-194 with the Latest pill before and after; a 200x50 tmux nvim pane opens at line 1, top-left, 1:1 before and after.

## Gates

`npx tsc --noEmit`, `bun run lint`, `bun run format:check`, `bun test src` (3099 pass). New tests in `history.test.ts`: the measured 59-row screen collapses to header, one blank, box; a transcript growing into the gap folds into one window with one header and one composer; three blank rows stay; history above the screen keeps its blank block while the screen loses its; a screen-owning frame is untouched; height 0 is untouched; an untouched read is byte-identical; a trailing run inside the screen collapses. In `terminal-text-size.test.ts`: the fit is program-agnostic, with the numbers above.

## Not verified

No prompt was sent to Claude Code, so a transcript growing and scrolling on Herdr was exercised only by the unit test with synthetic frames. The report's phone is a physical device on the maintainer's gateway; this is a simulator on a scratch one, and the nvim half reaches the phone only with the gateway release. The bottom-left placement of a Herdr editor taller than the phone (`terminalOpenView`) was not checked; the file here opened at line 1 on both backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
